### PR TITLE
Fix #736: exclude non-detoxified clients from Sober House enrollment

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/HarmReductionSoberHouseRegisterFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/HarmReductionSoberHouseRegisterFragmentPresenter.java
@@ -20,7 +20,7 @@ public class HarmReductionSoberHouseRegisterFragmentPresenter extends BaseHarmRe
 
     @Override
     public String getMainCondition() {
-        return getMainTable() + ".is_closed = 0";
+        return getMainTable() + ".is_closed = 0 AND " + getMainTable() + ".detoxification_done = 'yes'";
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
@@ -1,10 +1,6 @@
 package org.smartregister.chw.util;
 
 public interface ChwQueryConstant {
-    String ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION =
-            "ec_harm_reduction_sober_house_enrollment.is_closed is 0 " +
-                    "AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'";
-
     String ALL_CLIENTS_SELECT_QUERY = "SELECT * FROM (" +
             "/*INDEPENDENT MEMBERS*/\n" +
             "SELECT ec_family_member.first_name,\n" +
@@ -41,7 +37,7 @@ public interface ChwQueryConstant {
             "    FROM ec_harm_reduction_risk_assessment  where ec_harm_reduction_risk_assessment.is_closed is 0 \n" +
             "    UNION ALL\n" +
             "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
-            "    FROM ec_harm_reduction_sober_house_enrollment where " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + " \n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes' \n" +
             "    UNION ALL\n" +
             "    SELECT ec_anc_register.base_entity_id AS base_entity_id\n" +
             "    FROM ec_anc_register where ec_anc_register.is_closed is 0\n" +
@@ -743,7 +739,7 @@ public interface ChwQueryConstant {
             "  AND ec_family_member.base_entity_id IN (%s)\n" +
             "  AND ec_family_member.base_entity_id NOT IN (\n" +
             "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
-            "    FROM ec_harm_reduction_sober_house_enrollment where " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + "\n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'\n" +
             ")\n" +
             "\n" +
             "UNION ALL\n" +
@@ -769,7 +765,7 @@ public interface ChwQueryConstant {
             "         inner join ec_harm_reduction_sober_house_enrollment\n" +
             "                    on ec_family_member.base_entity_id = ec_harm_reduction_sober_house_enrollment.base_entity_id\n" +
             "where ec_family_member.date_removed is null\n" +
-            "  AND " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + "\n" +
+            "  AND ec_harm_reduction_sober_house_enrollment.is_closed is 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'\n" +
             "  AND ec_family_member.base_entity_id IN (%s)\n" +
             "\n" +
             "UNION ALL\n" +

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/ChwQueryConstant.java
@@ -1,6 +1,10 @@
 package org.smartregister.chw.util;
 
 public interface ChwQueryConstant {
+    String ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION =
+            "ec_harm_reduction_sober_house_enrollment.is_closed is 0 " +
+                    "AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'";
+
     String ALL_CLIENTS_SELECT_QUERY = "SELECT * FROM (" +
             "/*INDEPENDENT MEMBERS*/\n" +
             "SELECT ec_family_member.first_name,\n" +
@@ -37,7 +41,7 @@ public interface ChwQueryConstant {
             "    FROM ec_harm_reduction_risk_assessment  where ec_harm_reduction_risk_assessment.is_closed is 0 \n" +
             "    UNION ALL\n" +
             "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
-            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0 \n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + " \n" +
             "    UNION ALL\n" +
             "    SELECT ec_anc_register.base_entity_id AS base_entity_id\n" +
             "    FROM ec_anc_register where ec_anc_register.is_closed is 0\n" +
@@ -739,7 +743,7 @@ public interface ChwQueryConstant {
             "  AND ec_family_member.base_entity_id IN (%s)\n" +
             "  AND ec_family_member.base_entity_id NOT IN (\n" +
             "    SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
-            "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0\n" +
+            "    FROM ec_harm_reduction_sober_house_enrollment where " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + "\n" +
             ")\n" +
             "\n" +
             "UNION ALL\n" +
@@ -765,7 +769,7 @@ public interface ChwQueryConstant {
             "         inner join ec_harm_reduction_sober_house_enrollment\n" +
             "                    on ec_family_member.base_entity_id = ec_harm_reduction_sober_house_enrollment.base_entity_id\n" +
             "where ec_family_member.date_removed is null\n" +
-            "  AND ec_harm_reduction_sober_house_enrollment.is_closed is 0\n" +
+            "  AND " + ACTIVE_SOBER_HOUSE_ENROLLMENT_CONDITION + "\n" +
             "  AND ec_family_member.base_entity_id IN (%s)\n" +
             "\n" +
             "UNION ALL\n" +

--- a/opensrp-chw/src/test/java/org/smartregister/chw/presenter/HarmReductionSoberHouseRegisterFragmentPresenterTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/presenter/HarmReductionSoberHouseRegisterFragmentPresenterTest.java
@@ -1,0 +1,34 @@
+package org.smartregister.chw.presenter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.smartregister.chw.BaseUnitTest;
+import org.smartregister.chw.harmreduction.contract.HarmReductionRegisterFragmentContract;
+
+public class HarmReductionSoberHouseRegisterFragmentPresenterTest extends BaseUnitTest {
+
+    private HarmReductionSoberHouseRegisterFragmentPresenter presenter;
+
+    @Mock
+    private HarmReductionRegisterFragmentContract.View view;
+
+    @Mock
+    private HarmReductionRegisterFragmentContract.Model model;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        presenter = new HarmReductionSoberHouseRegisterFragmentPresenter(view, model, "");
+    }
+
+    @Test
+    public void testMainConditionRequiresDetoxification() {
+        Assert.assertEquals(
+                "ec_harm_reduction_sober_house_enrollment.is_closed = 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'",
+                presenter.getMainCondition()
+        );
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/ChwQueryConstantTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/ChwQueryConstantTest.java
@@ -9,7 +9,7 @@ public class ChwQueryConstantTest {
     public void testIndependentClientsExcludeOpenSoberHouseEnrollment() {
         Assert.assertTrue(ChwQueryConstant.ALL_CLIENTS_SELECT_QUERY.contains(
                 "SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id\n" +
-                        "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0"
+                        "    FROM ec_harm_reduction_sober_house_enrollment where ec_harm_reduction_sober_house_enrollment.is_closed is 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'"
         ));
     }
 
@@ -31,7 +31,7 @@ public class ChwQueryConstantTest {
 
         String harmReductionSection = query.substring(harmReductionIndex, soberHouseIndex);
         Assert.assertTrue(harmReductionSection.contains("SELECT ec_harm_reduction_sober_house_enrollment.base_entity_id AS base_entity_id"));
-        Assert.assertTrue(harmReductionSection.contains("ec_harm_reduction_sober_house_enrollment.is_closed is 0"));
+        Assert.assertTrue(harmReductionSection.contains("ec_harm_reduction_sober_house_enrollment.is_closed is 0 AND ec_harm_reduction_sober_house_enrollment.detoxification_done = 'yes'"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- treat only detoxified Sober House enrollments as active in All Clients queries
- filter the Sober House register to detoxified enrollments
- add focused query and presenter regression coverage

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.util.ChwQueryConstantTest --tests org.smartregister.chw.presenter.HarmReductionSoberHouseRegisterFragmentPresenterTest
- blocked by pre-existing compile errors in unrelated files on 