### PR TITLE
Fix #737: replace mteja with mpokea huduma

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -688,7 +688,7 @@
     <string name="harm_reduction_mat_clients">Wateja wa MAT</string>
     <string name="harm_reduction_sober_house_visit">Hudhurio la Nyumba ya Upataji Nafuu</string>
     <string name="harm_reduction_sober_house_enrollment">Usajili wa Nyumba ya Upataji Nafuu</string>
-    <string name="harm_reduction_sober_house_client_type">Aina ya mteja</string>
+    <string name="harm_reduction_sober_house_client_type">Aina ya mpokea huduma</string>
     <string name="harm_reduction_sober_house_follow_up_status">Hali ya ufuatiliaji</string>
     <string name="harm_reduction_sober_house_testing_services">Huduma za upimaji</string>
     <string name="harm_reduction_sober_house_systolic">Shinikizo la juu la damu</string>


### PR DESCRIPTION
## Summary
- update the remaining Swahili Sober House client type label in opensrp-client-chw to use mpokea huduma

## Testing
- verified the updated label with rg in opensrp-client-chw
- Gradle test execution remains blocked by pre-existing compile errors on feature/implement-harm-reduction