### PR TITLE
Add harm reduction route-specific substance strings

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -705,6 +705,7 @@
     <string name="harm_reduction_condom_education_prompt">Mwongozo</string>
     <string name="harm_reduction_condom_use_during_sex">Je, unatumia kondomu wakati wa kujamiiana?</string>
     <string name="harm_reduction_condoms_given">Je mpokea huduma amepewa Kondomu?</string>
+    <string name="harm_reduction_controlled_drugs">Dawa tiba zenye asili ya kulevya</string>
     <string name="harm_reduction_continue_service">Anaendelea na Huduma</string>
     <string name="harm_reduction_ctc_id">Namba ya Utambulisho (CTC)</string>
     <string name="harm_reduction_death_action_taken">Nini kilifanyika</string>
@@ -727,6 +728,7 @@
     <string name="harm_reduction_health_education_other_specify">Bainisha elimu nyingine ya afya iliyotolewa</string>
     <string name="harm_reduction_health_education_provided">Elimu ya afya iliyotolewa</string>
     <string name="harm_reduction_health_services_advocacy">Uhamasishaji wa huduma za Afya</string>
+    <string name="harm_reduction_hashish">Hashish</string>
     <string name="harm_reduction_hepatitis_bc">Homa ya Ini</string>
     <string name="harm_reduction_hepatitis_bc_screening">Uchunguzi wa Homa ya Ini B/C</string>
     <string name="harm_reduction_heroine">Heroine</string>
@@ -818,6 +820,7 @@
     <string name="harm_reduction_number_of_sexual_partners">Idadi ya wenza wa kingono</string>
     <string name="harm_reduction_nutrition">Lishe</string>
     <string name="harm_reduction_other">Nyinginezo (Taja)</string>
+    <string name="harm_reduction_petrol">Petroli</string>
     <string name="harm_reduction_overdose">Hali ya kuzidisha dawa (Overdose)</string>
     <string name="harm_reduction_overdose_action_taken">Nini kilifanyika</string>
     <string name="harm_reduction_overdose_management">Kuzuia na kumudu Overdose</string>
@@ -868,6 +871,7 @@
     <string name="harm_reduction_tb_leprosy">Kifua Kikuu/Ukoma</string>
     <string name="harm_reduction_tb_screening">Uchunguzi wa Kifua Kikuu</string>
     <string name="harm_reduction_tobacco">Tumbaku</string>
+    <string name="harm_reduction_glue">Gundi</string>
     <string name="harm_reduction_tramadol">Tramadol</string>
     <string name="harm_reduction_undergoing_treatment">Yupo kwenye matibabu</string>
     <string name="harm_reduction_unknown">Haijulikani</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -544,6 +544,7 @@
     <string name="harm_reduction_condom_education_prompt">Guidance</string>
     <string name="harm_reduction_condom_use_during_sex">Do you use condoms during sexual activity?</string>
     <string name="harm_reduction_condoms_given">Condoms given?</string>
+    <string name="harm_reduction_controlled_drugs">Controlled Drugs</string>
     <string name="harm_reduction_continue_service">Continue service</string>
     <string name="harm_reduction_ctc_id">CTC identification number</string>
     <string name="harm_reduction_death_action_taken">What was done</string>
@@ -568,6 +569,7 @@
     <string name="harm_reduction_health_education_other_specify">Specify other health education provided</string>
     <string name="harm_reduction_health_education_provided">Health education provided</string>
     <string name="harm_reduction_health_services_advocacy">Health services advocacy</string>
+    <string name="harm_reduction_hashish">Hashish</string>
     <string name="harm_reduction_hepatitis_bc">Hepatitis B/C</string>
     <string name="harm_reduction_hepatitis_bc_screening">Hepatitis B/C Screening</string>
     <string name="harm_reduction_heroine">Heroine</string>
@@ -661,6 +663,7 @@
     <string name="harm_reduction_number_of_sexual_partners">Number of sexual partners</string>
     <string name="harm_reduction_nutrition">Nutrition</string>
     <string name="harm_reduction_other">Others (Specify)</string>
+    <string name="harm_reduction_petrol">Petrol</string>
     <string name="harm_reduction_overdose">Overdose</string>
     <string name="harm_reduction_overdose_action_taken">What was done</string>
     <string name="harm_reduction_overdose_management">Overdose management and prevention</string>
@@ -713,6 +716,7 @@
     <string name="harm_reduction_tb_leprosy">TB/Leprosy</string>
     <string name="harm_reduction_tb_screening">TB Screening</string>
     <string name="harm_reduction_tobacco">Tobacco</string>
+    <string name="harm_reduction_glue">Glue</string>
     <string name="harm_reduction_tramadol">Tramadol</string>
     <string name="harm_reduction_undergoing_treatment">Undergoing treatment</string>
     <string name="harm_reduction_unknown">Unknown</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -80,6 +80,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_condom_education_prompt", "Guidance");
         values.put("harm_reduction_condom_use_during_sex", "Do you use condoms during sexual activity?");
         values.put("harm_reduction_condoms_given", "Condoms given?");
+        values.put("harm_reduction_controlled_drugs", "Controlled Drugs");
         values.put("harm_reduction_continue_service", "Continue service");
         values.put("harm_reduction_ctc_id", "CTC identification number");
         values.put("harm_reduction_death_action_taken", "What was done");
@@ -98,6 +99,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_gbv_vac", "GBV/VAC");
         values.put("harm_reduction_good_adherence", "Good adherence");
         values.put("harm_reduction_has_symptoms", "Has symptoms");
+        values.put("harm_reduction_hashish", "Hashish");
         values.put("harm_reduction_health_education_given", "Was health education provided?");
         values.put("harm_reduction_health_education_other_specify", "Specify other health education provided");
         values.put("harm_reduction_health_education_provided", "Health education provided");
@@ -192,6 +194,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_number_of_sexual_partners", "Number of sexual partners");
         values.put("harm_reduction_nutrition", "Nutrition");
         values.put("harm_reduction_other", "Others (Specify)");
+        values.put("harm_reduction_petrol", "Petrol");
         values.put("harm_reduction_overdose", "Overdose");
         values.put("harm_reduction_overdose_action_taken", "What was done");
         values.put("harm_reduction_overdose_management", "Overdose management and prevention");
@@ -241,6 +244,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_tb_leprosy", "TB/Leprosy");
         values.put("harm_reduction_tb_screening", "TB Screening");
         values.put("harm_reduction_tobacco", "Tobacco");
+        values.put("harm_reduction_glue", "Glue");
         values.put("harm_reduction_tramadol", "Tramadol");
         values.put("harm_reduction_undergoing_treatment", "Undergoing treatment");
         values.put("harm_reduction_unknown", "Unknown");
@@ -270,6 +274,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_condom_education_prompt", "Mwongozo");
         values.put("harm_reduction_condom_use_during_sex", "Je, unatumia kondomu wakati wa kujamiiana?");
         values.put("harm_reduction_condoms_given", "Je mpokea huduma amepewa Kondomu?");
+        values.put("harm_reduction_controlled_drugs", "Dawa tiba zenye asili ya kulevya");
         values.put("harm_reduction_continue_service", "Anaendelea na Huduma");
         values.put("harm_reduction_ctc_id", "Namba ya Utambulisho (CTC)");
         values.put("harm_reduction_death_action_taken", "Nini kilifanyika");
@@ -288,6 +293,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_gbv_vac", "Ukatili wa Kijinsia/Watoto");
         values.put("harm_reduction_good_adherence", "Anahudhuria");
         values.put("harm_reduction_has_symptoms", "Ana dalili");
+        values.put("harm_reduction_hashish", "Hashish");
         values.put("harm_reduction_health_education_given", "Je, elimu imetolewa?");
         values.put("harm_reduction_health_education_other_specify", "Bainisha elimu nyingine ya afya iliyotolewa");
         values.put("harm_reduction_health_education_provided", "Elimu ya afya iliyotolewa");
@@ -382,6 +388,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_number_of_sexual_partners", "Idadi ya wenza wa kingono");
         values.put("harm_reduction_nutrition", "Lishe");
         values.put("harm_reduction_other", "Nyinginezo (Taja)");
+        values.put("harm_reduction_petrol", "Petroli");
         values.put("harm_reduction_overdose", "Hali ya kuzidisha dawa (Overdose)");
         values.put("harm_reduction_overdose_action_taken", "Nini kilifanyika");
         values.put("harm_reduction_overdose_management", "Kuzuia na kumudu Overdose");
@@ -431,6 +438,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_tb_leprosy", "Kifua Kikuu/Ukoma");
         values.put("harm_reduction_tb_screening", "Uchunguzi wa Kifua Kikuu");
         values.put("harm_reduction_tobacco", "Tumbaku");
+        values.put("harm_reduction_glue", "Gundi");
         values.put("harm_reduction_tramadol", "Tramadol");
         values.put("harm_reduction_undergoing_treatment", "Yupo kwenye matibabu");
         values.put("harm_reduction_unknown", "Haijulikani");


### PR DESCRIPTION
## Summary
- add visit-history translations for the new harm reduction substance keys
- extend the focused visit-history translation test with the new keys

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest

Refs Digital-Square-Tanzania/opensrp-client-chw#844