### PR TITLE
fix: standardize mpokea huduma labels

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -44,8 +44,8 @@
     <string name="new_client">Mteja Mpya</string>
     <string name="existing_client">Mteja Aliyepo</string>
     <string name="harm_reduction_registration_type_prompt">Chagua aina ya usajili wa huduma za Harm Reduction</string>
-    <string name="harm_reduction_new_client_registration">Usajili wa Mteja Mpya</string>
-    <string name="harm_reduction_existing_client_registration">Usajili wa Mteja Aliyekuwepo</string>
+    <string name="harm_reduction_new_client_registration">Usajili wa Mpokea Huduma Mpya</string>
+    <string name="harm_reduction_existing_client_registration">Usajili wa Mpokea Huduma Aliyekuwepo</string>
     <string name="cancel_referral">Futa Rufaa</string>
     <string name="cancel_referral_title">Futa Rufaa?</string>
     <string name="record_mother_champion_follouwp_visit">Rekodi Hudhurio la Mama Kinara katika Jamii</string>
@@ -698,13 +698,13 @@
     <string name="harm_reduction_cause_of_death">Sababu ya kifo</string>
     <string name="harm_reduction_cause_of_death_other_specify">Taja sababu nyingine ya kifo</string>
     <string name="harm_reduction_client_deceased">Amefariki</string>
-    <string name="harm_reduction_client_started_mat">Je, mteja ameanza MAT?</string>
+    <string name="harm_reduction_client_started_mat">Je, mpokea huduma ameanza MAT?</string>
     <string name="harm_reduction_cocaine">Cocaine</string>
     <string name="harm_reduction_communicable_diseases">Magonjwa ya kuambukiza</string>
     <string name="harm_reduction_community">Ngazi ya jamii</string>
     <string name="harm_reduction_condom_education_prompt">Mwongozo</string>
     <string name="harm_reduction_condom_use_during_sex">Je, unatumia kondomu wakati wa kujamiiana?</string>
-    <string name="harm_reduction_condoms_given">Je mteja amepewa Kondomu?</string>
+    <string name="harm_reduction_condoms_given">Je mpokea huduma amepewa Kondomu?</string>
     <string name="harm_reduction_continue_service">Anaendelea na Huduma</string>
     <string name="harm_reduction_ctc_id">Namba ya Utambulisho (CTC)</string>
     <string name="harm_reduction_death_action_taken">Nini kilifanyika</string>
@@ -713,7 +713,7 @@
     <string name="harm_reduction_drinking">Kunywa</string>
     <string name="harm_reduction_drug_adherence_status_ctc">Hali ya ufuasi wa huduma</string>
     <string name="harm_reduction_dry_cotton">Pamba kavu</string>
-    <string name="harm_reduction_engaging_in_sexual_activity">Je, mteja anashiriki ngono?</string>
+    <string name="harm_reduction_engaging_in_sexual_activity">Je, mpokea huduma anashiriki ngono?</string>
     <string name="harm_reduction_enrolled_into_ctc_services">Je, mpokea huduma amejiunga na huduma za matibabu na matunzo (CTC)?</string>
     <string name="harm_reduction_epidemic_diseases">Magonjwa ya mlipuko</string>
     <string name="harm_reduction_excessive_alcohol_intake_smoking">Unywaji/Uvutaji kupita kiasi</string>
@@ -733,7 +733,7 @@
     <string name="harm_reduction_hiv_aids">VVU na UKIMWI</string>
     <string name="harm_reduction_hiv_results">Matokeo ya kipimo cha VVU</string>
     <string name="harm_reduction_hiv_test_location">Upimaji ulipofanyika</string>
-    <string name="harm_reduction_hiv_tested">Je, mteja amewahi kupima VVU?</string>
+    <string name="harm_reduction_hiv_tested">Je, mpokea huduma amewahi kupima VVU?</string>
     <string name="harm_reduction_hiv_testing">Upimaji wa VVU</string>
     <string name="harm_reduction_home">Nyumbani</string>
     <string name="harm_reduction_iec_communicable_diseases">Magonjwa ya kuambukiza</string>
@@ -796,7 +796,7 @@
     <string name="harm_reduction_lowering_infection_risk">Kupunguza hatari ya maambukizi</string>
     <string name="harm_reduction_marijuana">Bangi</string>
     <string name="harm_reduction_maskani">Maskani</string>
-    <string name="harm_reduction_mat_clients">Wateja wa MAT</string>
+    <string name="harm_reduction_mat_clients">Wapokea Huduma wa MAT</string>
     <string name="harm_reduction_mental_health">Afya ya akili</string>
     <string name="harm_reduction_methadone_services">Huduma ya Methadone (MAT)</string>
     <string name="harm_reduction_methadone_use">Matumizi ya Methadone</string>
@@ -885,7 +885,7 @@
     <string name="harm_reduction_sober_house_prompt_for_management_of_hypertension">Rufaa kwa usimamizi wa presha ya juu</string>
     <string name="harm_reduction_sober_house_prompt_for_management_of_hypotension">Rufaa kwa usimamizi wa presha ya chini</string>
     <string name="harm_reduction_sober_house_weight">Uzito</string>
-    <string name="harm_reduction_sober_house_client_current_status">Hali ya sasa ya mteja</string>
+    <string name="harm_reduction_sober_house_client_current_status">Hali ya sasa ya mpokea huduma</string>
     <string name="harm_reduction_sober_house_attended_recovery_meetings">Amehudhuria mikutano ya urejeshaji</string>
     <string name="harm_reduction_sober_house_recovery_meeting_types">Aina za mikutano ya urejeshaji</string>
     <string name="harm_reduction_sober_house_recovery_meeting_special_topic_specify">Mada maalum ya mkutano wa urejeshaji (ainisha)</string>
@@ -943,8 +943,8 @@
     <string name="harm_reduction_sober_house_stable">Yuko Imara / Thabiti</string>
     <string name="harm_reduction_sober_house_stis_reproductive">Magonjwa ya Ngono na via vya Uzazi</string>
     <string name="harm_reduction_sober_house_wounds_abscesses">Matibabu ya vidonda na Mabunyufu (majipu)</string>
-    <string name="record_services_provided_to_mat_clients">Rekodi huduma zilizotolewa kwa wateja wa MAT</string>
-    <string name="harm_reduction_mat_clients_followup_visit">Hudhurio la ufuatiliaji kwa wateja wa MAT</string>
+    <string name="record_services_provided_to_mat_clients">Rekodi huduma zilizotolewa kwa wapokea huduma wa MAT</string>
+    <string name="harm_reduction_mat_clients_followup_visit">Hudhurio la ufuatiliaji kwa wapokea huduma wa MAT</string>
     <string name="harm_reduction_mat_clients_health_education_provided">Elimu iliyotolewa</string>
     <string name="harm_reduction_mat_clients_education_delivery_method">Njia ya utoaji elimu</string>
     <string name="harm_reduction_mat_clients_group_session">Kikao cha vikundi</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionTerminologySwahiliStringsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionTerminologySwahiliStringsTest.java
@@ -1,0 +1,55 @@
+package org.smartregister.chw.resources;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+public class HarmReductionTerminologySwahiliStringsTest {
+
+    private static final String SW_STRINGS_XML_PATH = "src/nacp/res/values-sw/strings.xml";
+
+    @Test
+    public void shouldUseUpdatedClientTerminologyForHarmReductionStrings() throws Exception {
+        Map<String, String> strings = readStrings(SW_STRINGS_XML_PATH);
+        Map<String, String> expectedStrings = new LinkedHashMap<>();
+
+        expectedStrings.put("harm_reduction_new_client_registration", "Usajili wa Mpokea Huduma Mpya");
+        expectedStrings.put("harm_reduction_existing_client_registration", "Usajili wa Mpokea Huduma Aliyekuwepo");
+        expectedStrings.put("harm_reduction_mat_clients", "Wapokea Huduma wa MAT");
+        expectedStrings.put("record_services_provided_to_mat_clients", "Rekodi huduma zilizotolewa kwa wapokea huduma wa MAT");
+        expectedStrings.put("harm_reduction_mat_clients_followup_visit", "Hudhurio la ufuatiliaji kwa wapokea huduma wa MAT");
+        expectedStrings.put("harm_reduction_sober_house_client_current_status", "Hali ya sasa ya mpokea huduma");
+
+        for (Map.Entry<String, String> expectedEntry : expectedStrings.entrySet()) {
+            String actual = strings.get(expectedEntry.getKey());
+
+            Assert.assertEquals("Unexpected value for key: " + expectedEntry.getKey(), expectedEntry.getValue(), actual);
+            Assert.assertFalse("Found deprecated singular client term in key: " + expectedEntry.getKey(), actual.toLowerCase().contains("mteja"));
+            Assert.assertFalse("Found deprecated plural client term in key: " + expectedEntry.getKey(), actual.toLowerCase().contains("wateja"));
+        }
+    }
+
+    private Map<String, String> readStrings(String path) throws Exception {
+        File stringsFile = new File(path);
+        Assert.assertTrue("Missing strings.xml at " + path, stringsFile.exists());
+
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stringsFile);
+        NodeList stringNodes = document.getElementsByTagName("string");
+        Map<String, String> values = new LinkedHashMap<>();
+
+        for (int i = 0; i < stringNodes.getLength(); i++) {
+            Element element = (Element) stringNodes.item(i);
+            values.put(element.getAttribute("name"), element.getTextContent().trim());
+        }
+
+        return values;
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -263,13 +263,13 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_cause_of_death", "Sababu ya kifo");
         values.put("harm_reduction_cause_of_death_other_specify", "Taja sababu nyingine ya kifo");
         values.put("harm_reduction_client_deceased", "Amefariki");
-        values.put("harm_reduction_client_started_mat", "Je, mteja ameanza MAT?");
+        values.put("harm_reduction_client_started_mat", "Je, mpokea huduma ameanza MAT?");
         values.put("harm_reduction_cocaine", "Cocaine");
         values.put("harm_reduction_communicable_diseases", "Magonjwa ya kuambukiza");
         values.put("harm_reduction_community", "Ngazi ya jamii");
         values.put("harm_reduction_condom_education_prompt", "Mwongozo");
         values.put("harm_reduction_condom_use_during_sex", "Je, unatumia kondomu wakati wa kujamiiana?");
-        values.put("harm_reduction_condoms_given", "Je mteja amepewa Kondomu?");
+        values.put("harm_reduction_condoms_given", "Je mpokea huduma amepewa Kondomu?");
         values.put("harm_reduction_continue_service", "Anaendelea na Huduma");
         values.put("harm_reduction_ctc_id", "Namba ya Utambulisho (CTC)");
         values.put("harm_reduction_death_action_taken", "Nini kilifanyika");
@@ -278,7 +278,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_drinking", "Kunywa");
         values.put("harm_reduction_drug_adherence_status_ctc", "Hali ya ufuasi wa huduma");
         values.put("harm_reduction_dry_cotton", "Pamba kavu");
-        values.put("harm_reduction_engaging_in_sexual_activity", "Je, mteja anashiriki ngono?");
+        values.put("harm_reduction_engaging_in_sexual_activity", "Je, mpokea huduma anashiriki ngono?");
         values.put("harm_reduction_enrolled_into_ctc_services", "Je, mpokea huduma amejiunga na huduma za matibabu na matunzo (CTC)?");
         values.put("harm_reduction_epidemic_diseases", "Magonjwa ya mlipuko");
         values.put("harm_reduction_excessive_alcohol_intake_smoking", "Unywaji/Uvutaji kupita kiasi");
@@ -298,7 +298,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_hiv_aids", "VVU na UKIMWI");
         values.put("harm_reduction_hiv_results", "Matokeo ya kipimo cha VVU");
         values.put("harm_reduction_hiv_test_location", "Upimaji ulipofanyika");
-        values.put("harm_reduction_hiv_tested", "Je, mteja amewahi kupima VVU?");
+        values.put("harm_reduction_hiv_tested", "Je, mpokea huduma amewahi kupima VVU?");
         values.put("harm_reduction_hiv_testing", "Upimaji wa VVU");
         values.put("harm_reduction_home", "Nyumbani");
         values.put("harm_reduction_iec_communicable_diseases", "Magonjwa ya kuambukiza");


### PR DESCRIPTION
## Summary
- replace the remaining Harm Reduction and Sober House mteja/wateja wording in the app's Swahili strings with mpokea huduma/wapokea huduma
- update the visit-history translation expectations that read those string keys
- add a focused Swahili resource test for the extra registration, MAT, and Sober House labels changed here

Closes #839
