### PR TITLE
Align app-side needle collection assets and details

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
@@ -63,9 +63,11 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity extend
             "date_of_collection",
             "maskani_name",
             "collection_site_gps",
+            "number_of_used_needles_and_syringes_collected",
+            "issues_challenges_related_to_collection_of_used_needles_and_syringes",
+            "total_safety_boxes_collected",
             "other_collection",
             "fixed_bins",
-            "total_safety_boxes_collected",
             "name_of_ow"
     };
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/adapter/HarmReductionUsedNeedlesAndSyringesCollectionRegisterAdapter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/adapter/HarmReductionUsedNeedlesAndSyringesCollectionRegisterAdapter.java
@@ -50,26 +50,26 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionRegisterAdapter extend
 
     protected class CollectionViewHolder extends RecyclerView.ViewHolder {
         public TextView collectionDate;
-        public TextView safetyBoxesCollected;
+        public TextView usedNeedlesAndSyringesCollected;
 
         public CollectionViewHolder(@NonNull View itemView) {
             super(itemView);
         }
 
         public void bindData(HarmReductionUsedNeedlesAndSyringesCollectionModel collectionModel) {
-            safetyBoxesCollected = itemView.findViewById(R.id.mobilization_session_participants);
+            usedNeedlesAndSyringesCollected = itemView.findViewById(R.id.mobilization_session_participants);
             collectionDate = itemView.findViewById(R.id.mobilization_session_date);
 
-            String totalSafetyBoxes = collectionModel.getTotalSafetyBoxesCollected();
-            if (totalSafetyBoxes == null) {
-                totalSafetyBoxes = "0";
+            String collectedCount = collectionModel.getUsedNeedlesAndSyringesCollected();
+            if (collectedCount == null) {
+                collectedCount = "0";
             }
             String date = collectionModel.getCollectionDate();
             if (date == null) {
                 date = "";
             }
 
-            safetyBoxesCollected.setText(context.getString(R.string.harm_reduction_safety_boxes_collected, totalSafetyBoxes));
+            usedNeedlesAndSyringesCollected.setText(context.getString(R.string.harm_reduction_used_needles_and_syringes_collected, collectedCount));
             collectionDate.setText(context.getString(R.string.harm_reduction_collection_date, date));
             itemView.setOnClickListener(view -> HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.startMe((Activity) context, collectionModel.getCollectionId()));
         }

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -926,6 +926,8 @@
     <string name="harm_reduction_date_of_collection">Tarehe ya Mkusanyiko</string>
     <string name="harm_reduction_maskani_name">Jina la Maskani</string>
     <string name="harm_reduction_collection_site_gps">GPS eneo la tovuti ya ukusanyaji</string>
+    <string name="harm_reduction_number_of_used_needles_and_syringes_collected">Idadi ya sindano na mabomba yaliyotumika yaliyokusanywa</string>
+    <string name="harm_reduction_issues_challenges_related_to_collection_of_used_needles_and_syringes">Changamoto zinazohusiana na ukusanyaji wa sindano na mabomba yaliyotumika</string>
     <string name="harm_reduction_other_collection">Idadi ya Sanduku za Usalama zilizokusanywa (sindano zilizotumika) katika tovuti Zingine za Mkusanyiko</string>
     <string name="harm_reduction_fixed_bins">Idadi ya Sanduku za Usalama zilizokusanywa (sindano zilizotumika) kwenye Mapipa yasiyobadilika</string>
     <string name="harm_reduction_total_safety_boxes_collected">Jumla ya Sanduku za Usalama zilizokusanywa (sindano zilizotumika)</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -773,6 +773,8 @@
     <string name="harm_reduction_date_of_collection">Date of Collection</string>
     <string name="harm_reduction_maskani_name">Name of Maskani</string>
     <string name="harm_reduction_collection_site_gps">GPS location of collection site</string>
+    <string name="harm_reduction_number_of_used_needles_and_syringes_collected">Number of used Needles and Syringes collected</string>
+    <string name="harm_reduction_issues_challenges_related_to_collection_of_used_needles_and_syringes">Issues/Challenges related to collection of used syringes</string>
     <string name="harm_reduction_other_collection">Number of Safety Boxes collected (used syringes) in Other Collection sites</string>
     <string name="harm_reduction_fixed_bins">Number of Safety Boxes collected (used syringes) in Fixed Bins</string>
     <string name="harm_reduction_total_safety_boxes_collected">Total Safety Boxes collected (used syringes)</string>

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -12004,35 +12004,19 @@
           }
         },
         {
-          "column_name": "other_collection",
+          "column_name": "number_of_used_needles_and_syringes_collected",
           "type": "Event",
           "json_mapping": {
             "field": "obs.fieldCode",
-            "concept": "other_collection"
+            "concept": "number_of_used_needles_and_syringes_collected"
           }
         },
         {
-          "column_name": "fixed_bins",
+          "column_name": "issues_challenges_related_to_collection_of_used_needles_and_syringes",
           "type": "Event",
           "json_mapping": {
             "field": "obs.fieldCode",
-            "concept": "fixed_bins"
-          }
-        },
-        {
-          "column_name": "total_safety_boxes_collected",
-          "type": "Event",
-          "json_mapping": {
-            "field": "obs.fieldCode",
-            "concept": "total_safety_boxes_collected"
-          }
-        },
-        {
-          "column_name": "name_of_ow",
-          "type": "Event",
-          "json_mapping": {
-            "field": "obs.fieldCode",
-            "concept": "name_of_ow"
+            "concept": "issues_challenges_related_to_collection_of_used_needles_and_syringes"
           }
         },
         {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionUsedNeedlesCollectionConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionUsedNeedlesCollectionConfigTest.java
@@ -1,0 +1,88 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.chw.activity.HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HarmReductionUsedNeedlesCollectionConfigTest {
+
+    @Test
+    public void shouldUseRevisedCollectionColumnsInNacpEcClientFields() throws Exception {
+        JSONObject file = new JSONObject(readText("src/nacp/assets/ec_client_fields.json"));
+        JSONObject bindObject = findBindObject(file.getJSONArray("bindobjects"), "ec_harm_reduction_safety_box_collection");
+        JSONArray columns = bindObject.getJSONArray("columns");
+
+        List<String> columnNames = new ArrayList<>();
+        for (int i = 0; i < columns.length(); i++) {
+            columnNames.add(columns.getJSONObject(i).getString("column_name"));
+        }
+
+        Assert.assertTrue(columnNames.contains("collection_site_gps"));
+        Assert.assertTrue(columnNames.contains("number_of_used_needles_and_syringes_collected"));
+        Assert.assertTrue(columnNames.contains("issues_challenges_related_to_collection_of_used_needles_and_syringes"));
+        Assert.assertFalse(columnNames.contains("other_collection"));
+        Assert.assertFalse(columnNames.contains("fixed_bins"));
+        Assert.assertFalse(columnNames.contains("total_safety_boxes_collected"));
+        Assert.assertFalse(columnNames.contains("name_of_ow"));
+    }
+
+    @Test
+    public void shouldShowRevisedFieldsBeforeLegacyFallbacksInCollectionDetails() throws Exception {
+        Field field = HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.class.getDeclaredField("COLLECTION_FIELDS");
+        field.setAccessible(true);
+
+        String[] actual = (String[]) field.get(null);
+        String[] expected = {
+                "date_of_collection",
+                "maskani_name",
+                "collection_site_gps",
+                "number_of_used_needles_and_syringes_collected",
+                "issues_challenges_related_to_collection_of_used_needles_and_syringes",
+                "total_safety_boxes_collected",
+                "other_collection",
+                "fixed_bins",
+                "name_of_ow"
+        };
+
+        Assert.assertArrayEquals(expected, actual);
+    }
+
+    private static JSONObject findBindObject(JSONArray bindObjects, String name) throws Exception {
+        for (int i = 0; i < bindObjects.length(); i++) {
+            JSONObject bindObject = bindObjects.getJSONObject(i);
+            if (name.equals(bindObject.optString("name"))) {
+                return bindObject;
+            }
+        }
+
+        throw new AssertionError("Missing bind object: " + name);
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- update the NACP ec_client_fields mapping for the revised used-needle collection payload
- align the collection details screen with the revised fields while preserving legacy fallback display for old visits
- update the app adapter to the current Harm Reduction model contract

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionUsedNeedlesCollectionConfigTest

Refs Digital-Square-Tanzania/opensrp-client-chw#832