### PR TITLE
Tag Sober House clients in All Clients register

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/fragment/AllClientsRegisterFragment.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/fragment/AllClientsRegisterFragment.java
@@ -25,6 +25,7 @@ import org.smartregister.opd.utils.OpdDbConstants;
 public class AllClientsRegisterFragment extends CoreAllClientsRegisterFragment {
     public static final String REGISTER_TYPE = "register_type";
     private static final String AYP_REGISTER_TAG = "AYP";
+    private static final String HARM_REDUCTION_SOBER_HOUSE_REGISTER_TYPE = "Harm Reduction Sober House";
 
     @Override
     public void setupViews(View view) {
@@ -132,6 +133,9 @@ public class AllClientsRegisterFragment extends CoreAllClientsRegisterFragment {
                     break;
                 case CoreConstants.REGISTER_TYPE.HARM_REDUCTION:
                     AllClientsUtils.goToHarmReductionProfile(this.getActivity(), commonPersonObjectClient);
+                    break;
+                case HARM_REDUCTION_SOBER_HOUSE_REGISTER_TYPE:
+                    AllClientsUtils.goToHarmReductionSoberHouseProfile(this.getActivity(), commonPersonObjectClient);
                     break;
                 default:
                     AllClientsUtils.goToOtherMemberProfile(this.getActivity(), commonPersonObjectClient, bundle,

--- a/opensrp-chw/src/main/java/org/smartregister/chw/provider/OpdRegisterProvider.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/provider/OpdRegisterProvider.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import timber.log.Timber;
 
 public class OpdRegisterProvider extends org.smartregister.opd.provider.OpdRegisterProvider {
+    private static final String HARM_REDUCTION_SOBER_HOUSE_REGISTER_TYPE = "Harm Reduction Sober House";
     private final Context context;
 
     private OpdRegisterProviderMetadata opdRegisterProviderMetadata;
@@ -79,6 +80,8 @@ public class OpdRegisterProvider extends org.smartregister.opd.provider.OpdRegis
             return context.getString(R.string.menu_malaria);
         } else if (registerType.equalsIgnoreCase(CoreConstants.REGISTER_TYPE.INDEPENDENT)) {
             return context.getString(R.string.menu_independent);
+        } else if (registerType.equalsIgnoreCase(HARM_REDUCTION_SOBER_HOUSE_REGISTER_TYPE)) {
+            return context.getString(R.string.harm_reduction_sober_house);
         } else if (registerType.equalsIgnoreCase(CoreConstants.REGISTER_TYPE.CECAP)) {
             return context.getString(R.string.menu_cecap);
         }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
@@ -29,6 +29,7 @@ import org.smartregister.chw.activity.FamilyOtherMemberProfileActivity;
 import org.smartregister.chw.activity.FPMemberProfileActivity;
 import org.smartregister.chw.activity.FamilyOtherMemberProfileActivityFlv;
 import org.smartregister.chw.activity.HarmReductionProfileActivity;
+import org.smartregister.chw.activity.HarmReductionSoberHouseProfileActivity;
 import org.smartregister.chw.activity.HivProfileActivity;
 import org.smartregister.chw.activity.HpsMemberProfileActivity;
 import org.smartregister.chw.activity.IccmProfileActivity;
@@ -141,6 +142,10 @@ public class AllClientsUtils {
 
     public static void goToHarmReductionProfile(Activity activity, CommonPersonObjectClient client) {
         HarmReductionProfileActivity.startProfileActivity(activity, client.getCaseId());
+    }
+
+    public static void goToHarmReductionSoberHouseProfile(Activity activity, CommonPersonObjectClient client) {
+        HarmReductionSoberHouseProfileActivity.startProfileActivity(activity, client.getCaseId());
     }
 
     public static void goToSbcProfile(Activity activity, CommonPersonObjectClient client) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
@@ -35,6 +35,9 @@ public interface ChwQueryConstant {
             "    SELECT ec_harm_reduction_risk_assessment.base_entity_id AS base_entity_id\n" +
             "    FROM ec_harm_reduction_risk_assessment  where ec_harm_reduction_risk_assessment.is_closed is 0 \n" +
             "    UNION ALL\n" +
+            "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0 \n" +
+            "    UNION ALL\n" +
             "    SELECT ec_anc_register.base_entity_id AS base_entity_id\n" +
             "    FROM ec_anc_register where ec_anc_register.is_closed is 0\n" +
             "    UNION ALL\n" +
@@ -717,6 +720,35 @@ public interface ChwQueryConstant {
             "         inner join ec_harm_reduction_risk_assessment\n" +
             "                    on ec_family_member.base_entity_id = ec_harm_reduction_risk_assessment.base_entity_id\n" +
             "where ec_family_member.date_removed is null\n  AND ec_harm_reduction_risk_assessment.is_closed is 0 " +
+            "  AND ec_family_member.base_entity_id IN (%s)\n" +
+            "  AND ec_family_member.base_entity_id NOT IN (\n" +
+            "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0\n" +
+            ")\n" +
+            "\n" +
+            "UNION ALL\n" +
+            "\n" +
+            "/*ONLY Sober House clients*/\n" +
+            "SELECT ec_family_member.first_name,\n" +
+            "       ec_family_member.middle_name,\n" +
+            "       ec_family_member.last_name,\n" +
+            "       ec_family_member.gender,\n" +
+            "       ec_family_member.dob,\n" +
+            "       ec_family_member.base_entity_id,\n" +
+            "       ec_family_member.id                          as _id,\n" +
+            "       'Harm Reduction Sober House'                 AS register_type,\n" +
+            "       ec_family_member.relational_id               as relationalid,\n" +
+            "       ec_family.village_town                       as home_address,\n" +
+            "       NULL                                         AS mother_first_name,\n" +
+            "       NULL                                         AS mother_last_name,\n" +
+            "       NULL                                         AS mother_middle_name,\n" +
+            "       ec_harm_reduction_sober_house_enrollment.last_interacted_with AS last_interacted_with\n" +
+            "FROM ec_family_member\n" +
+            "         inner join ec_family on ec_family.base_entity_id = ec_family_member.relational_id\n" +
+            "         inner join ec_harm_reduction_sober_house_enrollment\n" +
+            "                    on ec_family_member.base_entity_id = ec_harm_reduction_sober_house_enrollment.base_entity_id\n" +
+            "where ec_family_member.date_removed is null\n" +
+            "  AND ec_harm_reduction_sober_house_enrollment.is_closed is 0\n" +
             "  AND ec_family_member.base_entity_id IN (%s)\n" +
             "\n" +
             "UNION ALL\n" +

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/ChwQueryConstantTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/ChwQueryConstantTest.java
@@ -1,0 +1,36 @@
+package org.smartregister.chw.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChwQueryConstantTest {
+
+    @Test
+    public void testIndependentClientsExcludeOpenSoberHouseEnrollment() {
+        Assert.assertTrue(ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY.contains(
+                "SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
+                        "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0"
+        ));
+    }
+
+    @Test
+    public void testSoberHouseClientsHaveDedicatedRegisterTypeBranch() {
+        Assert.assertTrue(ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY.contains("/*ONLY Sober House clients*/"));
+        Assert.assertTrue(ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY.contains("'Harm Reduction Sober House'                 AS register_type"));
+        Assert.assertTrue(ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY.contains("inner join ec_harm_reduction_sober_house_enrollment"));
+    }
+
+    @Test
+    public void testHarmReductionBranchExcludesOpenSoberHouseEnrollment() {
+        String query = ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY;
+        int harmReductionIndex = query.indexOf("/*ONLY Harm Reduction clients*/");
+        int soberHouseIndex = query.indexOf("/*ONLY Sober House clients*/");
+
+        Assert.assertTrue(harmReductionIndex >= 0);
+        Assert.assertTrue(soberHouseIndex > harmReductionIndex);
+
+        String harmReductionSection = query.substring(harmReductionIndex, soberHouseIndex);
+        Assert.assertTrue(harmReductionSection.contains("SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id"));
+        Assert.assertTrue(harmReductionSection.contains("ec_harm_reduction_sober_house_enrollment.is_closed is 0"));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated All Clients register branch for open `ec_harm_reduction_sober_house_enrollment` records
- exclude open Sober House enrollments from the generic `Independent` and `HARM REDUCTION` buckets so clients render once with the correct tag
- translate the new register type to `Sober House` and route All Clients rows into the Sober House profile
- add focused query coverage for the Sober House register precedence

## Issue
- Addresses Digital-Square-Tanzania/opensrp-client-chw#741
