### PR TITLE
Add options menu handling to HarmReductionSoberHouseProfileActivity

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionSoberHouseProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionSoberHouseProfileActivity.java
@@ -3,19 +3,40 @@ package org.smartregister.chw.activity;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 
 import androidx.annotation.NonNull;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
+import org.smartregister.chw.agyw.dao.AGYWDao;
+import org.smartregister.chw.application.ChwApplication;
+import org.smartregister.chw.cecap.dao.CecapDao;
 import org.smartregister.chw.core.activity.CoreFamilyProfileActivity;
+import org.smartregister.chw.core.dao.AncDao;
 import org.smartregister.chw.core.presenter.CoreFamilyOtherMemberActivityPresenter;
+import org.smartregister.chw.core.utils.CoreConstants;
+import org.smartregister.chw.core.utils.CoreJsonFormUtils;
+import org.smartregister.chw.core.utils.UpdateDetailsUtil;
 import org.smartregister.chw.domain.SortableVisit;
 import org.smartregister.chw.harmreduction.activity.BaseHarmReductionSoberHouseProfileActivity;
 import org.smartregister.chw.harmreduction.dao.HarmReductionDao;
 import org.smartregister.chw.harmreduction.util.Constants;
 import org.smartregister.chw.harmreduction.util.HarmReductionVisitsUtil;
+import org.smartregister.chw.hivst.dao.HivstDao;
 import org.smartregister.chw.interactor.HarmReductionVisitHistoryInteractor;
+import org.smartregister.chw.kvp.dao.KvpDao;
+import org.smartregister.chw.malaria.dao.IccmDao;
+import org.smartregister.chw.sbc.dao.SbcDao;
+import org.smartregister.chw.util.AllClientsUtils;
+import org.smartregister.chw.util.MemberProfileUtils;
+import org.smartregister.commonregistry.CommonPersonObject;
+import org.smartregister.commonregistry.CommonPersonObjectClient;
+import org.smartregister.commonregistry.CommonRepository;
+import org.smartregister.family.util.DBConstants;
+import org.smartregister.family.util.Utils;
 
 import java.util.Date;
 import java.util.List;
@@ -23,6 +44,7 @@ import java.util.List;
 import timber.log.Timber;
 
 public class HarmReductionSoberHouseProfileActivity extends BaseHarmReductionSoberHouseProfileActivity {
+    private final FamilyOtherMemberProfileActivity.Flavor flavor = new FamilyOtherMemberProfileActivityFlv();
 
     public static void startProfileActivity(Activity activity, String baseEntityId) {
         Intent intent = new Intent(activity, HarmReductionSoberHouseProfileActivity.class);
@@ -166,6 +188,197 @@ public class HarmReductionSoberHouseProfileActivity extends BaseHarmReductionSob
     protected void onResume() {
         super.onResume();
         refreshMedicalHistory(true);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        if (memberObject == null) {
+            return super.onCreateOptionsMenu(menu);
+        }
+
+        MenuItem addMember = menu.findItem(org.smartregister.chw.core.R.id.add_member);
+        if (addMember != null) {
+            addMember.setVisible(false);
+        }
+
+        getMenuInflater().inflate(org.smartregister.chw.core.R.menu.other_member_menu, menu);
+
+        int age = memberObject.getAge();
+        String gender = memberObject.getGender();
+        String baseEntityId = memberObject.getBaseEntityId();
+
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_location_info, true);
+        if (ChwApplication.getApplicationFlavor().hasHIV()) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_cbhs_registration, true);
+        }
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_tb_registration, false);
+
+        if (ChwApplication.getApplicationFlavor().hasFamilyPlanning() && age >= 10 && age <= 49) {
+            flavor.updateFpMenuItems(baseEntityId, menu);
+        } else {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_fp_initiation, false);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasANC() && !AncDao.isANCMember(baseEntityId) && age >= 10 && age <= 49 && gender.equalsIgnoreCase("Female")) {
+            flavor.updateFpMenuItems(baseEntityId, menu);
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_anc_registration, true);
+        } else {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_anc_registration, false);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasANC() && age >= 10 && age <= 49 && gender.equalsIgnoreCase("Female")) {
+            flavor.updateFpMenuItems(baseEntityId, menu);
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_pregnancy_out_come, true);
+        } else {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_pregnancy_out_come, false);
+        }
+
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_sick_child_follow_up, false);
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_malaria_diagnosis, false);
+        if (ChwApplication.getApplicationFlavor().hasMalaria()) {
+            flavor.updateMalariaMenuItems(baseEntityId, menu);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasHIVST()) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_hivst_registration, !HivstDao.isRegisteredForHivst(baseEntityId) && age >= 15);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasAGYW() && gender.equalsIgnoreCase("Female") && age >= 10 && age <= 24 && !AGYWDao.isRegisteredForAgyw(baseEntityId)) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_agyw_screening, true);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasKvp()) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_kvp_prep_registration, !KvpDao.isRegisteredForKvpPrEP(baseEntityId) && age >= 15);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasICCM() && !IccmDao.isRegisteredForIccm(baseEntityId)) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_iccm_registration, true);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasSbc()) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_sbc_registration, !SbcDao.isRegisteredForSbc(baseEntityId) && age >= 10);
+        }
+
+        if (ChwApplication.getApplicationFlavor().hasCecap()) {
+            AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_cancer_preventive_services_registration, !CecapDao.isRegisteredForCecap(baseEntityId) && age >= 14);
+        }
+
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_harm_reduction_assessment, false);
+        AllClientsUtils.setMenuItemVisibility(menu, org.smartregister.chw.R.id.action_harm_reduction_sober_house_enrollment, false);
+
+        AllClientsUtils.addTbLeprosyMenuItem(menu, baseEntityId);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (memberObject == null) {
+            return super.onOptionsItemSelected(item);
+        }
+
+        int i = item.getItemId();
+        if (i == android.R.id.home) {
+            onBackPressed();
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_anc_registration) {
+            MemberProfileUtils.startAncRegister(this, memberObject.getBaseEntityId(), memberObject.getPhoneNumber(), memberObject.getFamilyBaseEntityId(), memberObject.getFamilyName());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_pregnancy_out_come) {
+            MemberProfileUtils.startPncRegister(this, memberObject.getBaseEntityId(), memberObject.getPhoneNumber(), memberObject.getFamilyBaseEntityId(), memberObject.getFamilyName());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_fp_initiation) {
+            MemberProfileUtils.startFpRegister(this, memberObject.getBaseEntityId(), memberObject.getGender());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_fp_ecp_provision) {
+            MemberProfileUtils.startFpEcpScreening(this);
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_malaria_registration) {
+            MemberProfileUtils.startMalariaRegister(this, memberObject.getBaseEntityId(), memberObject.getFamilyBaseEntityId());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_iccm_registration) {
+            MemberProfileUtils.startIntegratedCommunityCaseManagementEnrollment(this, memberObject.getBaseEntityId(), memberObject.getFamilyBaseEntityId());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_vmmc_registration) {
+            MemberProfileUtils.startVmmcRegister(this, memberObject.getBaseEntityId(), memberObject.getPhoneNumber(), memberObject.getFamilyBaseEntityId(), memberObject.getFamilyName());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_hiv_registration || i == org.smartregister.chw.core.R.id.action_cbhs_registration) {
+            MemberProfileUtils.startHivRegister(this, memberObject.getBaseEntityId(), memberObject.getGender(), getMemberDob());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_tb_registration) {
+            MemberProfileUtils.startTbRegister(this, memberObject.getBaseEntityId());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_hivst_registration) {
+            MemberProfileUtils.startHivstRegistration(this, memberObject.getBaseEntityId(), memberObject.getGender());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_agyw_screening) {
+            MemberProfileUtils.startAgywScreening(this, memberObject.getBaseEntityId(), getMemberDob());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_kvp_prep_registration) {
+            MemberProfileUtils.startKvpPrEPRegistration(this, memberObject.getBaseEntityId(), memberObject.getGender(), getMemberDob());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_sbc_registration) {
+            MemberProfileUtils.startSbcRegistration(this, memberObject.getBaseEntityId());
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_cancer_preventive_services_registration) {
+            MemberProfileUtils.startCancerPreventiveServicesRegistration(this, memberObject.getBaseEntityId());
+            return true;
+        } else if (i == org.smartregister.chw.R.id.action_tbleprosy_screening) {
+            startTbLeprosyScreening();
+            return true;
+        } else if (i == org.smartregister.chw.core.R.id.action_location_info) {
+            JSONObject preFilledForm = CoreJsonFormUtils.getAutoPopulatedJsonEditFormString(
+                    CoreConstants.JSON_FORM.getFamilyDetailsRegister(),
+                    this,
+                    UpdateDetailsUtil.getFamilyRegistrationDetails(
+                            UpdateDetailsUtil.getFamilyBaseEntityId(
+                                    org.smartregister.chw.core.utils.Utils.getCommonPersonObjectClient(memberObject.getBaseEntityId())
+                            )
+                    ),
+                    Utils.metadata().familyRegister.updateEventType
+            );
+            if (preFilledForm != null) {
+                UpdateDetailsUtil.startUpdateClientDetailsActivity(preFilledForm, this);
+            }
+            return true;
+        } else if (i == org.smartregister.chw.R.id.action_remove_member) {
+            removeIndividualProfile();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void startTbLeprosyScreening() {
+        TbLeprosyRegisterActivity.startRegistration(this, memberObject.getBaseEntityId());
+    }
+
+    private void removeIndividualProfile() {
+        CommonRepository commonRepository = Utils.context().commonrepository(Utils.metadata().familyMemberRegister.tableName);
+        CommonPersonObject commonPersonObject = commonRepository.findByBaseEntityId(memberObject.getBaseEntityId());
+        CommonPersonObjectClient client = new CommonPersonObjectClient(commonPersonObject.getCaseId(), commonPersonObject.getDetails(), "");
+        client.setColumnmaps(commonPersonObject.getColumnmaps());
+
+        IndividualProfileRemoveActivity.startIndividualProfileActivity(
+                this,
+                client,
+                memberObject.getFamilyBaseEntityId(),
+                memberObject.getFamilyHead(),
+                memberObject.getPrimaryCareGiver(),
+                FamilyRegisterActivity.class.getCanonicalName()
+        );
+    }
+
+    private String getMemberDob() {
+        try {
+            CommonRepository commonRepository = Utils.context().commonrepository(Utils.metadata().familyMemberRegister.tableName);
+            CommonPersonObject commonPersonObject = commonRepository.findByBaseEntityId(memberObject.getBaseEntityId());
+            if (commonPersonObject == null || commonPersonObject.getColumnmaps() == null) {
+                return null;
+            }
+            return Utils.getValue(commonPersonObject.getColumnmaps(), DBConstants.KEY.DOB, false);
+        } catch (Exception e) {
+            Timber.e(e);
+            return null;
+        }
     }
 
     private boolean hasVisitsAfterMatConsent() {


### PR DESCRIPTION
## Summary
- add `onCreateOptionsMenu` to `HarmReductionSoberHouseProfileActivity` using `HarmReductionProfileActivity` as the reference pattern
- add `onOptionsItemSelected` handlers for the sober-house profile and keep only relevant actions enabled
- add local helper methods needed by the sober-house activity for DOB lookup, TB/leprosy screening, and individual profile removal

## Validation
- `./gradlew :opensrp-chw:compileNacpDebugJavaWithJavac`