### PR TITLE
Add safe injection not given history strings

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -814,6 +814,7 @@
     <string name="harm_reduction_none">Hakuna</string>
     <string name="harm_reduction_not_pregnant">Sio mjamzito</string>
     <string name="harm_reduction_not_screened">Hajachunguzwa</string>
+    <string name="harm_reduction_not_given">Hajapewa</string>
     <string name="harm_reduction_not_started">Hajaanza</string>
     <string name="harm_reduction_ntds">Magojwa yaliyokuwa hayapewi kipaumbele</string>
     <string name="harm_reduction_number_of_condoms">Idadi ya kondomu (vipande) vilivyotolewa</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -657,6 +657,7 @@
     <string name="harm_reduction_none">None</string>
     <string name="harm_reduction_not_pregnant">Not pregnant</string>
     <string name="harm_reduction_not_screened">Not screened</string>
+    <string name="harm_reduction_not_given">Not given</string>
     <string name="harm_reduction_not_started">Not started</string>
     <string name="harm_reduction_ntds">Neglected Tropical Diseases</string>
     <string name="harm_reduction_number_of_condoms">Number of condoms (pieces) provided</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -188,6 +188,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_none", "None");
         values.put("harm_reduction_not_pregnant", "Not pregnant");
         values.put("harm_reduction_not_screened", "Not screened");
+        values.put("harm_reduction_not_given", "Not given");
         values.put("harm_reduction_not_started", "Not started");
         values.put("harm_reduction_ntds", "Neglected Tropical Diseases");
         values.put("harm_reduction_number_of_condoms", "Number of condoms (pieces) provided");
@@ -382,6 +383,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_none", "Hakuna");
         values.put("harm_reduction_not_pregnant", "Sio mjamzito");
         values.put("harm_reduction_not_screened", "Hajachunguzwa");
+        values.put("harm_reduction_not_given", "Hajapewa");
         values.put("harm_reduction_not_started", "Hajaanza");
         values.put("harm_reduction_ntds", "Magojwa yaliyokuwa hayapewi kipaumbele");
         values.put("harm_reduction_number_of_condoms", "Idadi ya kondomu (vipande) vilivyotolewa");


### PR DESCRIPTION
## Summary
- add English and Swahili visit-history strings for `not_given`
- extend Harm Reduction visit-history string coverage

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest

Refs Digital-Square-Tanzania/opensrp-client-chw#854