### PR TITLE
Sync selected CHW event types by team ID

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
@@ -3,6 +3,8 @@ package org.smartregister.chw.application;
 import org.smartregister.SyncConfiguration;
 import org.smartregister.SyncFilter;
 import org.smartregister.chw.BuildConfig;
+import org.smartregister.chw.util.Constants;
+import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.Utils;
 
 import java.util.Arrays;
@@ -63,6 +65,10 @@ public class ChwSyncConfiguration extends SyncConfiguration {
     @Override
     public boolean isSyncUsingPost() {
         return !BuildConfig.DEBUG && ChwApplication.getApplicationFlavor().syncUsingPost();
+    }
+
+    public List<String> getTeamIdScopedEventTypes() {
+        return Arrays.asList(CoreConstants.EventType.CLOSE_REFERRAL, Constants.Events.LTFU_FEEDBACK);
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
@@ -71,6 +71,7 @@ public class ChwSyncConfiguration extends SyncConfiguration {
                 "Hiv Index Contact Registration",
                 "HIV Index Contact Community Followup Referral",
                 Constants.Events.LTFU_FEEDBACK,
+                "LTF Referral Registration",
                 "HIV Index Contact CHW Followup"
         );
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwSyncConfiguration.java
@@ -4,7 +4,6 @@ import org.smartregister.SyncConfiguration;
 import org.smartregister.SyncFilter;
 import org.smartregister.chw.BuildConfig;
 import org.smartregister.chw.util.Constants;
-import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.Utils;
 
 import java.util.Arrays;
@@ -68,7 +67,12 @@ public class ChwSyncConfiguration extends SyncConfiguration {
     }
 
     public List<String> getTeamIdScopedEventTypes() {
-        return Arrays.asList(CoreConstants.EventType.CLOSE_REFERRAL, Constants.Events.LTFU_FEEDBACK);
+        return Arrays.asList(
+                "Hiv Index Contact Registration",
+                "HIV Index Contact Community Followup Referral",
+                Constants.Events.LTFU_FEEDBACK,
+                "HIV Index Contact CHW Followup"
+        );
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
@@ -1,8 +1,290 @@
 package org.smartregister.chw.sync;
 
+import android.content.Intent;
+import android.util.Pair;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.AllConstants;
+import org.smartregister.CoreLibrary;
+import org.smartregister.SyncConfiguration;
+import org.smartregister.SyncFilter;
+import org.smartregister.chw.application.ChwSyncConfiguration;
+import org.smartregister.domain.FetchStatus;
+import org.smartregister.domain.Response;
+import org.smartregister.domain.SyncEntity;
+import org.smartregister.domain.SyncProgress;
+import org.smartregister.repository.AllSharedPreferences;
+import org.smartregister.sync.helper.ECSyncHelper;
 import org.smartregister.sync.intent.SyncIntentService;
+import org.smartregister.util.Utils;
+
+import java.net.URLEncoder;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
 
 public class ChwSyncIntentService extends SyncIntentService {
+    private static final String EVENT_TYPE = "eventType";
+    private static final String TEAM_ID_SCOPED_EVENT_TYPES_PREFIX = "teamId:";
+    private static final String UTF_8 = "UTF-8";
+    private long totalRecords;
+    private int fetchedRecords;
+    private boolean teamScopedSyncActive;
+    private boolean retryReturnCount = true;
+
+    @Override
+    protected void pullECFromServer() {
+        if (!shouldUseTeamIdScopedEventSync()) {
+            super.pullECFromServer();
+            return;
+        }
+
+        if (StringUtils.isBlank(getDefaultTeamId())) {
+            FetchStatus.fetchedFailed.setDisplayValue("Missing teamId for CHW sync");
+            complete(FetchStatus.fetchedFailed);
+            resetTeamScopedSyncState();
+            return;
+        }
+
+        resetTeamScopedSyncState();
+        teamScopedSyncActive = true;
+        fetchTeamScopedEvents(0, true);
+    }
+
+    private synchronized void fetchTeamScopedEvents(int count, boolean returnCount) {
+        retryReturnCount = returnCount;
+
+        try {
+            SyncConfiguration configs = getSyncConfiguration();
+            if (configs.getSyncFilterParam() == null || StringUtils.isBlank(configs.getSyncFilterValue())) {
+                complete(FetchStatus.fetchedFailed);
+                resetTeamScopedSyncState();
+                return;
+            }
+
+            ECSyncHelper ecSyncUpdater = ECSyncHelper.getInstance(getContext());
+            Long lastSyncDatetime = ecSyncUpdater.getLastSyncTimeStamp();
+            Response<String> response = getTeamScopedSyncResponse(getFormattedBaseUrl() + SYNC_URL, lastSyncDatetime,
+                    returnCount);
+
+            if (response == null) {
+                FetchStatus.fetchedFailed.setDisplayValue("Empty response");
+                complete(FetchStatus.fetchedFailed);
+                resetTeamScopedSyncState();
+                return;
+            }
+
+            if (response.isUrlError() || response.isTimeoutError()) {
+                FetchStatus.fetchedFailed.setDisplayValue(response.status().displayValue());
+                complete(FetchStatus.fetchedFailed);
+                resetTeamScopedSyncState();
+                return;
+            }
+
+            if (response.isFailure()) {
+                fetchFailed(count);
+                return;
+            }
+
+            if (returnCount && response.getTotalRecords() != null) {
+                totalRecords = response.getTotalRecords();
+            }
+
+            processFetchedTeamScopedEvents(response, ecSyncUpdater, count);
+        } catch (Exception e) {
+            Timber.e(e, "Fetch Retry Exception: %s", e.getMessage());
+            fetchFailed(count);
+        }
+    }
+
+    protected Response<String> getTeamScopedSyncResponse(String requestUrl, long lastSyncDatetime, boolean returnCount)
+            throws JSONException {
+        if (getHttpAgent() == null) {
+            return null;
+        }
+
+        if (getSyncConfiguration().isSyncUsingPost()) {
+            return getHttpAgent().postWithJsonResponse(requestUrl,
+                    buildTeamScopedSyncRequestPayload(lastSyncDatetime, returnCount).toString());
+        }
+
+        String requestUrlWithParams = buildTeamScopedSyncRequestUrl(requestUrl, lastSyncDatetime, returnCount);
+        Timber.i("URL: %s", requestUrlWithParams);
+        return getHttpAgent().fetch(requestUrlWithParams);
+    }
+
+    private void processFetchedTeamScopedEvents(Response<String> response, ECSyncHelper ecSyncUpdater, int count)
+            throws JSONException {
+        int eventCount;
+        JSONObject jsonObject = new JSONObject();
+        if (response.payload() == null) {
+            eventCount = 0;
+        } else {
+            jsonObject = new JSONObject(response.payload());
+            eventCount = fetchNumberOfEvents(jsonObject);
+        }
+
+        if (eventCount == 0) {
+            complete(FetchStatus.nothingFetched);
+            sendSyncProgressBroadcast(0);
+            resetTeamScopedSyncState();
+            return;
+        }
+
+        if (eventCount < 0) {
+            fetchFailed(count);
+            return;
+        }
+
+        Pair<Long, Long> serverVersionPair = getMinMaxServerVersions(jsonObject);
+        long lastServerVersion = serverVersionPair.second - 1;
+        if (eventCount < getEventPullLimit()) {
+            lastServerVersion = serverVersionPair.second;
+        }
+
+        boolean isSaved = ecSyncUpdater.saveAllClientsAndEvents(jsonObject);
+        if (isSaved) {
+            processClient(serverVersionPair);
+            ecSyncUpdater.updateLastSyncTimeStamp(lastServerVersion);
+        }
+
+        sendSyncProgressBroadcast(eventCount);
+        fetchTeamScopedEvents(0, false);
+    }
+
+    @Override
+    public void fetchFailed(int count) {
+        if (!teamScopedSyncActive) {
+            super.fetchFailed(count);
+            return;
+        }
+
+        if (count < getSyncConfiguration().getSyncMaxRetries()) {
+            fetchTeamScopedEvents(count + 1, retryReturnCount);
+        } else {
+            complete(FetchStatus.fetchedFailed);
+            resetTeamScopedSyncState();
+        }
+    }
+
+    @Override
+    protected void sendSyncProgressBroadcast(int eventCount) {
+        if (!teamScopedSyncActive) {
+            super.sendSyncProgressBroadcast(eventCount);
+            return;
+        }
+
+        fetchedRecords += eventCount;
+        SyncProgress syncProgress = new SyncProgress();
+        syncProgress.setSyncEntity(SyncEntity.EVENTS);
+        syncProgress.setTotalRecords(totalRecords);
+        syncProgress.setPercentageSynced(Utils.calculatePercentage(totalRecords, fetchedRecords));
+
+        Intent intent = new Intent();
+        intent.setAction(AllConstants.SyncProgressConstants.ACTION_SYNC_PROGRESS);
+        intent.putExtra(AllConstants.SyncProgressConstants.SYNC_PROGRESS_DATA, syncProgress);
+        LocalBroadcastManager.getInstance(getContext()).sendBroadcast(intent);
+    }
+
+    protected JSONObject buildTeamScopedSyncRequestPayload(long lastSyncDatetime, boolean returnCount)
+            throws JSONException {
+        Map<String, String> params = buildTeamScopedSyncParams(lastSyncDatetime, returnCount);
+        JSONObject requestPayload = new JSONObject();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            switch (entry.getKey()) {
+                case AllConstants.SERVER_VERSION:
+                    requestPayload.put(entry.getKey(), Long.parseLong(entry.getValue()));
+                    break;
+                case AllConstants.LIMIT:
+                    requestPayload.put(entry.getKey(), Integer.parseInt(entry.getValue()));
+                    break;
+                case AllConstants.RETURN_COUNT:
+                    requestPayload.put(entry.getKey(), Boolean.parseBoolean(entry.getValue()));
+                    break;
+                default:
+                    requestPayload.put(entry.getKey(), entry.getValue());
+                    break;
+            }
+        }
+
+        return requestPayload;
+    }
+
+    protected String buildTeamScopedSyncRequestUrl(String requestUrl, long lastSyncDatetime, boolean returnCount) {
+        return requestUrl + "?" + encodeQueryString(buildTeamScopedSyncParams(lastSyncDatetime, returnCount));
+    }
+
+    protected Map<String, String> buildTeamScopedSyncParams(long lastSyncDatetime, boolean returnCount) {
+        LinkedHashMap<String, String> requestParams = new LinkedHashMap<>();
+        SyncConfiguration syncConfiguration = getSyncConfiguration();
+        requestParams.put(syncConfiguration.getSyncFilterParam().value(), syncConfiguration.getSyncFilterValue());
+        requestParams.put(SyncFilter.TEAM_ID.value(), getDefaultTeamId());
+        requestParams.put(EVENT_TYPE, getTeamScopedEventTypeFilter());
+        requestParams.put(AllConstants.SERVER_VERSION, String.valueOf(lastSyncDatetime));
+        requestParams.put(AllConstants.LIMIT, String.valueOf(getEventPullLimit()));
+        requestParams.put(AllConstants.RETURN_COUNT, String.valueOf(returnCount));
+        return requestParams;
+    }
+
+    protected SyncConfiguration getSyncConfiguration() {
+        return CoreLibrary.getInstance().getSyncConfiguration();
+    }
+
+    protected List<String> getTeamIdScopedEventTypes() {
+        SyncConfiguration syncConfiguration = getSyncConfiguration();
+        if (syncConfiguration instanceof ChwSyncConfiguration) {
+            return ((ChwSyncConfiguration) syncConfiguration).getTeamIdScopedEventTypes();
+        }
+        return Collections.emptyList();
+    }
+
+    protected String getTeamScopedEventTypeFilter() {
+        return TEAM_ID_SCOPED_EVENT_TYPES_PREFIX + String.join(",", getTeamIdScopedEventTypes());
+    }
+
+    protected String getDefaultTeamId() {
+        AllSharedPreferences allSharedPreferences = CoreLibrary.getInstance().context().allSharedPreferences();
+        return allSharedPreferences.fetchDefaultTeamId(allSharedPreferences.fetchRegisteredANM());
+    }
+
+    protected boolean shouldUseTeamIdScopedEventSync() {
+        return !getTeamIdScopedEventTypes().isEmpty();
+    }
+
+    private String encodeQueryString(Map<String, String> requestParams) {
+        StringBuilder queryBuilder = new StringBuilder();
+        for (Map.Entry<String, String> entry : requestParams.entrySet()) {
+            if (queryBuilder.length() > 0) {
+                queryBuilder.append('&');
+            }
+
+            queryBuilder.append(urlEncode(entry.getKey())).append('=').append(urlEncode(entry.getValue()));
+        }
+
+        return queryBuilder.toString();
+    }
+
+    private String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to encode sync parameter", e);
+        }
+    }
+
+    private void resetTeamScopedSyncState() {
+        teamScopedSyncActive = false;
+        retryReturnCount = true;
+        totalRecords = 0;
+        fetchedRecords = 0;
+    }
 
     @Override
     public int getEventPullLimit() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
@@ -6,6 +6,7 @@ import android.util.Pair;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.smartregister.AllConstants;
@@ -23,17 +24,27 @@ import org.smartregister.sync.intent.SyncIntentService;
 import org.smartregister.util.Utils;
 
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import timber.log.Timber;
 
 public class ChwSyncIntentService extends SyncIntentService {
+    private static final String BASE_ENTITY_ID = "baseEntityId";
+    private static final String BASE_ENTITY_IDS = "baseEntityIds";
+    private static final int BASE_ENTITY_ID_BACKFILL_BATCH_SIZE = 1000;
+    private static final String CLIENTS = "clients";
     private static final String EVENT_TYPE = "eventType";
+    private static final String EVENTS = "events";
+    private static final String SYNC_BY_BASE_ENTITY_IDS_URL = "/rest/event/sync-by-base-entity-ids";
     private static final String TEAM_ID_SCOPED_EVENT_TYPES_PREFIX = "teamId:";
     private static final String UTF_8 = "UTF-8";
+    private static final String WITH_FAMILY_EVENTS = "withFamilyEvents";
     public static final String LIMIT = "limit";
     private long totalRecords;
     private int fetchedRecords;
@@ -122,7 +133,7 @@ public class ChwSyncIntentService extends SyncIntentService {
     }
 
     private void processFetchedTeamScopedEvents(Response<String> response, ECSyncHelper ecSyncUpdater, int count)
-            throws JSONException {
+            throws Exception {
         int eventCount;
         JSONObject jsonObject = new JSONObject();
         if (response.payload() == null) {
@@ -151,10 +162,18 @@ public class ChwSyncIntentService extends SyncIntentService {
         }
 
         boolean isSaved = ecSyncUpdater.saveAllClientsAndEvents(jsonObject);
-        if (isSaved) {
-            processClient(serverVersionPair);
-            ecSyncUpdater.updateLastSyncTimeStamp(lastServerVersion);
+        if (!isSaved) {
+            fetchFailed(count);
+            return;
         }
+
+        if (!syncRelatedClientEventsByBaseEntityIds(jsonObject)) {
+            fetchFailed(count);
+            return;
+        }
+
+        processClient(serverVersionPair);
+        ecSyncUpdater.updateLastSyncTimeStamp(lastServerVersion);
 
         sendSyncProgressBroadcast(eventCount);
         fetchTeamScopedEvents(0, false);
@@ -259,6 +278,67 @@ public class ChwSyncIntentService extends SyncIntentService {
         return !getTeamIdScopedEventTypes().isEmpty();
     }
 
+    protected boolean syncRelatedClientEventsByBaseEntityIds(JSONObject jsonObject) throws Exception {
+        List<String> baseEntityIds = new ArrayList<>(extractBaseEntityIds(jsonObject));
+        if (baseEntityIds.isEmpty()) {
+            return true;
+        }
+
+        for (int start = 0; start < baseEntityIds.size(); start += getBaseEntityBackfillBatchSize()) {
+            int end = Math.min(start + getBaseEntityBackfillBatchSize(), baseEntityIds.size());
+            JSONArray baseEntityIdsBatch = new JSONArray();
+            for (int i = start; i < end; i++) {
+                baseEntityIdsBatch.put(baseEntityIds.get(i));
+            }
+
+            Response<String> response = fetchClientEventsByBaseEntityIds(baseEntityIdsBatch);
+            if (response == null || response.payload() == null || response.isFailure()
+                    || response.isTimeoutError() || response.isUrlError()) {
+                return false;
+            }
+
+            if (!processRelatedClientEvents(new JSONObject(response.payload()))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected int getBaseEntityBackfillBatchSize() {
+        return BASE_ENTITY_ID_BACKFILL_BATCH_SIZE;
+    }
+
+    protected Set<String> extractBaseEntityIds(JSONObject jsonObject) {
+        LinkedHashSet<String> baseEntityIds = new LinkedHashSet<>();
+        if (jsonObject == null) {
+            return baseEntityIds;
+        }
+
+        appendBaseEntityIds(jsonObject.optJSONArray(EVENTS), baseEntityIds);
+        appendBaseEntityIds(jsonObject.optJSONArray(CLIENTS), baseEntityIds);
+        return baseEntityIds;
+    }
+
+    protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds) throws Exception {
+        JSONObject syncParams = new JSONObject();
+        syncParams.put(BASE_ENTITY_IDS, baseEntityIds);
+        syncParams.put(WITH_FAMILY_EVENTS, true);
+        syncParams.put(AllConstants.SERVER_VERSION, 0);
+        return getHttpAgent().postWithJsonResponse(getFormattedBaseUrl() + SYNC_BY_BASE_ENTITY_IDS_URL,
+                syncParams.toString());
+    }
+
+    protected boolean processRelatedClientEvents(JSONObject jsonObject) {
+        ECSyncHelper ecSyncUpdater = ECSyncHelper.getInstance(getContext());
+        Pair<Long, Long> serverVersionPair = getMinMaxServerVersions(jsonObject);
+        boolean isSaved = ecSyncUpdater.saveAllClientsAndEvents(jsonObject);
+        if (isSaved) {
+            processClient(serverVersionPair);
+        }
+        return isSaved;
+    }
+
     private String encodeQueryString(Map<String, String> requestParams) {
         StringBuilder queryBuilder = new StringBuilder();
         for (Map.Entry<String, String> entry : requestParams.entrySet()) {
@@ -285,6 +365,24 @@ public class ChwSyncIntentService extends SyncIntentService {
         retryReturnCount = true;
         totalRecords = 0;
         fetchedRecords = 0;
+    }
+
+    private void appendBaseEntityIds(JSONArray jsonArray, Set<String> baseEntityIds) {
+        if (jsonArray == null) {
+            return;
+        }
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            JSONObject jsonObject = jsonArray.optJSONObject(i);
+            if (jsonObject == null) {
+                continue;
+            }
+
+            String baseEntityId = StringUtils.trimToNull(jsonObject.optString(BASE_ENTITY_ID));
+            if (baseEntityId != null) {
+                baseEntityIds.add(baseEntityId);
+            }
+        }
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
@@ -34,6 +34,7 @@ public class ChwSyncIntentService extends SyncIntentService {
     private static final String EVENT_TYPE = "eventType";
     private static final String TEAM_ID_SCOPED_EVENT_TYPES_PREFIX = "teamId:";
     private static final String UTF_8 = "UTF-8";
+    public static final String LIMIT = "limit";
     private long totalRecords;
     private int fetchedRecords;
     private boolean teamScopedSyncActive;
@@ -202,7 +203,7 @@ public class ChwSyncIntentService extends SyncIntentService {
                 case AllConstants.SERVER_VERSION:
                     requestPayload.put(entry.getKey(), Long.parseLong(entry.getValue()));
                     break;
-                case AllConstants.LIMIT:
+                case LIMIT:
                     requestPayload.put(entry.getKey(), Integer.parseInt(entry.getValue()));
                     break;
                 case AllConstants.RETURN_COUNT:
@@ -228,7 +229,7 @@ public class ChwSyncIntentService extends SyncIntentService {
         requestParams.put(SyncFilter.TEAM_ID.value(), getDefaultTeamId());
         requestParams.put(EVENT_TYPE, getTeamScopedEventTypeFilter());
         requestParams.put(AllConstants.SERVER_VERSION, String.valueOf(lastSyncDatetime));
-        requestParams.put(AllConstants.LIMIT, String.valueOf(getEventPullLimit()));
+        requestParams.put(LIMIT, String.valueOf(getEventPullLimit()));
         requestParams.put(AllConstants.RETURN_COUNT, String.valueOf(returnCount));
         return requestParams;
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwSyncIntentService.java
@@ -38,9 +38,13 @@ public class ChwSyncIntentService extends SyncIntentService {
     private static final String BASE_ENTITY_ID = "baseEntityId";
     private static final String BASE_ENTITY_IDS = "baseEntityIds";
     private static final int BASE_ENTITY_ID_BACKFILL_BATCH_SIZE = 1000;
+    private static final String CLIENT_SEARCH_BY_CRITERIA_URL = "/rest/client/searchByCriteria";
+    private static final String CLIENT_TYPE = "clientType";
     private static final String CLIENTS = "clients";
     private static final String EVENT_TYPE = "eventType";
     private static final String EVENTS = "events";
+    private static final String FAMILY_REGISTRATION = "Family Registration";
+    private static final String HOUSEHOLD_MEMBER = "householdMember";
     private static final String SYNC_BY_BASE_ENTITY_IDS_URL = "/rest/event/sync-by-base-entity-ids";
     private static final String TEAM_ID_SCOPED_EVENT_TYPES_PREFIX = "teamId:";
     private static final String UTF_8 = "UTF-8";
@@ -279,27 +283,21 @@ public class ChwSyncIntentService extends SyncIntentService {
     }
 
     protected boolean syncRelatedClientEventsByBaseEntityIds(JSONObject jsonObject) throws Exception {
-        List<String> baseEntityIds = new ArrayList<>(extractBaseEntityIds(jsonObject));
-        if (baseEntityIds.isEmpty()) {
-            return true;
+        LinkedHashSet<String> syncedBaseEntityIds = new LinkedHashSet<>(extractBaseEntityIds(jsonObject));
+        LinkedHashSet<String> familyBaseEntityIds = new LinkedHashSet<>(extractFamilyRegistrationBaseEntityIds(jsonObject));
+
+        if (!syncClientEventsByBaseEntityIds(syncedBaseEntityIds, true, familyBaseEntityIds)) {
+            return false;
         }
 
-        for (int start = 0; start < baseEntityIds.size(); start += getBaseEntityBackfillBatchSize()) {
-            int end = Math.min(start + getBaseEntityBackfillBatchSize(), baseEntityIds.size());
-            JSONArray baseEntityIdsBatch = new JSONArray();
-            for (int i = start; i < end; i++) {
-                baseEntityIdsBatch.put(baseEntityIds.get(i));
-            }
+        LinkedHashSet<String> householdMemberBaseEntityIds = fetchHouseholdMemberBaseEntityIds(familyBaseEntityIds);
+        if (householdMemberBaseEntityIds == null) {
+            return false;
+        }
 
-            Response<String> response = fetchClientEventsByBaseEntityIds(baseEntityIdsBatch);
-            if (response == null || response.payload() == null || response.isFailure()
-                    || response.isTimeoutError() || response.isUrlError()) {
-                return false;
-            }
-
-            if (!processRelatedClientEvents(new JSONObject(response.payload()))) {
-                return false;
-            }
+        householdMemberBaseEntityIds.removeAll(syncedBaseEntityIds);
+        if (!syncClientEventsByBaseEntityIds(householdMemberBaseEntityIds, false, null)) {
+            return false;
         }
 
         return true;
@@ -321,12 +319,21 @@ public class ChwSyncIntentService extends SyncIntentService {
     }
 
     protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds) throws Exception {
+        return fetchClientEventsByBaseEntityIds(baseEntityIds, true);
+    }
+
+    protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds, boolean withFamilyEvents)
+            throws Exception {
         JSONObject syncParams = new JSONObject();
         syncParams.put(BASE_ENTITY_IDS, baseEntityIds);
-        syncParams.put(WITH_FAMILY_EVENTS, true);
+        syncParams.put(WITH_FAMILY_EVENTS, withFamilyEvents);
         syncParams.put(AllConstants.SERVER_VERSION, 0);
         return getHttpAgent().postWithJsonResponse(getFormattedBaseUrl() + SYNC_BY_BASE_ENTITY_IDS_URL,
                 syncParams.toString());
+    }
+
+    protected Response<String> fetchHouseholdMembersByFamilyId(String familyBaseEntityId) {
+        return getHttpAgent().fetch(buildHouseholdMemberSearchUrl(familyBaseEntityId));
     }
 
     protected boolean processRelatedClientEvents(JSONObject jsonObject) {
@@ -337,6 +344,13 @@ public class ChwSyncIntentService extends SyncIntentService {
             processClient(serverVersionPair);
         }
         return isSaved;
+    }
+
+    protected String buildHouseholdMemberSearchUrl(String familyBaseEntityId) {
+        LinkedHashMap<String, String> requestParams = new LinkedHashMap<>();
+        requestParams.put(CLIENT_TYPE, HOUSEHOLD_MEMBER);
+        requestParams.put(BASE_ENTITY_ID, familyBaseEntityId);
+        return getFormattedBaseUrl() + CLIENT_SEARCH_BY_CRITERIA_URL + "?" + encodeQueryString(requestParams);
     }
 
     private String encodeQueryString(Map<String, String> requestParams) {
@@ -365,6 +379,84 @@ public class ChwSyncIntentService extends SyncIntentService {
         retryReturnCount = true;
         totalRecords = 0;
         fetchedRecords = 0;
+    }
+
+    private boolean syncClientEventsByBaseEntityIds(Set<String> baseEntityIds, boolean withFamilyEvents,
+                                                    Set<String> familyBaseEntityIds) throws Exception {
+        List<String> uniqueBaseEntityIds = new ArrayList<>(baseEntityIds);
+        if (uniqueBaseEntityIds.isEmpty()) {
+            return true;
+        }
+
+        for (int start = 0; start < uniqueBaseEntityIds.size(); start += getBaseEntityBackfillBatchSize()) {
+            int end = Math.min(start + getBaseEntityBackfillBatchSize(), uniqueBaseEntityIds.size());
+            JSONArray baseEntityIdsBatch = new JSONArray();
+            for (int i = start; i < end; i++) {
+                baseEntityIdsBatch.put(uniqueBaseEntityIds.get(i));
+            }
+
+            Response<String> response = fetchClientEventsByBaseEntityIds(baseEntityIdsBatch, withFamilyEvents);
+            if (response == null || response.payload() == null || response.isFailure()
+                    || response.isTimeoutError() || response.isUrlError()) {
+                return false;
+            }
+
+            JSONObject relatedPayload = new JSONObject(response.payload());
+            if (familyBaseEntityIds != null) {
+                familyBaseEntityIds.addAll(extractFamilyRegistrationBaseEntityIds(relatedPayload));
+            }
+
+            if (!processRelatedClientEvents(relatedPayload)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private LinkedHashSet<String> fetchHouseholdMemberBaseEntityIds(Set<String> familyBaseEntityIds) throws Exception {
+        LinkedHashSet<String> householdMemberBaseEntityIds = new LinkedHashSet<>();
+        for (String familyBaseEntityId : familyBaseEntityIds) {
+            Response<String> response = fetchHouseholdMembersByFamilyId(familyBaseEntityId);
+            if (response == null || response.payload() == null || response.isFailure()
+                    || response.isTimeoutError() || response.isUrlError()) {
+                return null;
+            }
+
+            appendBaseEntityIds(new JSONObject(response.payload()).optJSONArray(CLIENTS), householdMemberBaseEntityIds);
+        }
+
+        return householdMemberBaseEntityIds;
+    }
+
+    private Set<String> extractFamilyRegistrationBaseEntityIds(JSONObject jsonObject) {
+        LinkedHashSet<String> familyBaseEntityIds = new LinkedHashSet<>();
+        if (jsonObject == null) {
+            return familyBaseEntityIds;
+        }
+
+        JSONArray events = jsonObject.optJSONArray(EVENTS);
+        if (events == null) {
+            return familyBaseEntityIds;
+        }
+
+        for (int i = 0; i < events.length(); i++) {
+            JSONObject event = events.optJSONObject(i);
+            if (event == null) {
+                continue;
+            }
+
+            if (!FAMILY_REGISTRATION.equals(StringUtils.trimToEmpty(event.optString(EVENT_TYPE)))) {
+                continue;
+            }
+
+            String baseEntityId = StringUtils.trimToNull(event.optString(BASE_ENTITY_ID));
+            if (baseEntityId != null) {
+                familyBaseEntityIds.add(baseEntityId);
+            }
+        }
+
+        return familyBaseEntityIds;
     }
 
     private void appendBaseEntityIds(JSONArray jsonArray, Set<String> baseEntityIds) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -206,6 +206,8 @@ public class Constants extends CoreConstants {
 
     public static final class Events {
         public static final String UPDATE_MALARIA_CONFIGURATION = "Update Malaria Confirmation";
+        
+        public static final String LTFU_FEEDBACK = "LTFU Feedback";
 
         public static final String MALARIA_CONFIRMATION = "malaria_confirmation";
 

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
@@ -1,0 +1,93 @@
+package org.smartregister.chw.sync;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.smartregister.AllConstants;
+import org.smartregister.SyncConfiguration;
+import org.smartregister.SyncFilter;
+import org.smartregister.chw.BaseUnitTest;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class ChwSyncIntentServiceTest extends BaseUnitTest {
+
+    @Test
+    public void buildTeamScopedSyncParamsShouldIncludeLocationTeamAndWhitelist() {
+        TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
+                Arrays.asList("Close Referral", "LTFU Feedback"));
+
+        Map<String, String> params = service.buildTeamScopedSyncParams(25L, true);
+
+        assertEquals("test-location-id", params.get("locationId"));
+        assertEquals("test-team-id", params.get("teamId"));
+        assertEquals("teamId:Close Referral,LTFU Feedback", params.get("eventType"));
+        assertEquals("25", params.get(AllConstants.SERVER_VERSION));
+        assertEquals("500", params.get(AllConstants.LIMIT));
+        assertEquals("true", params.get(AllConstants.RETURN_COUNT));
+    }
+
+    @Test
+    public void buildTeamScopedSyncRequestPayloadShouldUseTypedValues() throws Exception {
+        TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
+                Arrays.asList("Close Referral", "LTFU Feedback"));
+
+        JSONObject payload = service.buildTeamScopedSyncRequestPayload(42L, false);
+
+        assertEquals("test-location-id", payload.getString("locationId"));
+        assertEquals("test-team-id", payload.getString("teamId"));
+        assertEquals("teamId:Close Referral,LTFU Feedback", payload.getString("eventType"));
+        assertEquals(42L, payload.getLong(AllConstants.SERVER_VERSION));
+        assertEquals(500, payload.getInt(AllConstants.LIMIT));
+        assertEquals(false, payload.getBoolean(AllConstants.RETURN_COUNT));
+    }
+
+    @Test
+    public void buildTeamScopedSyncRequestUrlShouldEncodeEventTypes() {
+        TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
+                Arrays.asList("Close Referral", "LTFU Feedback"));
+
+        String requestUrl = service.buildTeamScopedSyncRequestUrl("https://example.org/rest/event/sync", 7L, true);
+
+        assertTrue(requestUrl.contains("locationId=test-location-id"));
+        assertTrue(requestUrl.contains("teamId=test-team-id"));
+        assertTrue(requestUrl.contains("eventType=teamId%3AClose+Referral%2CLTFU+Feedback"));
+        assertTrue(requestUrl.contains("serverVersion=7"));
+        assertTrue(requestUrl.contains("return_count=true"));
+    }
+
+    private static class TestableChwSyncIntentService extends ChwSyncIntentService {
+        private final SyncConfiguration syncConfiguration;
+        private final String teamId;
+        private final List<String> teamScopedEventTypes;
+
+        private TestableChwSyncIntentService(String locationId, String teamId, List<String> teamScopedEventTypes) {
+            this.syncConfiguration = mock(SyncConfiguration.class);
+            when(syncConfiguration.getSyncFilterParam()).thenReturn(SyncFilter.LOCATION);
+            when(syncConfiguration.getSyncFilterValue()).thenReturn(locationId);
+            this.teamId = teamId;
+            this.teamScopedEventTypes = teamScopedEventTypes;
+        }
+
+        @Override
+        protected SyncConfiguration getSyncConfiguration() {
+            return syncConfiguration;
+        }
+
+        @Override
+        protected String getDefaultTeamId() {
+            return teamId;
+        }
+
+        @Override
+        protected List<String> getTeamIdScopedEventTypes() {
+            return teamScopedEventTypes;
+        }
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
@@ -17,17 +17,29 @@ import java.util.List;
 import java.util.Map;
 
 public class ChwSyncIntentServiceTest extends BaseUnitTest {
+    private static final List<String> TEAM_SCOPED_EVENT_TYPES = Arrays.asList(
+            "Hiv Index Contact Registration",
+            "HIV Index Contact Community Followup Referral",
+            "LTFU Feedback",
+            "HIV Index Contact CHW Followup"
+    );
+    private static final String TEAM_SCOPED_EVENT_TYPES_PARAM =
+            "teamId:Hiv Index Contact Registration,HIV Index Contact Community Followup Referral,"
+                    + "LTFU Feedback,HIV Index Contact CHW Followup";
+    private static final String ENCODED_TEAM_SCOPED_EVENT_TYPES_PARAM =
+            "eventType=teamId%3AHiv+Index+Contact+Registration%2CHIV+Index+Contact+Community+"
+                    + "Followup+Referral%2CLTFU+Feedback%2CHIV+Index+Contact+CHW+Followup";
 
     @Test
     public void buildTeamScopedSyncParamsShouldIncludeLocationTeamAndWhitelist() {
         TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
-                Arrays.asList("Close Referral", "LTFU Feedback"));
+                TEAM_SCOPED_EVENT_TYPES);
 
         Map<String, String> params = service.buildTeamScopedSyncParams(25L, true);
 
         assertEquals("test-location-id", params.get("locationId"));
         assertEquals("test-team-id", params.get("teamId"));
-        assertEquals("teamId:Close Referral,LTFU Feedback", params.get("eventType"));
+        assertEquals(TEAM_SCOPED_EVENT_TYPES_PARAM, params.get("eventType"));
         assertEquals("25", params.get(AllConstants.SERVER_VERSION));
         assertEquals("500", params.get(AllConstants.LIMIT));
         assertEquals("true", params.get(AllConstants.RETURN_COUNT));
@@ -36,13 +48,13 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
     @Test
     public void buildTeamScopedSyncRequestPayloadShouldUseTypedValues() throws Exception {
         TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
-                Arrays.asList("Close Referral", "LTFU Feedback"));
+                TEAM_SCOPED_EVENT_TYPES);
 
         JSONObject payload = service.buildTeamScopedSyncRequestPayload(42L, false);
 
         assertEquals("test-location-id", payload.getString("locationId"));
         assertEquals("test-team-id", payload.getString("teamId"));
-        assertEquals("teamId:Close Referral,LTFU Feedback", payload.getString("eventType"));
+        assertEquals(TEAM_SCOPED_EVENT_TYPES_PARAM, payload.getString("eventType"));
         assertEquals(42L, payload.getLong(AllConstants.SERVER_VERSION));
         assertEquals(500, payload.getInt(AllConstants.LIMIT));
         assertEquals(false, payload.getBoolean(AllConstants.RETURN_COUNT));
@@ -51,13 +63,13 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
     @Test
     public void buildTeamScopedSyncRequestUrlShouldEncodeEventTypes() {
         TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
-                Arrays.asList("Close Referral", "LTFU Feedback"));
+                TEAM_SCOPED_EVENT_TYPES);
 
         String requestUrl = service.buildTeamScopedSyncRequestUrl("https://example.org/rest/event/sync", 7L, true);
 
         assertTrue(requestUrl.contains("locationId=test-location-id"));
         assertTrue(requestUrl.contains("teamId=test-team-id"));
-        assertTrue(requestUrl.contains("eventType=teamId%3AClose+Referral%2CLTFU+Feedback"));
+        assertTrue(requestUrl.contains(ENCODED_TEAM_SCOPED_EVENT_TYPES_PARAM));
         assertTrue(requestUrl.contains("serverVersion=7"));
         assertTrue(requestUrl.contains("return_count=true"));
     }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
@@ -1,18 +1,23 @@
 package org.smartregister.chw.sync;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.smartregister.chw.sync.ChwSyncIntentService.LIMIT;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.smartregister.AllConstants;
 import org.smartregister.SyncConfiguration;
 import org.smartregister.SyncFilter;
 import org.smartregister.chw.BaseUnitTest;
+import org.smartregister.domain.Response;
+import org.smartregister.domain.ResponseStatus;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +80,63 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         assertTrue(requestUrl.contains("return_count=true"));
     }
 
+    @Test
+    public void extractBaseEntityIdsShouldReturnUniqueEventAndClientIds() throws Exception {
+        TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("events", new JSONArray()
+                .put(new JSONObject().put("baseEntityId", "event-1"))
+                .put(new JSONObject().put("baseEntityId", "shared-id"))
+                .put(new JSONObject())
+                .put(new JSONObject().put("baseEntityId", "")));
+        jsonObject.put("clients", new JSONArray()
+                .put(new JSONObject().put("baseEntityId", "client-1"))
+                .put(new JSONObject().put("baseEntityId", "shared-id")));
+
+        List<String> baseEntityIds = new ArrayList<>(service.extractBaseEntityIds(jsonObject));
+
+        assertEquals(Arrays.asList("event-1", "shared-id", "client-1"), baseEntityIds);
+    }
+
+    @Test
+    public void syncRelatedClientEventsByBaseEntityIdsShouldFetchAndProcessUniqueBatches() throws Exception {
+        RecordingChwSyncIntentService service = new RecordingChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+        service.setBaseEntityBackfillBatchSize(2);
+        service.queueResponse(successResponse());
+        service.queueResponse(successResponse());
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("events", new JSONArray()
+                .put(new JSONObject().put("baseEntityId", "event-1"))
+                .put(new JSONObject().put("baseEntityId", "event-2")));
+        jsonObject.put("clients", new JSONArray()
+                .put(new JSONObject().put("baseEntityId", "event-2"))
+                .put(new JSONObject().put("baseEntityId", "client-1")));
+
+        boolean isSuccessful = service.syncRelatedClientEventsByBaseEntityIds(jsonObject);
+
+        assertTrue(isSuccessful);
+        assertEquals(Arrays.asList("event-1", "event-2"), service.getFetchedBaseEntityIdBatches().get(0));
+        assertEquals(Arrays.asList("client-1"), service.getFetchedBaseEntityIdBatches().get(1));
+        assertEquals(2, service.getProcessedRelatedPayloads().size());
+    }
+
+    @Test
+    public void syncRelatedClientEventsByBaseEntityIdsShouldReturnFalseWhenBatchFetchFails() throws Exception {
+        RecordingChwSyncIntentService service = new RecordingChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+        service.queueResponse(new Response<>(ResponseStatus.failure, null));
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("events", new JSONArray().put(new JSONObject().put("baseEntityId", "event-1")));
+
+        assertFalse(service.syncRelatedClientEventsByBaseEntityIds(jsonObject));
+    }
+
+    private Response<String> successResponse() {
+        return new Response<>(ResponseStatus.success, "{\"events\":[],\"clients\":[],\"no_of_events\":0}");
+    }
+
     private static class TestableChwSyncIntentService extends ChwSyncIntentService {
         private final SyncConfiguration syncConfiguration;
         private final String teamId;
@@ -101,6 +163,54 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         @Override
         protected List<String> getTeamIdScopedEventTypes() {
             return teamScopedEventTypes;
+        }
+    }
+
+    private static class RecordingChwSyncIntentService extends TestableChwSyncIntentService {
+        private final List<Response<String>> queuedResponses = new ArrayList<>();
+        private final List<List<String>> fetchedBaseEntityIdBatches = new ArrayList<>();
+        private final List<JSONObject> processedRelatedPayloads = new ArrayList<>();
+        private int baseEntityBackfillBatchSize = 1000;
+
+        private RecordingChwSyncIntentService(String locationId, String teamId, List<String> teamScopedEventTypes) {
+            super(locationId, teamId, teamScopedEventTypes);
+        }
+
+        @Override
+        protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds) {
+            List<String> fetchedBaseEntityIds = new ArrayList<>();
+            for (int i = 0; i < baseEntityIds.length(); i++) {
+                fetchedBaseEntityIds.add(baseEntityIds.optString(i));
+            }
+            fetchedBaseEntityIdBatches.add(fetchedBaseEntityIds);
+            return queuedResponses.remove(0);
+        }
+
+        @Override
+        protected boolean processRelatedClientEvents(JSONObject jsonObject) {
+            processedRelatedPayloads.add(jsonObject);
+            return true;
+        }
+
+        @Override
+        protected int getBaseEntityBackfillBatchSize() {
+            return baseEntityBackfillBatchSize;
+        }
+
+        private void queueResponse(Response<String> response) {
+            queuedResponses.add(response);
+        }
+
+        private void setBaseEntityBackfillBatchSize(int baseEntityBackfillBatchSize) {
+            this.baseEntityBackfillBatchSize = baseEntityBackfillBatchSize;
+        }
+
+        private List<List<String>> getFetchedBaseEntityIdBatches() {
+            return fetchedBaseEntityIdBatches;
+        }
+
+        private List<JSONObject> getProcessedRelatedPayloads() {
+            return processedRelatedPayloads;
         }
     }
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.smartregister.chw.sync.ChwSyncIntentService.LIMIT;
 
 import org.json.JSONObject;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         assertEquals("test-team-id", params.get("teamId"));
         assertEquals(TEAM_SCOPED_EVENT_TYPES_PARAM, params.get("eventType"));
         assertEquals("25", params.get(AllConstants.SERVER_VERSION));
-        assertEquals("500", params.get(AllConstants.LIMIT));
+        assertEquals("500", params.get(LIMIT));
         assertEquals("true", params.get(AllConstants.RETURN_COUNT));
     }
 
@@ -56,7 +57,7 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         assertEquals("test-team-id", payload.getString("teamId"));
         assertEquals(TEAM_SCOPED_EVENT_TYPES_PARAM, payload.getString("eventType"));
         assertEquals(42L, payload.getLong(AllConstants.SERVER_VERSION));
-        assertEquals(500, payload.getInt(AllConstants.LIMIT));
+        assertEquals(500, payload.getInt(LIMIT));
         assertEquals(false, payload.getBoolean(AllConstants.RETURN_COUNT));
     }
 

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/ChwSyncIntentServiceTest.java
@@ -81,6 +81,16 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
     }
 
     @Test
+    public void buildHouseholdMemberSearchUrlShouldIncludeClientTypeAndBaseEntityId() {
+        TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+
+        String requestUrl = service.buildHouseholdMemberSearchUrl("family id");
+
+        assertTrue(requestUrl.endsWith("clientType=householdMember&baseEntityId=family+id"));
+    }
+
+    @Test
     public void extractBaseEntityIdsShouldReturnUniqueEventAndClientIds() throws Exception {
         TestableChwSyncIntentService service = new TestableChwSyncIntentService("test-location-id", "test-team-id",
                 TEAM_SCOPED_EVENT_TYPES);
@@ -120,6 +130,7 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         assertEquals(Arrays.asList("event-1", "event-2"), service.getFetchedBaseEntityIdBatches().get(0));
         assertEquals(Arrays.asList("client-1"), service.getFetchedBaseEntityIdBatches().get(1));
         assertEquals(2, service.getProcessedRelatedPayloads().size());
+        assertEquals(Arrays.asList(true, true), service.getFetchedWithFamilyEvents());
     }
 
     @Test
@@ -133,8 +144,45 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         assertFalse(service.syncRelatedClientEventsByBaseEntityIds(jsonObject));
     }
 
+    @Test
+    public void syncRelatedClientEventsByBaseEntityIdsShouldBackfillHouseholdMembersForFamilyEvents() throws Exception {
+        RecordingChwSyncIntentService service = new RecordingChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+        service.queueResponse(responseWithPayload("{\"events\":[{\"baseEntityId\":\"family-1\",\"eventType\":\"Family Registration\"}],\"clients\":[],\"no_of_events\":1}"));
+        service.queueHouseholdMemberResponse(responseWithPayload("{\"clients\":[{\"baseEntityId\":\"team-member-1\"},{\"baseEntityId\":\"family-member-1\"}],\"total\":2}"));
+        service.queueResponse(responseWithPayload("{\"events\":[{\"baseEntityId\":\"family-member-1\",\"eventType\":\"Family Member Registration\"}],\"clients\":[],\"no_of_events\":1}"));
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("events", new JSONArray().put(new JSONObject().put("baseEntityId", "team-member-1")));
+
+        boolean isSuccessful = service.syncRelatedClientEventsByBaseEntityIds(jsonObject);
+
+        assertTrue(isSuccessful);
+        assertEquals(Arrays.asList("team-member-1"), service.getFetchedBaseEntityIdBatches().get(0));
+        assertEquals(Arrays.asList("family-member-1"), service.getFetchedBaseEntityIdBatches().get(1));
+        assertEquals(Arrays.asList("family-1"), service.getRequestedHouseholdMemberFamilyIds());
+        assertEquals(Arrays.asList(true, false), service.getFetchedWithFamilyEvents());
+    }
+
+    @Test
+    public void syncRelatedClientEventsByBaseEntityIdsShouldReturnFalseWhenHouseholdMemberLookupFails() throws Exception {
+        RecordingChwSyncIntentService service = new RecordingChwSyncIntentService("test-location-id", "test-team-id",
+                TEAM_SCOPED_EVENT_TYPES);
+        service.queueResponse(responseWithPayload("{\"events\":[{\"baseEntityId\":\"family-1\",\"eventType\":\"Family Registration\"}],\"clients\":[],\"no_of_events\":1}"));
+        service.queueHouseholdMemberResponse(new Response<>(ResponseStatus.failure, null));
+
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("events", new JSONArray().put(new JSONObject().put("baseEntityId", "team-member-1")));
+
+        assertFalse(service.syncRelatedClientEventsByBaseEntityIds(jsonObject));
+    }
+
     private Response<String> successResponse() {
         return new Response<>(ResponseStatus.success, "{\"events\":[],\"clients\":[],\"no_of_events\":0}");
+    }
+
+    private Response<String> responseWithPayload(String payload) {
+        return new Response<>(ResponseStatus.success, payload);
     }
 
     private static class TestableChwSyncIntentService extends ChwSyncIntentService {
@@ -168,8 +216,11 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
 
     private static class RecordingChwSyncIntentService extends TestableChwSyncIntentService {
         private final List<Response<String>> queuedResponses = new ArrayList<>();
+        private final List<Response<String>> queuedHouseholdMemberResponses = new ArrayList<>();
         private final List<List<String>> fetchedBaseEntityIdBatches = new ArrayList<>();
+        private final List<Boolean> fetchedWithFamilyEvents = new ArrayList<>();
         private final List<JSONObject> processedRelatedPayloads = new ArrayList<>();
+        private final List<String> requestedHouseholdMemberFamilyIds = new ArrayList<>();
         private int baseEntityBackfillBatchSize = 1000;
 
         private RecordingChwSyncIntentService(String locationId, String teamId, List<String> teamScopedEventTypes) {
@@ -177,13 +228,20 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
         }
 
         @Override
-        protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds) {
+        protected Response<String> fetchClientEventsByBaseEntityIds(JSONArray baseEntityIds, boolean withFamilyEvents) {
             List<String> fetchedBaseEntityIds = new ArrayList<>();
             for (int i = 0; i < baseEntityIds.length(); i++) {
                 fetchedBaseEntityIds.add(baseEntityIds.optString(i));
             }
             fetchedBaseEntityIdBatches.add(fetchedBaseEntityIds);
+            fetchedWithFamilyEvents.add(withFamilyEvents);
             return queuedResponses.remove(0);
+        }
+
+        @Override
+        protected Response<String> fetchHouseholdMembersByFamilyId(String familyBaseEntityId) {
+            requestedHouseholdMemberFamilyIds.add(familyBaseEntityId);
+            return queuedHouseholdMemberResponses.remove(0);
         }
 
         @Override
@@ -201,6 +259,10 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
             queuedResponses.add(response);
         }
 
+        private void queueHouseholdMemberResponse(Response<String> response) {
+            queuedHouseholdMemberResponses.add(response);
+        }
+
         private void setBaseEntityBackfillBatchSize(int baseEntityBackfillBatchSize) {
             this.baseEntityBackfillBatchSize = baseEntityBackfillBatchSize;
         }
@@ -209,8 +271,16 @@ public class ChwSyncIntentServiceTest extends BaseUnitTest {
             return fetchedBaseEntityIdBatches;
         }
 
+        private List<Boolean> getFetchedWithFamilyEvents() {
+            return fetchedWithFamilyEvents;
+        }
+
         private List<JSONObject> getProcessedRelatedPayloads() {
             return processedRelatedPayloads;
+        }
+
+        private List<String> getRequestedHouseholdMemberFamilyIds() {
+            return requestedHouseholdMemberFamilyIds;
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep `ChwSyncConfiguration.getSyncFilterParam()` on `SyncFilter.LOCATION`
- add a CHW-specific mixed sync request that pulls whitelisted event types by `teamId` while keeping all other events location-scoped
- add request-construction coverage for the mixed GET/POST sync params

## Testing
- `./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.sync.ChwSyncIntentServiceTest` *(blocked: GitHub Packages credentials for `opensrp-client-chw-malaria:2.0.1-NACP-SNAPSHOT` were not available in this environment)*

## Merge Order
1. [opensrp-server-core PR #2](https://github.com/Digital-Square-Tanzania/opensrp-server-core/pull/2)
2. [opensrp-server-web PR #2](https://github.com/Digital-Square-Tanzania/opensrp-server-web/pull/2)
3. opensrp-client-chw

## Related PRs
- depends on [opensrp-server-core PR #2](https://github.com/Digital-Square-Tanzania/opensrp-server-core/pull/2)
- depends on [opensrp-server-web PR #2](https://github.com/Digital-Square-Tanzania/opensrp-server-web/pull/2)
