### PR TITLE
Expand RoC terminology in English app assets

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form/ayp_out_school_enrollment.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ayp_out_school_enrollment.json
@@ -875,7 +875,7 @@
         "openmrs_entity": "",
         "openmrs_entity_id": "",
         "type": "toaster_notes",
-        "text": "RoC is not eligible to be enrolled into AYP Out of School",
+        "text": "Recipient of Care is not eligible to be enrolled into AYP Out of School",
         "text_color": "#CF0800",
         "toaster_type": "problem",
         "relevance": {

--- a/opensrp-chw/src/nacp/assets/reports/harmreduction/5. HR Report.htm
+++ b/opensrp-chw/src/nacp/assets/reports/harmreduction/5. HR Report.htm
@@ -3390,7 +3390,7 @@ AIQBAAAobQEAAAA=
  </tr>
  <tr height=21 style='height:16.0pt'>
   <td height=21 class=xl73 style='height:16.0pt'>&nbsp;</td>
-  <td class=xl67 colspan=2 style='mso-ignore:colspan'>RoC name<span
+  <td class=xl67 colspan=2 style='mso-ignore:colspan'>Recipient of Care name<span
   style='mso-spacerun:yes'>  </span><u>{{ROC_NAME}}</u></td>
   <td class=xl67></td>
   <td class=xl67>Sex <u>{{ROC_SEX}}</u></td>
@@ -3401,7 +3401,7 @@ AIQBAAAobQEAAAA=
  </tr>
  <tr height=21 style='height:16.0pt'>
   <td height=21 class=xl73 style='height:16.0pt'>&nbsp;</td>
-  <td class=xl67 colspan=2 style='mso-ignore:colspan'>RoC Residence:
+  <td class=xl67 colspan=2 style='mso-ignore:colspan'>Recipient of Care Residence:
   _______________</td>
   <td class=xl67></td>
   <td class=xl67></td>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -692,7 +692,7 @@
     <string name="harm_reduction_risky_behaviours_injecting_only">Risky behaviour</string>
     <string name="harm_reduction_risky_behaviours_non_injecting_only">Risky behaviour</string>
     <string name="harm_reduction_risky_behaviours_other_specify">If others, specify</string>
-    <string name="harm_reduction_roc_consent_joining_mat_services">Does RoC consent joining MAT Services?</string>
+    <string name="harm_reduction_roc_consent_joining_mat_services">Does the Recipient of Care consent to join MAT Services?</string>
     <string name="harm_reduction_safe_injection">Safe injection</string>
     <string name="harm_reduction_safe_injection_tools">Safe injection services provided - Type of tools</string>
     <string name="harm_reduction_sharing_needles_syringes">Sharing needles and syringes</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/RocTerminologyEnglishAssetsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/RocTerminologyEnglishAssetsTest.java
@@ -1,0 +1,51 @@
+package org.smartregister.chw.resources;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class RocTerminologyEnglishAssetsTest {
+
+    private static final Pattern ROC_ABBREVIATION = Pattern.compile("\\bRoC\\b");
+
+    private static final List<String> ENGLISH_ASSET_PATHS = Arrays.asList(
+            "src/nacp/res/values/strings.xml",
+            "src/nacp/assets/json.form/ayp_out_school_enrollment.json",
+            "src/nacp/assets/reports/harmreduction/5. HR Report.htm"
+    );
+
+    @Test
+    public void testEnglishAssetsExpandRocAbbreviationInUserFacingText() throws Exception {
+        for (String assetPath : ENGLISH_ASSET_PATHS) {
+            String asset = readText(assetPath);
+            Assert.assertFalse("User-facing English text should expand RoC in " + assetPath,
+                    ROC_ABBREVIATION.matcher(asset).find());
+        }
+    }
+
+    private static String readText(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- replace user-facing English `RoC` text with `Recipient of Care` in app resources, AYP asset, and HR report template
- add focused scan coverage for affected English assets

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.resources.RocTerminologyEnglishAssetsTest

Refs Digital-Square-Tanzania/opensrp-client-chw#853