### PR TITLE
fix: standardize dawa terminology

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/agyw_screening.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/agyw_screening.json
@@ -929,7 +929,7 @@
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
         "openmrs_entity_id": "illicit_drug_usage",
-        "label": "Je ushawahi kutumia madawa ya kulevya  katika kipindi cha miezi 3 iliyopita?",
+        "label": "Je ushawahi kutumia dawa za kulevya katika kipindi cha miezi 3 iliyopita?",
         "text_color": "#000000",
         "type": "native_radio",
         "options": [

--- a/opensrp-chw/src/nacp/assets/json.form-sw/hps_education_on_behavioural_change.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/hps_education_on_behavioural_change.json
@@ -812,7 +812,7 @@
           },
           {
             "key": "substance_abuse_drug_addiction",
-            "text": "24.Uraibu wa madawa ya kulevya",
+            "text": "24.Uraibu wa dawa za kulevya",
             "openmrs_entity": "concept",
             "openmrs_entity_id": "substance_abuse_drug_addiction",
             "property": {
@@ -1766,7 +1766,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "number_of_leaflets_substance_abuse_drug_addiction",
         "type": "edit_text",
-        "hint": "Idadi ya vipeperushi vilivyogawiwa (Uraibu wa madawa ya kulevya)",
+        "hint": "Idadi ya vipeperushi vilivyogawiwa (Uraibu wa dawa za kulevya)",
         "v_required": {
           "value": "true",
           "err": "Tafadhali taja idadi ya vipeperushi vilivyogawiwa"
@@ -2274,7 +2274,7 @@
           },
           {
             "key": "substance_abuse_drug_addiction",
-            "text": "24.Uraibu wa madawa ya kulevya",
+            "text": "24.Uraibu wa dawa za kulevya",
             "openmrs_entity": "concept",
             "openmrs_entity_id": "substance_abuse_drug_addiction",
             "property": {
@@ -3228,7 +3228,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "number_of_posters_substance_abuse_drug_addiction",
         "type": "edit_text",
-        "hint": "Idadi ya Mabango vilivyogawiwa (Uraibu wa madawa ya kulevya)",
+        "hint": "Idadi ya Mabango vilivyogawiwa (Uraibu wa dawa za kulevya)",
         "v_required": {
           "value": "true",
           "err": "Tafadhali taja idadi ya Mabango vilivyogawiwa"
@@ -3736,7 +3736,7 @@
           },
           {
             "key": "substance_abuse_drug_addiction",
-            "text": "24.Uraibu wa madawa ya kulevya",
+            "text": "24.Uraibu wa dawa za kulevya",
             "openmrs_entity": "concept",
             "openmrs_entity_id": "substance_abuse_drug_addiction",
             "property": {
@@ -4690,7 +4690,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "number_of_brochures_substance_abuse_drug_addiction",
         "type": "edit_text",
-        "hint": "Idadi ya Vijarida vilivyogawiwa (Uraibu wa madawa ya kulevya)",
+        "hint": "Idadi ya Vijarida vilivyogawiwa (Uraibu wa dawa za kulevya)",
         "v_required": {
           "value": "true",
           "err": "Tafadhali taja idadi ya Vijarida vilivyogawiwa"

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -1066,7 +1066,7 @@
     <string name="hps_safe_clean_water_sanitation">Huduma za maji safi na salama na usafi wa mazingira (WASH)</string>
     <string name="hps_accidents_injuries">Ajali/Kuumia</string>
     <string name="hps_mental_health">Afya ya Akili</string>
-    <string name="hps_substance_abuse_drug_addiction">Uraibu wa madawa ya kulevya</string>
+    <string name="hps_substance_abuse_drug_addiction">Uraibu wa dawa za kulevya</string>
     <string name="hps_gender_based_violence">Ukatili wakijinsia</string>
     <string name="hps_psychological_support">Msaada wa kisaikolojia</string>
     <string name="hps_violence_against_children">Ukatili kwa Watoto</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/DrugTerminologyAssetScanTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/DrugTerminologyAssetScanTest.java
@@ -1,0 +1,51 @@
+package org.smartregister.chw.resources;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+public class DrugTerminologyAssetScanTest {
+
+    private static final String OLD_TERM = "ma" + "dawa ya kulevya";
+    private static final String NEW_TERM = "dawa za kulevya";
+    private static final List<String> AFFECTED_FILES = Arrays.asList(
+            "src/nacp/assets/json.form-sw/agyw_screening.json",
+            "src/nacp/assets/json.form-sw/hps_education_on_behavioural_change.json",
+            "src/nacp/res/values-sw/strings.xml"
+    );
+
+    @Test
+    public void shouldNotContainDeprecatedDrugTerminology() throws Exception {
+        for (String relativePath : AFFECTED_FILES) {
+            String content = readText(relativePath).toLowerCase();
+
+            Assert.assertFalse("Found deprecated terminology in " + relativePath, content.contains(OLD_TERM));
+            Assert.assertTrue("Missing updated terminology in " + relativePath, content.contains(NEW_TERM));
+        }
+    }
+
+    private static String readText(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the remaining Swahili  wording in app assets and resources with 
- update the affected AGYW and HPS form prompts to keep terminology consistent
- add a focused asset scan test to guard the wording change

Closes #840