### PR TITLE
Fix #711: add Harm Reduction registration chooser

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionRegisterActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionRegisterActivity.java
@@ -1,6 +1,7 @@
 package org.smartregister.chw.activity;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Intent;
 
 import androidx.annotation.MenuRes;
@@ -24,14 +25,27 @@ import org.smartregister.helper.BottomNavigationHelper;
 import org.smartregister.view.fragment.BaseRegisterFragment;
 
 public class HarmReductionRegisterActivity extends CoreHarmReductionRegisterActivity {
+    static final String EXTRA_SHOW_REGISTRATION_CHOOSER = "show_harm_reduction_registration_chooser";
+    static final String HARM_REDUCTION_REGISTER_EXISTING_CLIENT_FORM = "harm_reduction_register_existing_client";
     private static final String YES = "yes";
     private static final String ROC_MAT_PRE_SESSION_FIELD = "roc_mat_pre_session";
+    private static final int EXISTING_CLIENT_REGISTRATION_INDEX = 1;
 
     public static void startRegistration(Activity activity, String memberBaseEntityID) {
         Intent intent = new Intent(activity, HarmReductionRegisterActivity.class);
         intent.putExtra(Constants.ACTIVITY_PAYLOAD.BASE_ENTITY_ID, memberBaseEntityID);
-        intent.putExtra(Constants.ACTIVITY_PAYLOAD.HARM_REDUCTION_FORM_NAME, Constants.FORMS.HARM_REDUCTION_RISK_ASSESSMENT);
+        intent.putExtra(EXTRA_SHOW_REGISTRATION_CHOOSER, true);
         activity.startActivity(intent);
+    }
+
+    @Override
+    protected void onStartActivityWithAction() {
+        if (shouldShowRegistrationChooser(getIntent())) {
+            showRegistrationChooser(true);
+            return;
+        }
+
+        super.onStartActivityWithAction();
     }
 
     @Override
@@ -94,6 +108,23 @@ public class HarmReductionRegisterActivity extends CoreHarmReductionRegisterActi
         maybeOpenPreMatVisit(requestCode, resultCode, data);
     }
 
+    void showRegistrationChooser(boolean finishOnDismiss) {
+        String[] options = {
+                getString(R.string.harm_reduction_new_client_registration),
+                getString(R.string.harm_reduction_existing_client_registration)
+        };
+
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.harm_reduction_registration_type_prompt)
+                .setItems(options, (dialog, which) -> startFormActivity(resolveRegistrationFormName(which), BASE_ENTITY_ID, null))
+                .setOnCancelListener(dialog -> {
+                    if (finishOnDismiss) {
+                        finish();
+                    }
+                })
+                .show();
+    }
+
     void maybeOpenPreMatVisit(int requestCode, int resultCode, Intent data) {
         if (resultCode != Activity.RESULT_OK
                 || requestCode != org.smartregister.family.util.JsonFormUtils.REQUEST_CODE_GET_JSON
@@ -125,6 +156,18 @@ public class HarmReductionRegisterActivity extends CoreHarmReductionRegisterActi
         } catch (JSONException e) {
             timber.log.Timber.e(e);
         }
+    }
+
+    static boolean shouldShowRegistrationChooser(Intent intent) {
+        return intent != null && intent.getBooleanExtra(EXTRA_SHOW_REGISTRATION_CHOOSER, false);
+    }
+
+    static String resolveRegistrationFormName(int selectedIndex) {
+        if (selectedIndex == EXISTING_CLIENT_REGISTRATION_INDEX) {
+            return HARM_REDUCTION_REGISTER_EXISTING_CLIENT_FORM;
+        }
+
+        return Constants.FORMS.HARM_REDUCTION_RISK_ASSESSMENT;
     }
 
     static boolean shouldLaunchPreMatSession(JSONObject form) {

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
@@ -150,15 +150,6 @@ public class ChwRepositoryFlv {
                 case 37:
                     upgradeToVersion37(db);
                     break;
-                case 35:
-                    upgradeToVersion35(db);
-                    break;
-                case 36:
-                    upgradeToVersion36(db);
-                    break;
-                case 37:
-                    upgradeToVersion37(db);
-                    break;
                 default:
                     break;
             }

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -43,6 +43,9 @@
     <string name="register_partner">Sajili Mwenza</string>
     <string name="new_client">Mteja Mpya</string>
     <string name="existing_client">Mteja Aliyepo</string>
+    <string name="harm_reduction_registration_type_prompt">Chagua aina ya usajili wa huduma za Harm Reduction</string>
+    <string name="harm_reduction_new_client_registration">Usajili wa Mteja Mpya</string>
+    <string name="harm_reduction_existing_client_registration">Usajili wa Mteja Aliyekuwepo</string>
     <string name="cancel_referral">Futa Rufaa</string>
     <string name="cancel_referral_title">Futa Rufaa?</string>
     <string name="record_mother_champion_follouwp_visit">Rekodi Hudhurio la Mama Kinara katika Jamii</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -43,6 +43,9 @@
     <string name="partner_registration_action_title">Partner Registration</string>
     <string name="new_client">New Client</string>
     <string name="existing_client">Existing Client</string>
+    <string name="harm_reduction_registration_type_prompt">Select Harm Reduction registration type</string>
+    <string name="harm_reduction_new_client_registration">New Client Registration</string>
+    <string name="harm_reduction_existing_client_registration">Existing Client Registration</string>
     <string name="all_male_clients">All Male Clients</string>
     <string name="register_partner_dialog_title">Register this client as Partner?</string>
     <string name="view_partner_prefile">View Partner Profile</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionRegisterActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionRegisterActivityTest.java
@@ -1,5 +1,7 @@
 package org.smartregister.chw.activity;
 
+import android.content.Intent;
+
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,5 +34,18 @@ public class HarmReductionRegisterActivityTest extends BaseUnitTest {
                         )));
 
         Assert.assertFalse(HarmReductionRegisterActivity.shouldLaunchPreMatSession(form));
+    }
+
+    @Test
+    public void resolveRegistrationFormNameReturnsExistingClientFormForExistingClientChoice() {
+        Assert.assertEquals(HarmReductionRegisterActivity.HARM_REDUCTION_REGISTER_EXISTING_CLIENT_FORM,
+                HarmReductionRegisterActivity.resolveRegistrationFormName(1));
+    }
+
+    @Test
+    public void shouldShowRegistrationChooserReturnsTrueWhenLaunchFlagIsSet() {
+        Intent intent = new Intent().putExtra(HarmReductionRegisterActivity.EXTRA_SHOW_REGISTRATION_CHOOSER, true);
+
+        Assert.assertTrue(HarmReductionRegisterActivity.shouldShowRegistrationChooser(intent));
     }
 }


### PR DESCRIPTION
## Summary
- prompt Harm Reduction registration launches to choose New Client Registration or Existing Client Registration
- route the existing-client choice to the dedicated existing-client form name
- add focused tests for the chooser routing helpers

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.activity.HarmReductionRegisterActivityTest
- blocked by pre-existing branch compile failures in profile activities and ChwRepositoryFlv