### PR TITLE
Fix #738: align Sober House testing services label

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -690,7 +690,7 @@
     <string name="harm_reduction_sober_house_enrollment">Usajili wa Nyumba ya Upataji Nafuu</string>
     <string name="harm_reduction_sober_house_client_type">Aina ya mteja</string>
     <string name="harm_reduction_sober_house_follow_up_status">Hali ya ufuatiliaji</string>
-    <string name="harm_reduction_sober_house_testing_services">Huduma za upimaji</string>
+    <string name="harm_reduction_sober_house_testing_services">Huduma za Vipimo</string>
     <string name="harm_reduction_sober_house_systolic">Shinikizo la juu la damu</string>
     <string name="harm_reduction_sober_house_diastolic">Shinikizo la chini la damu</string>
     <string name="harm_reduction_sober_house_prompt_for_management_of_hypertension">Rufaa kwa usimamizi wa presha ya juu</string>


### PR DESCRIPTION
## Summary
- update the remaining Swahili Sober House testing services label to Huduma za Vipimo in opensrp-client-chw

## Testing
- verified the updated label with rg in opensrp-client-chw
- Gradle test execution remains blocked by pre-existing compile errors on feature/implement-harm-reduction