### PR TITLE
Fix MAT follow-up form completion status

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/HarmReductionMatClientsFollowupActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/HarmReductionMatClientsFollowupActionHelper.java
@@ -1,0 +1,76 @@
+package org.smartregister.chw.actionhelper;
+
+import android.content.Context;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.harmreduction.domain.VisitDetail;
+import org.smartregister.chw.harmreduction.model.BaseHarmReductionVisitAction;
+import org.smartregister.chw.util.JsonFormUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+public class HarmReductionMatClientsFollowupActionHelper implements BaseHarmReductionVisitAction.HarmReductionVisitActionHelper {
+    private static final String HEALTH_EDUCATION_PROVIDED_FIELD_KEY = "health_education_provided";
+
+    private String healthEducationProvided;
+
+    @Override
+    public void onJsonFormLoaded(String jsonPayload, Context context, Map<String, List<VisitDetail>> details) {
+        // no-op
+    }
+
+    @Override
+    public String getPreProcessed() {
+        return null;
+    }
+
+    @Override
+    public void onPayloadReceived(String jsonPayload) {
+        try {
+            JSONObject jsonObject = new JSONObject(jsonPayload);
+            healthEducationProvided = JsonFormUtils.getValue(jsonObject, HEALTH_EDUCATION_PROVIDED_FIELD_KEY);
+            if (StringUtils.isBlank(healthEducationProvided)) {
+                healthEducationProvided = JsonFormUtils.getCheckBoxValue(jsonObject, HEALTH_EDUCATION_PROVIDED_FIELD_KEY);
+            }
+        } catch (JSONException e) {
+            Timber.e(e);
+        }
+    }
+
+    @Override
+    public BaseHarmReductionVisitAction.ScheduleStatus getPreProcessedStatus() {
+        return null;
+    }
+
+    @Override
+    public String getPreProcessedSubTitle() {
+        return null;
+    }
+
+    @Override
+    public String postProcess(String jsonPayload) {
+        return null;
+    }
+
+    @Override
+    public String evaluateSubTitle() {
+        return null;
+    }
+
+    @Override
+    public BaseHarmReductionVisitAction.Status evaluateStatusOnPayload() {
+        return StringUtils.isNotBlank(healthEducationProvided)
+                ? BaseHarmReductionVisitAction.Status.COMPLETED
+                : BaseHarmReductionVisitAction.Status.PENDING;
+    }
+
+    @Override
+    public void onPayloadReceived(BaseHarmReductionVisitAction baseVisitAction) {
+        // no-op
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/HarmReductionMatClientsVisitInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/HarmReductionMatClientsVisitInteractor.java
@@ -1,7 +1,7 @@
 package org.smartregister.chw.interactor;
 
 import org.smartregister.chw.R;
-import org.smartregister.chw.harmreduction.actionhelper.HarmReductionHealthEducationActionHelper;
+import org.smartregister.chw.actionhelper.HarmReductionMatClientsFollowupActionHelper;
 import org.smartregister.chw.harmreduction.contract.BaseHarmReductionVisitContract;
 import org.smartregister.chw.harmreduction.domain.VisitDetail;
 import org.smartregister.chw.harmreduction.interactor.BaseHarmReductionVisitInteractor;
@@ -42,7 +42,7 @@ public class HarmReductionMatClientsVisitInteractor extends BaseHarmReductionVis
 
     private void evaluateMatClientsFollowup(Map<String, List<VisitDetail>> details)
             throws BaseHarmReductionVisitAction.ValidationException {
-        HarmReductionHealthEducationActionHelper actionHelper = new HarmReductionHealthEducationActionHelper();
+        HarmReductionMatClientsFollowupActionHelper actionHelper = new HarmReductionMatClientsFollowupActionHelper();
         BaseHarmReductionVisitAction action = getBuilder(context.getString(R.string.harm_reduction_mat_clients_followup_visit))
                 .withOptional(false)
                 .withDetails(details)

--- a/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/HarmReductionMatClientsFollowupActionHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/HarmReductionMatClientsFollowupActionHelperTest.java
@@ -1,0 +1,61 @@
+package org.smartregister.chw.actionhelper;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.chw.harmreduction.model.BaseHarmReductionVisitAction;
+
+public class HarmReductionMatClientsFollowupActionHelperTest {
+
+    @Test
+    public void evaluateStatusOnPayloadReturnsPendingWhenNothingIsSelected() throws Exception {
+        HarmReductionMatClientsFollowupActionHelper actionHelper = new HarmReductionMatClientsFollowupActionHelper();
+
+        actionHelper.onPayloadReceived(buildPayload().toString());
+
+        Assert.assertEquals(BaseHarmReductionVisitAction.Status.PENDING, actionHelper.evaluateStatusOnPayload());
+    }
+
+    @Test
+    public void evaluateStatusOnPayloadReturnsCompletedWhenCombinedValueIsPresent() throws Exception {
+        HarmReductionMatClientsFollowupActionHelper actionHelper = new HarmReductionMatClientsFollowupActionHelper();
+        JSONObject payload = buildPayload();
+        payload.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).put("value", "tuberculosis");
+
+        actionHelper.onPayloadReceived(payload.toString());
+
+        Assert.assertEquals(BaseHarmReductionVisitAction.Status.COMPLETED, actionHelper.evaluateStatusOnPayload());
+    }
+
+    @Test
+    public void evaluateStatusOnPayloadReturnsCompletedWhenCheckboxOptionIsSelected() throws Exception {
+        HarmReductionMatClientsFollowupActionHelper actionHelper = new HarmReductionMatClientsFollowupActionHelper();
+        JSONObject payload = buildPayload();
+        payload.getJSONObject("step1")
+                .getJSONArray("fields")
+                .getJSONObject(0)
+                .getJSONArray("options")
+                .getJSONObject(0)
+                .put("value", true);
+
+        actionHelper.onPayloadReceived(payload.toString());
+
+        Assert.assertEquals(BaseHarmReductionVisitAction.Status.COMPLETED, actionHelper.evaluateStatusOnPayload());
+    }
+
+    private JSONObject buildPayload() throws Exception {
+        JSONObject option = new JSONObject()
+                .put("key", "tuberculosis")
+                .put("text", "Tuberculosis");
+
+        JSONObject field = new JSONObject()
+                .put("key", "health_education_provided")
+                .put("type", "check_box")
+                .put("options", new JSONArray().put(option));
+
+        JSONObject stepOne = new JSONObject().put("fields", new JSONArray().put(field));
+
+        return new JSONObject().put("step1", stepOne);
+    }
+}


### PR DESCRIPTION
## Summary
- add a MAT-clients-specific action helper that marks the visit action complete from the MAT follow-up form payload
- switch the MAT clients visit interactor to use that helper instead of the general health-education helper
- add regression coverage for both combined checkbox values and selected checkbox options

## Testing
- blocked: `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.actionhelper.HarmReductionMatClientsFollowupActionHelperTest`
  - dependency resolution requires GitHub Packages credentials for internal `opensrp-client-chw-*` artifacts (`github.properties` or matching env vars were not present in this worktree)

Fixes #666