### PR TITLE
Fix remaining HR visit history list rendering

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
@@ -91,19 +91,38 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
             return parsedValues;
         }
 
-        String normalizedValue = rawValue.trim().replaceAll("^\\[|]$", "");
+        String normalizedValue = rawValue.trim();
         if (StringUtils.isBlank(normalizedValue)) {
             return parsedValues;
         }
 
-        String[] values = normalizedValue.split(",");
+        if (!normalizedValue.startsWith("[") || !normalizedValue.endsWith("]")) {
+            parsedValues.add(normalizeHistoryValue(normalizedValue));
+            return parsedValues;
+        }
+
+        String bracketedContent = normalizedValue.substring(1, normalizedValue.length() - 1).trim();
+        if (StringUtils.isBlank(bracketedContent)) {
+            return parsedValues;
+        }
+
+        String[] values = bracketedContent.split(",");
+        boolean looksLikeIdentifierList = true;
         for (String value : values) {
-            String cleanedValue = value.trim().replaceAll("^\"|\"$", "");
-            if (StringUtils.isNotBlank(cleanedValue)) {
-                parsedValues.add(cleanedValue);
+            if (!normalizeHistoryValue(value).matches("[a-z0-9_]+")) {
+                looksLikeIdentifierList = false;
+                break;
             }
         }
 
+        if (!looksLikeIdentifierList) {
+            parsedValues.add(normalizeHistoryValue(bracketedContent));
+            return parsedValues;
+        }
+
+        for (String value : values) {
+            parsedValues.add(normalizeHistoryValue(value));
+        }
         return parsedValues;
     }
 
@@ -126,6 +145,12 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
             }
         }
         return false;
+    }
+
+    private static String normalizeHistoryValue(String value) {
+        return value.trim()
+                .replaceAll("^\"|\"$", "")
+                .replaceFirst("^\\d+\\.\\s*", "");
     }
 
     private static class HarmReductionHistoryActivityFlv extends DefaultAncMedicalHistoryActivityFlv {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
@@ -40,6 +40,8 @@ import timber.log.Timber;
 
 public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActivity {
     private static MemberObject harmReductionMemberObject;
+    static final String SUBSTANCES_USED = "substances_used";
+    static final String RISKY_BEHAVIOURS = "risky_behaviours";
 
     private final Flavor flavor = new HarmReductionHistoryActivityFlv();
     private ProgressBar progressBar;
@@ -81,6 +83,49 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
     @Override
     public void displayLoadingState(boolean state) {
         progressBar.setVisibility(state ? View.VISIBLE : View.GONE);
+    }
+
+    static List<String> parseHistoryValues(String rawValue) {
+        List<String> parsedValues = new ArrayList<>();
+        if (StringUtils.isBlank(rawValue)) {
+            return parsedValues;
+        }
+
+        String normalizedValue = rawValue.trim().replaceAll("^\\[|]$", "");
+        if (StringUtils.isBlank(normalizedValue)) {
+            return parsedValues;
+        }
+
+        String[] values = normalizedValue.split(",");
+        for (String value : values) {
+            String cleanedValue = value.trim().replaceAll("^\"|\"$", "");
+            if (StringUtils.isNotBlank(cleanedValue)) {
+                parsedValues.add(cleanedValue);
+            }
+        }
+
+        return parsedValues;
+    }
+
+    static boolean shouldSkipHiddenAggregateField(Map<String, String> vals, String valueKey) {
+        if (SUBSTANCES_USED.equals(valueKey)) {
+            return hasAnyValue(vals, "substances_used_injecting_only", "substances_used_non_injecting_only", "substances_used_all");
+        }
+
+        if (RISKY_BEHAVIOURS.equals(valueKey)) {
+            return hasAnyValue(vals, "risky_behaviours_injecting_only", "risky_behaviours_non_injecting_only");
+        }
+
+        return false;
+    }
+
+    private static boolean hasAnyValue(Map<String, String> vals, String... keys) {
+        for (String key : keys) {
+            if (StringUtils.isNotBlank(vals.get(key))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class HarmReductionHistoryActivityFlv extends DefaultAncMedicalHistoryActivityFlv {
@@ -247,19 +292,23 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
         }
 
         private void evaluateView(Context context, Map<String, String> vals, TextView tv, String valueKey, int viewTitleStringResource) {
+            if (shouldSkipHiddenAggregateField(vals, valueKey)) {
+                tv.setVisibility(View.GONE);
+                return;
+            }
+
             if (StringUtils.isNotBlank(getMapValue(vals, valueKey))) {
                 SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
                 spannableStringBuilder.append(context.getString(viewTitleStringResource), boldSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE).append("\n");
 
-                String stringValue = getMapValue(vals, valueKey);
-                if (stringValue.contains(",")) {
-                    String[] stringValueArray = stringValue.split(",");
-                    for (String value : stringValueArray) {
-                        String mValue = value.trim().replaceAll("^\\[|]$", "");
-                        spannableStringBuilder.append(getStringResource(context, mValue) + "\n", new BulletSpan(10), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                List<String> parsedValues = parseHistoryValues(getMapValue(vals, valueKey));
+                if (parsedValues.size() > 1) {
+                    for (String value : parsedValues) {
+                        spannableStringBuilder.append(getStringResource(context, value) + "\n", new BulletSpan(10), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                     }
                 } else {
-                    spannableStringBuilder.append(getStringResource(context, stringValue)).append("\n");
+                    String translatedValue = parsedValues.isEmpty() ? getMapValue(vals, valueKey) : parsedValues.get(0);
+                    spannableStringBuilder.append(getStringResource(context, translatedValue)).append("\n");
                 }
                 tv.setText(spannableStringBuilder);
             } else {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
@@ -28,6 +28,22 @@ public class HarmReductionVisitHistoryActivityTest extends BaseUnitTest {
     }
 
     @Test
+    public void parseHistoryValuesShouldKeepPlainTextWithCommasAsSingleValue() {
+        List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("7. Reproductive health, father, mother, child and adolescents");
+
+        Assert.assertEquals(1, values.size());
+        Assert.assertEquals("Reproductive health, father, mother, child and adolescents", values.get(0));
+    }
+
+    @Test
+    public void parseHistoryValuesShouldKeepBracketedTextWithCommasAsSingleValue() {
+        List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("[7. Reproductive health, father, mother, child and adolescents]");
+
+        Assert.assertEquals(1, values.size());
+        Assert.assertEquals("Reproductive health, father, mother, child and adolescents", values.get(0));
+    }
+
+    @Test
     public void shouldSkipHiddenAggregateFieldShouldSkipSubstancesUsedWhenSpecificFieldExists() {
         Map<String, String> values = new HashMap<>();
         values.put("substances_used_injecting_only", "[heroine]");

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
@@ -1,0 +1,55 @@
+package org.smartregister.chw.activity;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.chw.BaseUnitTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class HarmReductionVisitHistoryActivityTest extends BaseUnitTest {
+
+    @Test
+    public void parseHistoryValuesShouldHandleSingleBracketedValue() {
+        List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("[heroine]");
+
+        Assert.assertEquals(1, values.size());
+        Assert.assertEquals("heroine", values.get(0));
+    }
+
+    @Test
+    public void parseHistoryValuesShouldHandleMultipleBracketedValues() {
+        List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("[heroine, cocaine]");
+
+        Assert.assertEquals(2, values.size());
+        Assert.assertEquals("heroine", values.get(0));
+        Assert.assertEquals("cocaine", values.get(1));
+    }
+
+    @Test
+    public void shouldSkipHiddenAggregateFieldShouldSkipSubstancesUsedWhenSpecificFieldExists() {
+        Map<String, String> values = new HashMap<>();
+        values.put("substances_used_injecting_only", "[heroine]");
+        values.put(HarmReductionVisitHistoryActivity.SUBSTANCES_USED, "[heroine]");
+
+        Assert.assertTrue(HarmReductionVisitHistoryActivity.shouldSkipHiddenAggregateField(values, HarmReductionVisitHistoryActivity.SUBSTANCES_USED));
+    }
+
+    @Test
+    public void shouldSkipHiddenAggregateFieldShouldSkipRiskyBehavioursWhenSpecificFieldExists() {
+        Map<String, String> values = new HashMap<>();
+        values.put("risky_behaviours_injecting_only", "[sharing_needles_syringes]");
+        values.put(HarmReductionVisitHistoryActivity.RISKY_BEHAVIOURS, "[sharing_needles_syringes]");
+
+        Assert.assertTrue(HarmReductionVisitHistoryActivity.shouldSkipHiddenAggregateField(values, HarmReductionVisitHistoryActivity.RISKY_BEHAVIOURS));
+    }
+
+    @Test
+    public void shouldSkipHiddenAggregateFieldShouldKeepAggregateFieldWhenNoSpecificFieldExists() {
+        Map<String, String> values = new HashMap<>();
+        values.put(HarmReductionVisitHistoryActivity.SUBSTANCES_USED, "[heroine]");
+
+        Assert.assertFalse(HarmReductionVisitHistoryActivity.shouldSkipHiddenAggregateField(values, HarmReductionVisitHistoryActivity.SUBSTANCES_USED));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize single-item bracketed HR history values before translating them
- skip the hidden aggregate risky behaviour and substance fields when a visible specific field is already present
- add focused regression coverage for parsing and duplicate-suppression behavior

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest --tests org.smartregister.chw.activity.HarmReductionVisitHistoryActivityTest