### PR TITLE
Fix wavuvi report references and remove TB leprosy referral

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -327,7 +327,7 @@ dependencies {
     }
 
 
-    implementation('org.smartregister:opensrp-client-chw-core:2.0.5-ALPHA1-MOH-SNAPSHOT@aar') {
+    implementation('org.smartregister:opensrp-client-chw-core:2.0.5-ALPHA2-MOH-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-plan-evaluator'
         exclude group: 'com.android.support', module: 'appcompat-v7'

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/TbLeprosyProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/TbLeprosyProfileActivity.java
@@ -16,6 +16,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -44,6 +45,7 @@ import org.smartregister.chw.model.ReferralTypeModel;
 import org.smartregister.chw.presenter.TbLeprosyContactRegisterPresenter;
 import org.smartregister.chw.tbleprosy.TbLeprosyLibrary;
 import org.smartregister.chw.tbleprosy.dao.TbLeprosyDao;
+import org.smartregister.chw.tbleprosy.domain.MemberObject;
 import org.smartregister.chw.tbleprosy.domain.Visit;
 import org.smartregister.chw.tbleprosy.util.Constants;
 import org.smartregister.chw.tbleprosy.util.DBConstants;
@@ -190,7 +192,15 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
 
     @Override
     protected void setupButtons() {
-        if (isClientDeceased()) {
+        if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+            updateDeceasedClientStatusTag(false);
+            hideDeceasedClientActionViews();
+            return;
+        }
+
+        boolean deceasedClient = isClientDeceased();
+        updateDeceasedClientStatusTag(deceasedClient);
+        if (deceasedClient) {
             hideDeceasedClientActionViews();
             return;
         }
@@ -502,7 +512,22 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
         try {
             new Handler(Looper.getMainLooper()).postDelayed(() -> {
                 TbLeprosyDao.closeTbNegativeClients();
-                memberObject = getMemberObject(memberObject.getBaseEntityId());
+                if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+                    Timber.w("Skipping TB/Leprosy profile refresh because memberObject is missing");
+                    return;
+                }
+
+                String baseEntityId = memberObject.getBaseEntityId();
+                MemberObject refreshedMemberObject = getMemberObject(baseEntityId);
+                if (refreshedMemberObject != null) {
+                    memberObject = refreshedMemberObject;
+                }
+
+                if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+                    Timber.w("Skipping TB/Leprosy profile refresh because refreshed memberObject is missing");
+                    return;
+                }
+
                 fetchProfileData();
                 profilePresenter.refreshProfileBottom();
                 setupViews();
@@ -527,12 +552,39 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
     }
 
     void applyTbLeprosyDeceasedHandling() {
-        if (!isClientDeceased()) {
+        boolean deceasedClient = isClientDeceased();
+        updateDeceasedClientStatusTag(deceasedClient);
+        if (!deceasedClient) {
             return;
         }
 
         hideDeceasedClientActionViews();
         autoMarkTbLeprosyClientAsDeceased();
+    }
+
+    void updateDeceasedClientStatusTag(boolean isClientDeceased) {
+        TextView clientStatusTag = getClientStatusTagView();
+        if (clientStatusTag == null) {
+            return;
+        }
+
+        if (isClientDeceased) {
+            clientStatusTag.setText(R.string.tbleprosy_followup_visit_client_deceased);
+            clientStatusTag.setVisibility(View.VISIBLE);
+            return;
+        }
+
+        clientStatusTag.setVisibility(View.GONE);
+    }
+
+    @Nullable
+    TextView getClientStatusTagView() {
+        try {
+            return findViewById(R.id.family_tbleprosy_head);
+        } catch (Throwable throwable) {
+            Timber.e(throwable);
+            return null;
+        }
     }
 
     private void autoMarkTbLeprosyClientAsDeceased() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/TbLeprosyProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/TbLeprosyProfileActivity.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.smartregister.AllConstants;
 import org.smartregister.chw.BuildConfig;
 import org.smartregister.chw.R;
 import org.smartregister.chw.application.ChwApplication;
@@ -189,9 +190,14 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
 
     @Override
     protected void setupButtons() {
+        if (isClientDeceased()) {
+            hideDeceasedClientActionViews();
+            return;
+        }
 
         String baseEntityId = memberObject.getBaseEntityId();
         boolean isContactClient = getTbLeprosyClientStatus(baseEntityId).equalsIgnoreCase("contact");
+
         textViewRecordTbLeprosy.setOnClickListener(this);
 
         if (!isContactClient && !TbLeprosyDao.isClientTbOrLeprosyNegative(baseEntityId)) {
@@ -488,10 +494,11 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
     @Override
     protected void onResume() {
         super.onResume();
+        applyTbLeprosyDeceasedHandling();
         delayRefresh();
     }
 
-    private void delayRefresh() {
+    protected void delayRefresh() {
         try {
             new Handler(Looper.getMainLooper()).postDelayed(() -> {
                 TbLeprosyDao.closeTbNegativeClients();
@@ -503,6 +510,63 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
             }, 500);
         } catch (Exception e) {
             Timber.e(e);
+        }
+    }
+
+    protected boolean isClientDeceased() {
+        if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+            return false;
+        }
+
+        try {
+            return TbLeprosyDao.isClientDeceased(memberObject.getBaseEntityId());
+        } catch (Throwable throwable) {
+            Timber.e(throwable);
+            return false;
+        }
+    }
+
+    void applyTbLeprosyDeceasedHandling() {
+        if (!isClientDeceased()) {
+            return;
+        }
+
+        hideDeceasedClientActionViews();
+        autoMarkTbLeprosyClientAsDeceased();
+    }
+
+    private void autoMarkTbLeprosyClientAsDeceased() {
+        if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+            return;
+        }
+
+        try {
+            JSONObject removeFamilyMemberForm = (new com.vijay.jsonwizard.utils.FormUtils())
+                    .getFormJsonFromRepositoryOrAssets(this, CoreConstants.JSON_FORM.FAMILY_DETAILS_REMOVE_MEMBER);
+            org.smartregister.chw.anc.util.JsonFormUtils.getRegistrationForm(
+                    removeFamilyMemberForm,
+                    memberObject.getBaseEntityId(),
+                    org.smartregister.Context.getInstance().allSharedPreferences()
+                            .getPreference(AllConstants.CURRENT_LOCATION_ID)
+            );
+
+            JSONArray jsonArray = removeFamilyMemberForm.getJSONObject(org.smartregister.chw.anc.util.JsonFormUtils.STEP1).getJSONArray(org.smartregister.util.JsonFormUtils.FIELDS);
+            org.smartregister.chw.anc.util.JsonFormUtils.updateFormField(jsonArray, "remove_reason", "Death");
+            org.smartregister.chw.anc.util.JsonFormUtils.updateFormField(jsonArray, "dob", String.valueOf(memberObject.getAge()));
+            org.smartregister.chw.anc.util.JsonFormUtils.updateFormField(jsonArray, "age_at_death", memberObject.getAge() + "y");
+            org.smartregister.chw.anc.util.JsonFormUtils.updateFormField(jsonArray, "date_died", new SimpleDateFormat("dd-MM-yyyy", Locale.getDefault()).format(new Date()));
+            Utils.removeUser(null, removeFamilyMemberForm, Utils.context().allSharedPreferences().fetchRegisteredANM());
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+    void hideDeceasedClientActionViews() {
+        if (textViewRecordTbLeprosy != null) {
+            textViewRecordTbLeprosy.setVisibility(View.GONE);
+        }
+        if (textViewRecordLeprosyTreatmentStartDate != null) {
+            textViewRecordLeprosyTreatmentStartDate.setVisibility(View.GONE);
         }
     }
 
@@ -829,28 +893,36 @@ public class TbLeprosyProfileActivity extends CoreTbLeprosyProfileActivity imple
 
         if (requestCode == REQUEST_CODE_CONTACT_REGISTER && resultCode == Activity.RESULT_OK && data != null) {
             handleNewClientRegistrationResult(data);
+            applyTbLeprosyDeceasedHandling();
             return;
         }
 
         if (requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON && pendingTbLeprosyReferralLaunch) {
             handlePendingReferralFormResult(resultCode);
+            applyTbLeprosyDeceasedHandling();
             return;
         }
 
         if (requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON && resultCode == Activity.RESULT_OK) {
             if (data == null) {
+                applyTbLeprosyDeceasedHandling();
                 return;
             }
 
             try {
                 String jsonString = data.getStringExtra(Constants.JSON_FORM_EXTRA.JSON);
                 if (StringUtils.isBlank(jsonString)) {
+                    applyTbLeprosyDeceasedHandling();
                     return;
                 }
                 handleJsonFormActivityResult(jsonString);
+                applyTbLeprosyDeceasedHandling();
             } catch (Exception e) {
                 Timber.e(e);
+                applyTbLeprosyDeceasedHandling();
             }
+        } else {
+            applyTbLeprosyDeceasedHandling();
         }
     }
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/domain/tbleprosy_reports/TbLeprosySpecialAreasReportObject.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/domain/tbleprosy_reports/TbLeprosySpecialAreasReportObject.java
@@ -56,7 +56,7 @@ public class TbLeprosySpecialAreasReportObject extends ReportObject {
                 "ibada",
                 "shule",
                 "sokoni",
-                "wavuvu",
+                "wavuvi",
                 "maskani",
                 "kwingineko");
         return Collections.unmodifiableList(locations);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Utils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Utils.java
@@ -68,8 +68,6 @@ public class Utils extends org.smartregister.chw.core.utils.Utils {
         if (BuildConfig.USE_UNIFIED_REFERRAL_APPROACH) {
             referralTypeModels.add(new ReferralTypeModel(activity.getString(R.string.gbv_referral),
                     Constants.JSON_FORM.getGbvReferralForm(), CoreConstants.TASKS_FOCUS.SUSPECTED_GBV));
-            referralTypeModels.add(new ReferralTypeModel(activity.getString(R.string.tb_leprosy_referral),
-                    Constants.JSON_FORM.getTbLeprosyReferralForm(), CoreConstants.TASKS_FOCUS.TBLEPROSY));
             referralTypeModels.add(new ReferralTypeModel(activity.getString(R.string.hts_referral),
                     CoreConstants.JSON_FORM.getHtsReferralForm(), CoreConstants.TASKS_FOCUS.CONVENTIONAL_HIV_TEST));
             if (gender.equalsIgnoreCase("Male")) {

--- a/opensrp-chw/src/nacp/assets/config/tbleprosy-monthly-report.yml
+++ b/opensrp-chw/src/nacp/assets/config/tbleprosy-monthly-report.yml
@@ -2535,9 +2535,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col1_ke_wavuvu"
+  - key: "tbleprosy_area_col1_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya watu waliochunguzwa TB au ukoma - Kambi za Wavuvu (KE)"
+    description: "Idadi ya watu waliochunguzwa TB au ukoma - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       WHERE efm.gender='Female'
@@ -2546,9 +2546,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col1_me_wavuvu"
+  - key: "tbleprosy_area_col1_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya watu waliochunguzwa TB au ukoma - Kambi za Wavuvu (ME)"
+    description: "Idadi ya watu waliochunguzwa TB au ukoma - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       WHERE efm.gender='Male'
@@ -2557,9 +2557,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col2_ke_wavuvu"
+  - key: "tbleprosy_area_col2_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wahisiwa wa kifua kikuu au ukoma - Kambi za Wavuvu (KE)"
+    description: "Idadi ya wahisiwa wa kifua kikuu au ukoma - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       WHERE efm.gender='Female'
@@ -2569,9 +2569,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col2_me_wavuvu"
+  - key: "tbleprosy_area_col2_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wahisiwa wa kifua kikuu au ukoma - Kambi za Wavuvu (ME)"
+    description: "Idadi ya wahisiwa wa kifua kikuu au ukoma - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       WHERE efm.gender='Male'
@@ -2581,9 +2581,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col3_ke_wavuvu"
+  - key: "tbleprosy_area_col3_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wahisiwa walipewa rufaa ya upimaji wa TB (Sampuli + Mteja) au ukoma - Kambi za Wavuvu (KE)"
+    description: "Idadi ya wahisiwa walipewa rufaa ya upimaji wa TB (Sampuli + Mteja) au ukoma - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       INNER JOIN task t ON efm.base_entity_id = t.for
@@ -2595,9 +2595,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col3_me_wavuvu"
+  - key: "tbleprosy_area_col3_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wahisiwa walipewa rufaa ya upimaji wa TB (Sampuli + Mteja) au ukoma - Kambi za Wavuvu (ME)"
+    description: "Idadi ya wahisiwa walipewa rufaa ya upimaji wa TB (Sampuli + Mteja) au ukoma - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT ets.base_entity_id) as count FROM ec_tbleprosy_screening ets 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = ets.base_entity_id
                       INNER JOIN task t ON efm.base_entity_id = t.for
@@ -2609,9 +2609,9 @@ indicators:
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(ets.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col4_ke_wavuvu"
+  - key: "tbleprosy_area_col4_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya sampuli au wateja waliopimwa TB au ukoma - Kambi za Wavuvu (KE)"
+    description: "Idadi ya sampuli au wateja waliopimwa TB au ukoma - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2621,9 +2621,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col4_me_wavuvu"
+  - key: "tbleprosy_area_col4_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya sampuli au wateja waliopimwa TB au ukoma - Kambi za Wavuvu (ME)"
+    description: "Idadi ya sampuli au wateja waliopimwa TB au ukoma - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2633,9 +2633,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col5_ke_wavuvu"
+  - key: "tbleprosy_area_col5_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa waliogundulika kuwa na TB au ukoma - Kambi za Wavuvu (KE)"
+    description: "Idadi ya wagonjwa waliogundulika kuwa na TB au ukoma - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2646,9 +2646,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col5_me_wavuvu"
+  - key: "tbleprosy_area_col5_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa waliogundulika kuwa na TB au ukoma - Kambi za Wavuvu (ME)"
+    description: "Idadi ya wagonjwa waliogundulika kuwa na TB au ukoma - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2659,9 +2659,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col6_ke_wavuvu"
+  - key: "tbleprosy_area_col6_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa wa TB au ukoma walioanza matibabu - Kambi za Wavuvu (KE)"
+    description: "Idadi ya wagonjwa wa TB au ukoma walioanza matibabu - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2672,9 +2672,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col6_me_wavuvu"
+  - key: "tbleprosy_area_col6_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa wa TB au ukoma walioanza matibabu - Kambi za Wavuvu (ME)"
+    description: "Idadi ya wagonjwa wa TB au ukoma walioanza matibabu - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2685,9 +2685,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col7_ke_wavuvu"
+  - key: "tbleprosy_area_col7_ke_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa wanaojua hali yao ya maambukizi ya VVU - Kambi za Wavuvu (KE)"
+    description: "Idadi ya wagonjwa wanaojua hali yao ya maambukizi ya VVU - Kambi za wavuvi (KE)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id
@@ -2698,9 +2698,9 @@ indicators:
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) || '-' || substr(strftime('%Y-%m-%d',
                       datetime(etor.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
 
-  - key: "tbleprosy_area_col7_me_wavuvu"
+  - key: "tbleprosy_area_col7_me_wavuvi"
     grouping: "TBLeprosy Special Areas"
-    description: "Idadi ya wagonjwa wanaojua hali yao ya maambukizi ya VVU - Kambi za Wavuvu (ME)"
+    description: "Idadi ya wagonjwa wanaojua hali yao ya maambukizi ya VVU - Kambi za wavuvi (ME)"
     indicatorQuery: " SELECT count(DISTINCT etor.base_entity_id) as count FROM ec_tbleprosy_observation_results etor 
                       INNER JOIN ec_family_member efm ON efm.base_entity_id = etor.base_entity_id
                       INNER JOIN ec_tbleprosy_screening ets ON ets.base_entity_id = etor.base_entity_id

--- a/opensrp-chw/src/nacp/assets/reports/tbleprosy_reports/tbleprosy-merged-report.html
+++ b/opensrp-chw/src/nacp/assets/reports/tbleprosy_reports/tbleprosy-merged-report.html
@@ -571,21 +571,21 @@
         <td data-indicator="tbleprosy_area_col7_me_sokoni" data-column="area-col7-me" class="unknown">N/A</td>
     </tr>
     <tr>
-        <td class="location-cell">9. Kambi za Wavuvu</td>
-        <td data-indicator="tbleprosy_area_col1_ke_wavuvu" data-column="area-col1-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col1_me_wavuvu" data-column="area-col1-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col2_ke_wavuvu" data-column="area-col2-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col2_me_wavuvu" data-column="area-col2-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col3_ke_wavuvu" data-column="area-col3-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col3_me_wavuvu" data-column="area-col3-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col4_ke_wavuvu" data-column="area-col4-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col4_me_wavuvu" data-column="area-col4-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col5_ke_wavuvu" data-column="area-col5-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col5_me_wavuvu" data-column="area-col5-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col6_ke_wavuvu" data-column="area-col6-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col6_me_wavuvu" data-column="area-col6-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col7_ke_wavuvu" data-column="area-col7-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col7_me_wavuvu" data-column="area-col7-me" class="unknown">N/A</td>
+        <td class="location-cell">9. Kambi za wavuvi</td>
+        <td data-indicator="tbleprosy_area_col1_ke_wavuvi" data-column="area-col1-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col1_me_wavuvi" data-column="area-col1-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col2_ke_wavuvi" data-column="area-col2-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col2_me_wavuvi" data-column="area-col2-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col3_ke_wavuvi" data-column="area-col3-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col3_me_wavuvi" data-column="area-col3-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col4_ke_wavuvi" data-column="area-col4-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col4_me_wavuvi" data-column="area-col4-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col5_ke_wavuvi" data-column="area-col5-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col5_me_wavuvi" data-column="area-col5-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col6_ke_wavuvi" data-column="area-col6-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col6_me_wavuvi" data-column="area-col6-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col7_ke_wavuvi" data-column="area-col7-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col7_me_wavuvi" data-column="area-col7-me" class="unknown">N/A</td>
     </tr>
     <tr>
         <td class="location-cell">10. Maskani</td>

--- a/opensrp-chw/src/nacp/assets/reports/tbleprosy_reports/tbleprosy-special-areas-report.html
+++ b/opensrp-chw/src/nacp/assets/reports/tbleprosy_reports/tbleprosy-special-areas-report.html
@@ -264,21 +264,21 @@
         <td data-indicator="tbleprosy_area_col7_me_sokoni" data-column="area-col7-me" class="unknown">N/A</td>
     </tr>
     <tr>
-        <td class="location-cell">9. Kambi za Wavuvu</td>
-        <td data-indicator="tbleprosy_area_col1_ke_wavuvu" data-column="area-col1-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col1_me_wavuvu" data-column="area-col1-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col2_ke_wavuvu" data-column="area-col2-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col2_me_wavuvu" data-column="area-col2-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col3_ke_wavuvu" data-column="area-col3-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col3_me_wavuvu" data-column="area-col3-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col4_ke_wavuvu" data-column="area-col4-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col4_me_wavuvu" data-column="area-col4-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col5_ke_wavuvu" data-column="area-col5-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col5_me_wavuvu" data-column="area-col5-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col6_ke_wavuvu" data-column="area-col6-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col6_me_wavuvu" data-column="area-col6-me" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col7_ke_wavuvu" data-column="area-col7-ke" class="unknown">N/A</td>
-        <td data-indicator="tbleprosy_area_col7_me_wavuvu" data-column="area-col7-me" class="unknown">N/A</td>
+        <td class="location-cell">9. Kambi za Wavuvi</td>
+        <td data-indicator="tbleprosy_area_col1_ke_wavuvi" data-column="area-col1-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col1_me_wavuvi" data-column="area-col1-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col2_ke_wavuvi" data-column="area-col2-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col2_me_wavuvi" data-column="area-col2-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col3_ke_wavuvi" data-column="area-col3-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col3_me_wavuvi" data-column="area-col3-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col4_ke_wavuvi" data-column="area-col4-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col4_me_wavuvi" data-column="area-col4-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col5_ke_wavuvi" data-column="area-col5-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col5_me_wavuvi" data-column="area-col5-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col6_ke_wavuvi" data-column="area-col6-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col6_me_wavuvi" data-column="area-col6-me" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col7_ke_wavuvi" data-column="area-col7-ke" class="unknown">N/A</td>
+        <td data-indicator="tbleprosy_area_col7_me_wavuvi" data-column="area-col7-me" class="unknown">N/A</td>
     </tr>
     <tr>
         <td class="location-cell">10. Maskani</td>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/TbLeprosyProfileActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/TbLeprosyProfileActivityTest.java
@@ -1,6 +1,8 @@
 package org.smartregister.chw.activity;
 
 import android.app.Activity;
+import android.view.View;
+import android.widget.TextView;
 
 import org.joda.time.DateTime;
 import org.json.JSONArray;
@@ -11,6 +13,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.robolectric.util.ReflectionHelpers;
+import org.smartregister.chw.BaseUnitTest;
 import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.FormUtils;
 import org.smartregister.chw.tbleprosy.dao.TbLeprosyDao;
@@ -20,7 +23,80 @@ import org.smartregister.family.util.JsonFormUtils;
 
 import java.util.Date;
 
-public class TbLeprosyProfileActivityTest {
+public class TbLeprosyProfileActivityTest extends BaseUnitTest {
+
+    @Test
+    public void onResumeShouldHandleDeceasedClient() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        MemberObject memberObject = Mockito.mock(MemberObject.class);
+        Mockito.doReturn("base-id").when(memberObject).getBaseEntityId();
+        ReflectionHelpers.setField(activity, "memberObject", memberObject);
+
+        TextView recordTbLeprosyButton = Mockito.mock(TextView.class);
+        TextView recordLeprosyTreatmentStartDateButton = Mockito.mock(TextView.class);
+        ReflectionHelpers.setField(activity, "textViewRecordTbLeprosy", recordTbLeprosyButton);
+        ReflectionHelpers.setField(activity, "textViewRecordLeprosyTreatmentStartDate", recordLeprosyTreatmentStartDateButton);
+
+        try (MockedStatic<TbLeprosyDao> tbLeprosyDaoStatic = Mockito.mockStatic(TbLeprosyDao.class)) {
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientDeceased("base-id")).thenReturn(true);
+
+            activity.applyTbLeprosyDeceasedHandling();
+
+            tbLeprosyDaoStatic.verify(() -> TbLeprosyDao.isClientDeceased("base-id"));
+            Mockito.verify(recordTbLeprosyButton).setVisibility(View.GONE);
+            Mockito.verify(recordLeprosyTreatmentStartDateButton).setVisibility(View.GONE);
+        }
+    }
+
+    @Test
+    public void shouldHideRecordActionsWhenClientIsDeceased() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        MemberObject memberObject = Mockito.mock(MemberObject.class);
+        TextView recordTbLeprosyButton = Mockito.mock(TextView.class);
+        TextView recordLeprosyTreatmentStartDateButton = Mockito.mock(TextView.class);
+        Mockito.doReturn("base-id").when(memberObject).getBaseEntityId();
+
+        ReflectionHelpers.setField(activity, "memberObject", memberObject);
+        ReflectionHelpers.setField(activity, "textViewRecordTbLeprosy", recordTbLeprosyButton);
+        ReflectionHelpers.setField(activity, "textViewRecordLeprosyTreatmentStartDate", recordLeprosyTreatmentStartDateButton);
+
+        try (MockedStatic<TbLeprosyDao> tbLeprosyDaoStatic = Mockito.mockStatic(TbLeprosyDao.class)) {
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientDeceased("base-id")).thenReturn(true);
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.getTbLeprosyClientStatus("base-id")).thenReturn("contact");
+
+            activity.setupButtons();
+
+            Mockito.verify(recordTbLeprosyButton).setVisibility(View.GONE);
+            Mockito.verify(recordLeprosyTreatmentStartDateButton).setVisibility(View.GONE);
+            tbLeprosyDaoStatic.verify(() -> TbLeprosyDao.isClientDeceased("base-id"));
+        }
+    }
+
+    @Test
+    public void shouldNotHideRecordActionsForNonDeceasedClient() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        MemberObject memberObject = Mockito.mock(MemberObject.class);
+        TextView recordTbLeprosyButton = Mockito.mock(TextView.class);
+        TextView recordLeprosyTreatmentStartDateButton = Mockito.mock(TextView.class);
+        Mockito.doReturn("base-id").when(memberObject).getBaseEntityId();
+
+        ReflectionHelpers.setField(activity, "memberObject", memberObject);
+        ReflectionHelpers.setField(activity, "textViewRecordTbLeprosy", recordTbLeprosyButton);
+        ReflectionHelpers.setField(activity, "textViewRecordLeprosyTreatmentStartDate", recordLeprosyTreatmentStartDateButton);
+
+        try (MockedStatic<TbLeprosyDao> tbLeprosyDaoStatic = Mockito.mockStatic(TbLeprosyDao.class)) {
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientDeceased("base-id")).thenReturn(false);
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.getTbLeprosyClientStatus("base-id")).thenReturn("contact");
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientTbOrLeprosyNegative("base-id")).thenReturn(false);
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.getTbLeprosyObservationResults("base-id")).thenReturn(null);
+
+            activity.applyTbLeprosyDeceasedHandling();
+
+            Mockito.verify(recordTbLeprosyButton, Mockito.never()).setVisibility(View.GONE);
+            Mockito.verify(recordLeprosyTreatmentStartDateButton, Mockito.never()).setVisibility(View.GONE);
+            tbLeprosyDaoStatic.verify(() -> TbLeprosyDao.isClientDeceased("base-id"));
+        }
+    }
 
     @Test
     public void shouldRemoveTreatmentDecisionAlgorithmForClientsAgedTenOrAbove() throws Exception {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/TbLeprosyProfileActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/TbLeprosyProfileActivityTest.java
@@ -14,6 +14,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.robolectric.util.ReflectionHelpers;
 import org.smartregister.chw.BaseUnitTest;
+import org.smartregister.chw.R;
 import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.FormUtils;
 import org.smartregister.chw.tbleprosy.dao.TbLeprosyDao;
@@ -49,6 +50,44 @@ public class TbLeprosyProfileActivityTest extends BaseUnitTest {
     }
 
     @Test
+    public void applyTbLeprosyDeceasedHandlingShouldShowStatusTagWhenClientIsDeceased() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        MemberObject memberObject = Mockito.mock(MemberObject.class);
+        TextView statusTag = Mockito.mock(TextView.class);
+        Mockito.doReturn("base-id").when(memberObject).getBaseEntityId();
+        ReflectionHelpers.setField(activity, "memberObject", memberObject);
+        Mockito.doReturn(statusTag).when(activity).findViewById(R.id.family_tbleprosy_head);
+
+        try (MockedStatic<TbLeprosyDao> tbLeprosyDaoStatic = Mockito.mockStatic(TbLeprosyDao.class)) {
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientDeceased("base-id")).thenReturn(true);
+
+            activity.applyTbLeprosyDeceasedHandling();
+
+            Mockito.verify(statusTag).setText(R.string.tbleprosy_followup_visit_client_deceased);
+            Mockito.verify(statusTag).setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Test
+    public void applyTbLeprosyDeceasedHandlingShouldHideStatusTagWhenClientIsNotDeceased() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        MemberObject memberObject = Mockito.mock(MemberObject.class);
+        TextView statusTag = Mockito.mock(TextView.class);
+        Mockito.doReturn("base-id").when(memberObject).getBaseEntityId();
+        ReflectionHelpers.setField(activity, "memberObject", memberObject);
+        Mockito.doReturn(statusTag).when(activity).findViewById(R.id.family_tbleprosy_head);
+
+        try (MockedStatic<TbLeprosyDao> tbLeprosyDaoStatic = Mockito.mockStatic(TbLeprosyDao.class)) {
+            tbLeprosyDaoStatic.when(() -> TbLeprosyDao.isClientDeceased("base-id")).thenReturn(false);
+
+            activity.applyTbLeprosyDeceasedHandling();
+
+            Mockito.verify(statusTag).setVisibility(View.GONE);
+            Mockito.verify(statusTag, Mockito.never()).setText(Mockito.anyInt());
+        }
+    }
+
+    @Test
     public void shouldHideRecordActionsWhenClientIsDeceased() {
         TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
         MemberObject memberObject = Mockito.mock(MemberObject.class);
@@ -70,6 +109,22 @@ public class TbLeprosyProfileActivityTest extends BaseUnitTest {
             Mockito.verify(recordLeprosyTreatmentStartDateButton).setVisibility(View.GONE);
             tbLeprosyDaoStatic.verify(() -> TbLeprosyDao.isClientDeceased("base-id"));
         }
+    }
+
+    @Test
+    public void setupButtonsShouldHideRecordActionsWhenMemberObjectIsNull() {
+        TbLeprosyProfileActivity activity = Mockito.mock(TbLeprosyProfileActivity.class, Mockito.CALLS_REAL_METHODS);
+        TextView recordTbLeprosyButton = Mockito.mock(TextView.class);
+        TextView recordLeprosyTreatmentStartDateButton = Mockito.mock(TextView.class);
+
+        ReflectionHelpers.setField(activity, "memberObject", null);
+        ReflectionHelpers.setField(activity, "textViewRecordTbLeprosy", recordTbLeprosyButton);
+        ReflectionHelpers.setField(activity, "textViewRecordLeprosyTreatmentStartDate", recordLeprosyTreatmentStartDateButton);
+
+        activity.setupButtons();
+
+        Mockito.verify(recordTbLeprosyButton).setVisibility(View.GONE);
+        Mockito.verify(recordLeprosyTreatmentStartDateButton).setVisibility(View.GONE);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- standardize the special-area label to “wavuvi” across Java domain objects and report templates so the maps and tables match the intended location name
- update the NACP report config indicator keys and descriptions to use the corrected “wavuvi” spelling
- remove the TB/Leprosy referral option from the unified-referral menu since it is no longer appropriate while keeping other referral types intact
- didn’t invoke smart_git_commit because no new commits were created or requested

## Testing
- Not run (not requested)