### PR TITLE
Report Sober House treatment by condition

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_sober_house_reports/HarmReductionSoberHouseReportObject.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_sober_house_reports/HarmReductionSoberHouseReportObject.java
@@ -37,6 +37,53 @@ public class HarmReductionSoberHouseReportObject extends ReportObject {
                     "LEFT JOIN ec_family_member efm " +
                     "ON efm.base_entity_id = ehshe.base_entity_id AND efm.date_removed IS NULL";
 
+    private static final String HIV_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.hiv_result, '')) = 'positive' AND (" +
+                    "lower(ifnull(ehshe.enrolled_into_ctc_services, '')) = 'yes' OR " +
+                    "trim(ifnull(ehshe.ctc_id, '')) <> ''" +
+                    ")";
+    private static final String STIS_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.stis_treatment_after_screening, '')) = 'yes'";
+    private static final String HEART_DISEASES_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.heart_diseases_treatment_after_screening, '')) = 'yes'";
+    private static final String MENTAL_HEALTH_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.mental_health_treatment_after_screening, '')) = 'yes'";
+    private static final String HEPATITIS_B_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.hepatitis_b_treatment_after_screening, '')) = 'yes'";
+    private static final String HEPATITIS_C_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.hepatitis_c_treatment_after_screening, '')) = 'yes'";
+    private static final String OTHER_HEPATITIS_PROXY_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.other_conditions_specify, '')) LIKE '%hepat%' AND " +
+                    "lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'";
+    private static final String DIABETES_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.diabetes_treatment_after_screening, '')) = 'yes'";
+    private static final String TUBERCULOSIS_TREATMENT_CONDITION =
+            "lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms' AND " +
+                    "lower(ifnull(ehshe.tuberculosis_treatment_after_screening, '')) = 'yes'";
+    private static final String OTHER_CONDITIONS_TREATMENT_CONDITION =
+            "trim(ifnull(ehshe.other_conditions_specify, '')) <> '' AND " +
+                    "lower(ifnull(ehshe.other_conditions_specify, '')) NOT LIKE '%hepat%' AND " +
+                    "lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'";
+    private static final String ANY_REPORTED_CONDITION_TREATED_CONDITION =
+            "(" +
+                    HIV_TREATMENT_CONDITION + " OR " +
+                    STIS_TREATMENT_CONDITION + " OR " +
+                    HEART_DISEASES_TREATMENT_CONDITION + " OR " +
+                    MENTAL_HEALTH_TREATMENT_CONDITION + " OR " +
+                    HEPATITIS_B_TREATMENT_CONDITION + " OR " +
+                    HEPATITIS_C_TREATMENT_CONDITION + " OR " +
+                    OTHER_HEPATITIS_PROXY_TREATMENT_CONDITION + " OR " +
+                    DIABETES_TREATMENT_CONDITION + " OR " +
+                    TUBERCULOSIS_TREATMENT_CONDITION + " OR " +
+                    OTHER_CONDITIONS_TREATMENT_CONDITION +
+                    ")";
+
     private static final List<BreakdownColumn> BREAKDOWN_COLUMNS = createBreakdownColumns();
     private static final List<String> RESULT_COLUMNS = createResultColumns();
     private static final List<IndicatorDefinition> INDICATOR_DEFINITIONS = createIndicatorDefinitions();
@@ -211,49 +258,17 @@ public class HarmReductionSoberHouseReportObject extends ReportObject {
                 enrollmentIndicator("sh-8j",
                         "trim(ifnull(ehshe.other_conditions_specify, '')) <> '' AND " +
                                 "lower(ifnull(ehshe.other_conditions_specify, '')) NOT LIKE '%hepat%'"),
-                enrollmentIndicator("sh-9",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND (" +
-                                "lower(ifnull(ehshe.hiv_result, '')) = 'positive' OR " +
-                                "lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms' OR " +
-                                "lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms' OR " +
-                                "trim(ifnull(ehshe.other_conditions_specify, '')) <> ''" +
-                                ")"),
-                enrollmentIndicator("sh-9a",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.hiv_result, '')) = 'positive'"),
-                enrollmentIndicator("sh-9b",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9c",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9d",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9e",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9f",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9g",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.other_conditions_specify, '')) LIKE '%hepat%'"),
-                enrollmentIndicator("sh-9h",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9i",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms'"),
-                enrollmentIndicator("sh-9j",
-                        "lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes' AND " +
-                                "trim(ifnull(ehshe.other_conditions_specify, '')) <> '' AND " +
-                                "lower(ifnull(ehshe.other_conditions_specify, '')) NOT LIKE '%hepat%'"),
+                enrollmentIndicator("sh-9", ANY_REPORTED_CONDITION_TREATED_CONDITION),
+                enrollmentIndicator("sh-9a", HIV_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9b", STIS_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9c", HEART_DISEASES_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9d", MENTAL_HEALTH_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9e", HEPATITIS_B_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9f", HEPATITIS_C_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9g", OTHER_HEPATITIS_PROXY_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9h", DIABETES_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9i", TUBERCULOSIS_TREATMENT_CONDITION),
+                enrollmentIndicator("sh-9j", OTHER_CONDITIONS_TREATMENT_CONDITION),
                 serviceIndicator("sh-10",
                         "(" +
                                 "lower(ifnull(ehshs.follow_up_status, '')) IN ('absconded', 'died') OR " +

--- a/opensrp-chw/src/nacp/assets/config/harm-reduction-sober-house-monthly-report.yml
+++ b/opensrp-chw/src/nacp/assets/config/harm-reduction-sober-house-monthly-report.yml
@@ -451,17 +451,42 @@ indicators:
     description: "Wakazi waliopatiwa tiba kwa magonjwa yaliyoripotiwa"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND (
-                        lower(ifnull(ehshe.hiv_result, '')) = 'positive' OR
-                        lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms' OR
-                        lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms' OR
-                        trim(ifnull(ehshe.other_conditions_specify, '')) <> ''
+                      WHERE (
+                        (
+                          lower(ifnull(ehshe.hiv_result, '')) = 'positive'
+                          AND (
+                            lower(ifnull(ehshe.enrolled_into_ctc_services, '')) = 'yes'
+                            OR trim(ifnull(ehshe.ctc_id, '')) <> ''
+                          )
+                        ) OR (
+                          lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.stis_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.heart_diseases_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.mental_health_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.hepatitis_b_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.hepatitis_c_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.other_conditions_specify, '')) LIKE '%hepat%'
+                          AND lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.diabetes_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms'
+                          AND lower(ifnull(ehshe.tuberculosis_treatment_after_screening, '')) = 'yes'
+                        ) OR (
+                          trim(ifnull(ehshe.other_conditions_specify, '')) <> ''
+                          AND lower(ifnull(ehshe.other_conditions_specify, '')) NOT LIKE '%hepat%'
+                          AND lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'
+                        )
                       )
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
@@ -472,8 +497,11 @@ indicators:
     description: "Waliopatiwa tiba - VVU na UKIMWI"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.hiv_result, '')) = 'positive'
+                      WHERE lower(ifnull(ehshe.hiv_result, '')) = 'positive'
+                      AND (
+                        lower(ifnull(ehshe.enrolled_into_ctc_services, '')) = 'yes'
+                        OR trim(ifnull(ehshe.ctc_id, '')) <> ''
+                      )
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -483,8 +511,8 @@ indicators:
     description: "Waliopatiwa tiba - Magonjwa ya ngono"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.stis_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.stis_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -494,8 +522,8 @@ indicators:
     description: "Waliopatiwa tiba - Magonjwa ya moyo"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.heart_diseases_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.heart_diseases_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -505,8 +533,8 @@ indicators:
     description: "Waliopatiwa tiba - Magonjwa ya afya ya akili"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.mental_health_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.mental_health_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -516,8 +544,8 @@ indicators:
     description: "Waliopatiwa tiba - Homa ya ini aina ya B"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.hepatitis_b_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.hepatitis_b_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -527,8 +555,8 @@ indicators:
     description: "Waliopatiwa tiba - Homa ya ini aina ya C"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.hepatitis_c_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.hepatitis_c_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -539,8 +567,8 @@ indicators:
     description: "Waliopatiwa tiba - Homa nyengine za ini (proxy)"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.other_conditions_specify, '')) LIKE '%hepat%'
+                      WHERE lower(ifnull(ehshe.other_conditions_specify, '')) LIKE '%hepat%'
+                      AND lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -550,8 +578,8 @@ indicators:
     description: "Waliopatiwa tiba - Ugonjwa wa kisukari"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.diabetes_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.diabetes_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -561,8 +589,8 @@ indicators:
     description: "Waliopatiwa tiba - Ugonjwa wa kifua kikuu"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms'
+                      WHERE lower(ifnull(ehshe.tuberculosis_result, '')) = 'has_symptoms'
+                      AND lower(ifnull(ehshe.tuberculosis_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"
@@ -572,9 +600,9 @@ indicators:
     description: "Waliopatiwa tiba - Magonjwa mengineyo"
     indicatorQuery: "SELECT count(DISTINCT ehshe.base_entity_id) as count
                       FROM ec_harm_reduction_sober_house_enrollment ehshe
-                      WHERE lower(ifnull(ehshe.treatment_after_screening, '')) = 'yes'
-                      AND trim(ifnull(ehshe.other_conditions_specify, '')) <> ''
+                      WHERE trim(ifnull(ehshe.other_conditions_specify, '')) <> ''
                       AND lower(ifnull(ehshe.other_conditions_specify, '')) NOT LIKE '%hepat%'
+                      AND lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
                       '-' || substr(strftime('%Y-%m-%d', datetime(ehshe.last_interacted_with / 1000, 'unixepoch', 'localtime')), 6, 2) || '-' || '01')"

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -12071,6 +12071,14 @@
           }
         },
         {
+          "column_name": "other_conditions_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "other_conditions_treatment_after_screening"
+          }
+        },
+        {
           "column_name": "hiv_screening",
           "type": "Event",
           "json_mapping": {
@@ -12119,6 +12127,14 @@
           }
         },
         {
+          "column_name": "other_hepatitis_result",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "other_hepatitis_result"
+          }
+        },
+        {
           "column_name": "diabetes_result",
           "type": "Event",
           "json_mapping": {
@@ -12127,11 +12143,75 @@
           }
         },
         {
+          "column_name": "stis_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "stis_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "heart_diseases_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "heart_diseases_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "mental_health_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "mental_health_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "hepatitis_b_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "hepatitis_b_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "hepatitis_c_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "hepatitis_c_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "other_hepatitis_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "other_hepatitis_treatment_after_screening"
+          }
+        },
+        {
+          "column_name": "diabetes_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "diabetes_treatment_after_screening"
+          }
+        },
+        {
           "column_name": "tuberculosis_result",
           "type": "Event",
           "json_mapping": {
             "field": "obs.fieldCode",
             "concept": "tuberculosis_result"
+          }
+        },
+        {
+          "column_name": "tuberculosis_treatment_after_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "tuberculosis_treatment_after_screening"
           }
         },
         {
@@ -12196,6 +12276,14 @@
           "json_mapping": {
             "field": "obs.fieldCode",
             "concept": "hiv_status"
+          }
+        },
+        {
+          "column_name": "enrolled_into_ctc_services",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "enrolled_into_ctc_services"
           }
         },
         {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_sober_house_reports/HarmReductionSoberHouseReportObjectTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_sober_house_reports/HarmReductionSoberHouseReportObjectTest.java
@@ -1,7 +1,10 @@
 package org.smartregister.chw.domain.harm_reduction_sober_house_reports;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -9,11 +12,20 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.smartregister.chw.dao.ReportDao;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public class HarmReductionSoberHouseReportObjectTest {
 
@@ -22,11 +34,13 @@ public class HarmReductionSoberHouseReportObjectTest {
         HarmReductionSoberHouseReportObject reportObject = new HarmReductionSoberHouseReportObject(
                 new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH).parse("2026-03-01")
         );
+        List<String> capturedSql = new ArrayList<>();
 
         try (MockedStatic<ReportDao> reportDao = Mockito.mockStatic(ReportDao.class)) {
             reportDao.when(() -> ReportDao.getReportBreakdown(Mockito.anyString(), ArgumentMatchers.<String>anyList()))
                     .thenAnswer(invocation -> {
                         String sql = invocation.getArgument(0);
+                        capturedSql.add(sql);
                         List<String> columns = invocation.getArgument(1);
                         Map<String, Integer> values = emptyBreakdown(columns);
 
@@ -70,6 +84,44 @@ public class HarmReductionSoberHouseReportObjectTest {
             assertEquals(0, indicatorDataObject.getInt("sh-5a"));
             assertEquals(0, indicatorDataObject.getInt("sh-5a-female-total"));
         }
+
+        assertTrue(containsSql(capturedSql, "lower(ifnull(ehshe.enrolled_into_ctc_services, '')) = 'yes'"));
+        assertTrue(containsSql(capturedSql, "trim(ifnull(ehshe.ctc_id, '')) <> ''"));
+        assertTrue(containsSql(capturedSql, "lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'"));
+        assertFalse(containsSql(capturedSql, "ehshe.treatment_after_screening"));
+    }
+
+    @Test
+    public void soberHouseEnrollmentBindObjectShouldMapIndicatorNineTreatmentFields() throws Exception {
+        JSONObject clientFields = readJson("src/nacp/assets/ec_client_fields.json");
+        Set<String> mappedColumns = mappedColumns(clientFields, "ec_harm_reduction_sober_house_enrollment");
+
+        for (String column : Arrays.asList(
+                "enrolled_into_ctc_services",
+                "ctc_id",
+                "stis_treatment_after_screening",
+                "heart_diseases_treatment_after_screening",
+                "mental_health_treatment_after_screening",
+                "hepatitis_b_treatment_after_screening",
+                "hepatitis_c_treatment_after_screening",
+                "other_hepatitis_treatment_after_screening",
+                "diabetes_treatment_after_screening",
+                "tuberculosis_treatment_after_screening",
+                "other_conditions_treatment_after_screening"
+        )) {
+            assertTrue("Missing ec_harm_reduction_sober_house_enrollment mapping for " + column,
+                    mappedColumns.contains(column));
+        }
+    }
+
+    @Test
+    public void monthlyReportConfigShouldUseIndicatorNineTreatmentFields() throws Exception {
+        String reportConfig = readText("src/nacp/assets/config/harm-reduction-sober-house-monthly-report.yml");
+
+        assertTrue(reportConfig.contains("lower(ifnull(ehshe.enrolled_into_ctc_services, '')) = 'yes'"));
+        assertTrue(reportConfig.contains("trim(ifnull(ehshe.ctc_id, '')) <> ''"));
+        assertTrue(reportConfig.contains("lower(ifnull(ehshe.other_conditions_treatment_after_screening, '')) = 'yes'"));
+        assertFalse(reportConfig.contains("ehshe.treatment_after_screening"));
     }
 
     private static Map<String, Integer> emptyBreakdown(List<String> columns) {
@@ -78,5 +130,57 @@ public class HarmReductionSoberHouseReportObjectTest {
             values.put(column, 0);
         }
         return values;
+    }
+
+    private static boolean containsSql(List<String> sqlQueries, String expectedSql) {
+        for (String sql : sqlQueries) {
+            if (sql.contains(expectedSql)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Set<String> mappedColumns(JSONObject clientFields, String bindObjectName) throws Exception {
+        JSONArray columns = getBindObjectColumns(clientFields, bindObjectName);
+        Set<String> mappedColumns = new LinkedHashSet<>();
+        for (int i = 0; i < columns.length(); i++) {
+            mappedColumns.add(columns.getJSONObject(i).optString("column_name"));
+        }
+        return mappedColumns;
+    }
+
+    private static JSONArray getBindObjectColumns(JSONObject clientFields, String bindObjectName) throws Exception {
+        JSONArray bindObjects = clientFields.getJSONArray("bindobjects");
+        for (int i = 0; i < bindObjects.length(); i++) {
+            JSONObject bindObject = bindObjects.getJSONObject(i);
+            if (bindObjectName.equals(bindObject.optString("name"))) {
+                return bindObject.getJSONArray("columns");
+            }
+        }
+
+        throw new AssertionError("Missing bindobject: " + bindObjectName);
+    }
+
+    private static JSONObject readJson(String relativePath) throws Exception {
+        return new JSONObject(readText(relativePath));
+    }
+
+    private static String readText(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
     }
 }


### PR DESCRIPTION
## Summary
- map Sober House condition-specific treatment fields and CTC enrollment status in the app ec_client_fields asset
- update Indicator 9 report logic to use condition-specific treatment answers instead of the legacy shared treatment field
- count HIV treatment through CTC enrollment/CTC ID and link Other Diseases treatment to sh-9/sh-9g/sh-9j

## Testing
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.domain.harm_reduction_sober_house_reports.HarmReductionSoberHouseReportObjectTest

Refs #804