### PR TITLE
Clean up insurance provider fields and fix typos in registration forms

### DIFF
--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -625,7 +625,7 @@
           "column_name": "insurance_provider",
           "type": "Client",
           "json_mapping": {
-            "field": "attributes.insurance_provider"
+            "field": "attributes.Health_Insurance_Type"
           }
         },
         {

--- a/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_registration_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_registration_form.json
@@ -716,25 +716,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Mtoa huduma mwingine wa bima ya afya",
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali bainisha mtoa huduma wa bima"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "all_clients_member_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_update_registration_info_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_update_registration_info_form.json
@@ -545,25 +545,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Mtoa huduma mwingine wa bima ya afya",
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali taja mtoa huduma wa bima"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "all_clients_member_update_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -599,7 +580,7 @@
         "type": "spinner",
         "hint": "Ulemavu",
         "values": [
-          "Ndiyo ",
+          "Ndio",
           "Hapana"
         ],
         "keys": [

--- a/opensrp-chw/src/nacp/assets/json.form-sw/child_enrollment.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/child_enrollment.json
@@ -284,25 +284,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Mtoa huduma mwingine wa bima ya afya",
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali ingiza mtoa huduma ya bima"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "family_register_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "gender",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/family_member_register.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/family_member_register.json
@@ -581,25 +581,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Mtoa huduma mwingine wa bima ya afya",
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali bainisha mtoa huduma wa bima"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "family_member_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/all_clients_registration_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/all_clients_registration_form.json
@@ -716,25 +716,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Other health insurance provider",
-        "v_required": {
-          "value": "true",
-          "err": "Please specify the insurance provider"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "all_clients_member_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/all_clients_update_registration_info_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/all_clients_update_registration_info_form.json
@@ -545,25 +545,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Other health insurance provider",
-        "v_required": {
-          "value": "true",
-          "err": "Please specify the insurance provider"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "all_clients_member_update_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/child_enrollment.json
+++ b/opensrp-chw/src/nacp/assets/json.form/child_enrollment.json
@@ -284,25 +284,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Other health insurance provider",
-        "v_required": {
-          "value": "true",
-          "err": "Please specify the insurance provider"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "family_register_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "gender",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person",

--- a/opensrp-chw/src/nacp/assets/json.form/family_register.json
+++ b/opensrp-chw/src/nacp/assets/json.form/family_register.json
@@ -759,25 +759,6 @@
         }
       },
       {
-        "key": "insurance_provider_other",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "Other_Health_Insurance_Type",
-        "type": "edit_text",
-        "hint": "Other health insurance provider",
-        "v_required": {
-          "value": "true",
-          "err": "Please specify the insurance provider"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "family_register_relevance.yml"
-            }
-          }
-        }
-      },
-      {
         "key": "wra",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_relevance.yml
@@ -70,7 +70,7 @@ actions:
   - "isRelevant = true"
 ---
 name: step2_insurance_provider_number
-descripltion: insurance number relevance
+description: insurance number relevance
 priority: 1
 condition: "!step2_insurance_provider.isEmpty() && !step2_insurance_provider.contains('None')"
 actions:

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_relevance.yml
@@ -63,7 +63,7 @@ actions:
   - "isRelevant = true"
 ---
 name: step1_insurance_provider_number
-descripltion: insurance number relevance
+description: insurance number relevance
 priority: 1
 condition: "!step1_insurance_provider.isEmpty() && !step1_insurance_provider.contains('None')"
 actions:
@@ -153,4 +153,3 @@ priority: 1
 condition: "step1_id_avail.equalsIgnoreCase('chk_passport_number')"
 actions:
   - "isRelevant = true"
----

--- a/opensrp-chw/src/nacp/assets/rule/family-child-relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/family-child-relevance.yml
@@ -20,22 +20,8 @@ condition: "step1_dob_unknown.contains('dob_unknown')"
 actions:
   - "isRelevant = true"
 ---
-name: step1_insurance_provider_other
-descripltion: insurance relevance
-priority: 1
-condition: "step1_insurance_provider.contains('Other')"
-actions:
-  - "isRelevant = true"
----
-name: step1_insurance_provider_number
-descripltion: insurance number relevance
-priority: 1
-condition: "!step1_insurance_provider.contains('None')"
-actions:
-  - "isRelevant = true"
----
 name: step1_type_of_disability
-descripltion: other physical disabilities
+description: other physical disabilities
 priority: 1
 condition: "step1_disabilities.contains('Yes')"
 actions:
@@ -49,7 +35,7 @@ actions:
   - "isRelevant = true"
 ---
 name: step1_birth_regist_number
-descripltion: birth registration number
+description: birth registration number
 priority: 1
 condition: "step1_birth_cert_available.contains('Yes')"
 actions:


### PR DESCRIPTION
* Removed `insurance_provider_other` field from all enrollment and registration forms
* Updated `insurance_provider` mapping to use `Health_Insurance_Type` attribute
* Fixed "descripltion" typos in relevance rule files
* Corrected Swahili translation for "Ndio" in the disability field
* Removed obsolete insurance-related relevance rules in `family-child-relevance.yml`