### PR TITLE
Fix HR visit history raw referral lists

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
@@ -96,32 +96,26 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
             return parsedValues;
         }
 
-        if (!normalizedValue.startsWith("[") || !normalizedValue.endsWith("]")) {
-            parsedValues.add(normalizeHistoryValue(normalizedValue));
+        String content = normalizedValue;
+        if (normalizedValue.startsWith("[") && normalizedValue.endsWith("]")) {
+            content = normalizedValue.substring(1, normalizedValue.length() - 1).trim();
+        }
+
+        if (StringUtils.isBlank(content)) {
             return parsedValues;
         }
 
-        String bracketedContent = normalizedValue.substring(1, normalizedValue.length() - 1).trim();
-        if (StringUtils.isBlank(bracketedContent)) {
+        String[] values = content.split(",");
+        if (!looksLikeIdentifierList(values)) {
+            parsedValues.add(normalizeHistoryValue(content));
             return parsedValues;
         }
 
-        String[] values = bracketedContent.split(",");
-        boolean looksLikeIdentifierList = true;
         for (String value : values) {
-            if (!normalizeHistoryValue(value).matches("[a-z0-9_]+")) {
-                looksLikeIdentifierList = false;
-                break;
+            String cleanedValue = normalizeHistoryValue(value);
+            if (StringUtils.isNotBlank(cleanedValue)) {
+                parsedValues.add(cleanedValue);
             }
-        }
-
-        if (!looksLikeIdentifierList) {
-            parsedValues.add(normalizeHistoryValue(bracketedContent));
-            return parsedValues;
-        }
-
-        for (String value : values) {
-            parsedValues.add(normalizeHistoryValue(value));
         }
         return parsedValues;
     }
@@ -145,6 +139,19 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
             }
         }
         return false;
+    }
+
+    private static boolean looksLikeIdentifierList(String[] values) {
+        if (values.length <= 1) {
+            return false;
+        }
+
+        for (String value : values) {
+            if (!normalizeHistoryValue(value).matches("[a-z0-9_]+")) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String normalizeHistoryValue(String value) {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivityTest.java
@@ -28,6 +28,16 @@ public class HarmReductionVisitHistoryActivityTest extends BaseUnitTest {
     }
 
     @Test
+    public void parseHistoryValuesShouldHandleMultipleUnbracketedIdentifierValues() {
+        List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("hiv_aids, epidemic_diseases, communicable_diseases");
+
+        Assert.assertEquals(3, values.size());
+        Assert.assertEquals("hiv_aids", values.get(0));
+        Assert.assertEquals("epidemic_diseases", values.get(1));
+        Assert.assertEquals("communicable_diseases", values.get(2));
+    }
+
+    @Test
     public void parseHistoryValuesShouldKeepPlainTextWithCommasAsSingleValue() {
         List<String> values = HarmReductionVisitHistoryActivity.parseHistoryValues("7. Reproductive health, father, mother, child and adolescents");
 


### PR DESCRIPTION
## Summary
- split raw unbracketed Harm Reduction referral key lists so visit history can translate every referral option
- keep comma-containing human-readable labels as a single rendered item
- add focused parser coverage for the raw referrals storage format

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest --tests org.smartregister.chw.activity.HarmReductionVisitHistoryActivityTest