### PR TITLE
Show MAT treatment outcome in visit history

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionMatClientsVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionMatClientsVisitHistoryActivity.java
@@ -38,6 +38,7 @@ import timber.log.Timber;
 
 public class HarmReductionMatClientsVisitHistoryActivity extends CoreAncMedicalHistoryActivity {
     private static final String MAT_CLIENTS_FOLLOWUP_EVENT = "Harm Reduction MAT Clients Followup";
+    static final String METHADONE_TREATMENT_STATUS = "methadone_treatment_status";
     private static MemberObject harmReductionMemberObject;
 
     private final Flavor flavor = new HarmReductionMatClientsHistoryActivityFlv();
@@ -86,8 +87,18 @@ public class HarmReductionMatClientsVisitHistoryActivity extends CoreAncMedicalH
         progressBar.setVisibility(state ? View.VISIBLE : View.GONE);
     }
 
+    static boolean isVisitHistoryParam(String param) {
+        for (String visitParam : HarmReductionMatClientsHistoryActivityFlv.VISIT_PARAMS) {
+            if (StringUtils.equals(param, visitParam)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static class HarmReductionMatClientsHistoryActivityFlv extends DefaultAncMedicalHistoryActivityFlv {
         private static final String[] VISIT_PARAMS = {
+                METHADONE_TREATMENT_STATUS,
                 "health_education_provided",
                 "education_delivery_method"
         };

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -950,6 +950,10 @@
     <string name="harm_reduction_sober_house_wounds_abscesses">Matibabu ya vidonda na Mabunyufu (majipu)</string>
     <string name="record_services_provided_to_mat_clients">Rekodi huduma zilizotolewa kwa wapokea huduma wa MAT</string>
     <string name="harm_reduction_mat_clients_followup_visit">Hudhurio la ufuatiliaji kwa wapokea huduma wa MAT</string>
+    <string name="harm_reduction_mat_clients_methadone_treatment_status">Tiba ya Methadone</string>
+    <string name="harm_reduction_mat_clients_continuing_methadone_treatment">Anaendelea na Tiba ya Methadone</string>
+    <string name="harm_reduction_mat_clients_stopped_using_methadone">Ameacha kutumia Methadone</string>
+    <string name="harm_reduction_mat_clients_completed_methadone_treatment">Amemaliza Tiba ya Methadone</string>
     <string name="harm_reduction_mat_clients_health_education_provided">Elimu iliyotolewa</string>
     <string name="harm_reduction_mat_clients_education_delivery_method">Njia ya utoaji elimu</string>
     <string name="harm_reduction_mat_clients_group_session">Kikao cha vikundi</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -796,6 +796,10 @@
     <string name="harm_reduction_sober_house_wounds_abscesses">Wounds and abscesses management</string>
     <string name="record_services_provided_to_mat_clients">Record Services Provided to MAT Clients</string>
     <string name="harm_reduction_mat_clients_followup_visit">MAT Clients Followup Visit</string>
+    <string name="harm_reduction_mat_clients_methadone_treatment_status">Methadone treatment</string>
+    <string name="harm_reduction_mat_clients_continuing_methadone_treatment">Continuing Methadone treatment</string>
+    <string name="harm_reduction_mat_clients_stopped_using_methadone">Stopped using Methadone</string>
+    <string name="harm_reduction_mat_clients_completed_methadone_treatment">Completed Methadone treatment</string>
     <string name="harm_reduction_mat_clients_health_education_provided">Health Education Provided</string>
     <string name="harm_reduction_mat_clients_education_delivery_method">Education Delivery Method</string>
     <string name="harm_reduction_mat_clients_group_session">Group session</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionMatClientsVisitHistoryActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionMatClientsVisitHistoryActivityTest.java
@@ -1,0 +1,15 @@
+package org.smartregister.chw.activity;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.chw.BaseUnitTest;
+
+public class HarmReductionMatClientsVisitHistoryActivityTest extends BaseUnitTest {
+
+    @Test
+    public void visitHistoryParamsShouldIncludeMethadoneTreatmentStatus() {
+        Assert.assertTrue(HarmReductionMatClientsVisitHistoryActivity.isVisitHistoryParam(
+                HarmReductionMatClientsVisitHistoryActivity.METHADONE_TREATMENT_STATUS
+        ));
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionMatVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionMatVisitHistoryStringTranslationsTest.java
@@ -63,6 +63,10 @@ public class HarmReductionMatVisitHistoryStringTranslationsTest {
 
     private Map<String, String> expectedEnglishStrings() {
         Map<String, String> values = new LinkedHashMap<>();
+        values.put("harm_reduction_mat_clients_methadone_treatment_status", "Methadone treatment");
+        values.put("harm_reduction_mat_clients_continuing_methadone_treatment", "Continuing Methadone treatment");
+        values.put("harm_reduction_mat_clients_stopped_using_methadone", "Stopped using Methadone");
+        values.put("harm_reduction_mat_clients_completed_methadone_treatment", "Completed Methadone treatment");
         values.put("harm_reduction_mat_clients_drug_education", "Drug education");
         values.put("harm_reduction_mat_clients_drug_use_related_diseases", "Diseases associated with drug use");
         values.put("harm_reduction_mat_clients_epidemic_diseases", "Epidemic diseases");
@@ -73,6 +77,10 @@ public class HarmReductionMatVisitHistoryStringTranslationsTest {
 
     private Map<String, String> expectedSwahiliStrings() {
         Map<String, String> values = new LinkedHashMap<>();
+        values.put("harm_reduction_mat_clients_methadone_treatment_status", "Tiba ya Methadone");
+        values.put("harm_reduction_mat_clients_continuing_methadone_treatment", "Anaendelea na Tiba ya Methadone");
+        values.put("harm_reduction_mat_clients_stopped_using_methadone", "Ameacha kutumia Methadone");
+        values.put("harm_reduction_mat_clients_completed_methadone_treatment", "Amemaliza Tiba ya Methadone");
         values.put("harm_reduction_mat_clients_drug_education", "Dawa za kulevya");
         values.put("harm_reduction_mat_clients_drug_use_related_diseases", "Magonjwa yanayoambatana na matumizi ya dawa za kulevya");
         values.put("harm_reduction_mat_clients_epidemic_diseases", "Magonjwa ya mlipuko");


### PR DESCRIPTION
## Summary
- include methadone_treatment_status in MAT clients visit-history rendering
- add English and Swahili strings for the Methadone treatment field and outcome options
- add focused tests for the visit-history parameter and translations

## Testing
- git diff --check
- ./gradlew :opensrp-chw:testDebugUnitTest --tests org.smartregister.chw.activity.HarmReductionMatClientsVisitHistoryActivityTest --tests org.smartregister.chw.resources.HarmReductionMatVisitHistoryStringTranslationsTest

Refs #807