### PR TITLE
Refresh ADDO navigation after location sync

### DIFF
--- a/opensrp-chw/src/main/AndroidManifest.xml
+++ b/opensrp-chw/src/main/AndroidManifest.xml
@@ -724,6 +724,9 @@
         <service android:name="org.smartregister.sync.intent.SyncLocationsByLevelAndTagsIntentService"
             android:foregroundServiceType="dataSync"/>
 
+        <service android:name=".sync.intent.ChwSyncLocationsByLevelAndTagsIntentService"
+            android:foregroundServiceType="dataSync"/>
+
         <service android:name="org.smartregister.sync.intent.DocumentConfigurationIntentService"
             android:foregroundServiceType="dataSync"/>
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
@@ -6,20 +6,27 @@ import static org.smartregister.chw.util.Utils.truncateTimeFromDate;
 import static org.smartregister.family.util.Utils.metadata;
 import static org.smartregister.util.Utils.getValue;
 
-import android.app.AlertDialog;
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.text.TextUtils;
 import android.util.Pair;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.domain.Form;
@@ -43,8 +50,8 @@ import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.CoreJsonFormUtils;
 import org.smartregister.chw.core.utils.UpdateDetailsUtil;
 import org.smartregister.chw.custom_view.HpsFloatingMenu;
-import org.smartregister.chw.dao.FamilyDao;
 import org.smartregister.chw.dao.ChwHpsDao;
+import org.smartregister.chw.dao.FamilyDao;
 import org.smartregister.chw.dataloader.AncMemberDataLoader;
 import org.smartregister.chw.dataloader.FamilyMemberDataLoader;
 import org.smartregister.chw.hivst.dao.HivstDao;
@@ -56,10 +63,11 @@ import org.smartregister.chw.hps.util.Constants;
 import org.smartregister.chw.hps.util.VisitUtils;
 import org.smartregister.chw.kvp.dao.KvpDao;
 import org.smartregister.chw.malaria.dao.IccmDao;
+import org.smartregister.chw.model.FamilyDetailsModel;
 import org.smartregister.chw.model.ReferralTypeModel;
 import org.smartregister.chw.sbc.dao.SbcDao;
-import org.smartregister.chw.util.MemberProfileUtils;
 import org.smartregister.chw.util.AllClientsUtils;
+import org.smartregister.chw.util.MemberProfileUtils;
 import org.smartregister.commonregistry.CommonPersonObject;
 import org.smartregister.commonregistry.CommonPersonObjectClient;
 import org.smartregister.commonregistry.CommonRepository;
@@ -69,6 +77,7 @@ import org.smartregister.family.util.Utils;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -78,20 +87,24 @@ import timber.log.Timber;
 public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements OnRetrieveNotifications {
     private final FamilyOtherMemberProfileActivity.Flavor flavor = new FamilyOtherMemberProfileActivityFlv();
     private final List<ReferralTypeModel> referralTypeModels = new ArrayList<>();
-    private java.util.List<org.smartregister.chw.model.FamilyDetailsModel> headedFamilies = java.util.Collections.emptyList();
     private final NotificationListAdapter notificationListAdapter = new NotificationListAdapter();
-
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        notificationAndReferralRecyclerView.setAdapter(notificationListAdapter);
-        notificationListAdapter.setOnClickListener(this);
-    }
+    private List<FamilyDetailsModel> headedFamilies = Collections.emptyList();
 
     public static void startMe(Activity activity, String baseEntityID) {
         Intent intent = new Intent(activity, HpsMemberProfileActivity.class);
         intent.putExtra(Constants.ACTIVITY_PAYLOAD.BASE_ENTITY_ID, baseEntityID);
         activity.startActivityForResult(intent, Constants.REQUEST_CODE_GET_JSON);
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        try {
+            notificationAndReferralRecyclerView.setAdapter(notificationListAdapter);
+            notificationListAdapter.setOnClickListener(this);
+        } catch (Exception e) {
+            Timber.e(e);
+        }
     }
 
     @Override
@@ -108,11 +121,12 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
             headedFamilies = FamilyDao.getFamiliesByHead(memberObject.getBaseEntityId());
         } catch (Exception e) {
             Timber.e(e);
-            headedFamilies = java.util.Collections.emptyList();
+            headedFamilies = Collections.emptyList();
         }
         try {
             delayInvalidateOptionsMenu();
-        } catch (Exception ignore) { }
+        } catch (Exception ignore) {
+        }
 
         if (ChwHpsDao.wereSelfTestingKitsDistributed(memberObject.getBaseEntityId())) {
             if (HivstDao.isRegisteredForHivst(memberObject.getBaseEntityId())) {
@@ -350,14 +364,15 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
             householdsItem.setActionView(org.smartregister.chw.R.layout.action_households_action);
             View av = householdsItem.getActionView();
             if (av != null) {
-                android.widget.TextView tv = av.findViewById(org.smartregister.chw.R.id.tv_households_label);
+                TextView tv = av.findViewById(org.smartregister.chw.R.id.tv_households_label);
                 if (tv != null) {
                     boolean shortLabel = getResources().getBoolean(org.smartregister.chw.R.bool.use_short_hh_label);
                     tv.setText(getString(shortLabel ? org.smartregister.chw.R.string.hh_with_count : org.smartregister.chw.R.string.household_with_count, hhCount));
                 }
                 av.setOnClickListener(v -> {
                     if (hhCount <= 0) return;
-                    if (hhCount == 1) openFamilyProfile(headedFamilies.get(0)); else handleViewHouseholdsClick();
+                    if (hhCount == 1) openFamilyProfile(headedFamilies.get(0));
+                    else handleViewHouseholdsClick();
                 });
                 String fullTitle = getString(org.smartregister.chw.R.string.view_households_with_count, hhCount);
                 av.setContentDescription(fullTitle);
@@ -435,8 +450,7 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
             }
 
             return true;
-        }
-        else if (i == R.id.action_remove_member) {
+        } else if (i == R.id.action_remove_member) {
             removeIndividualProfile();
             return true;
         } else if (i == org.smartregister.chw.R.id.action_view_households) {
@@ -454,17 +468,17 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
         }
 
         LayoutInflater inflater = LayoutInflater.from(this);
-        android.view.View dialogView = inflater.inflate(org.smartregister.chw.R.layout.dialog_households_list, null, false);
+        View dialogView = inflater.inflate(org.smartregister.chw.R.layout.dialog_households_list, null, false);
         ListView listView = dialogView.findViewById(org.smartregister.chw.R.id.list_households);
         HouseholdsAdapter adapter = new HouseholdsAdapter(this, headedFamilies);
         listView.setAdapter(adapter);
-        android.widget.TextView btnCancel = dialogView.findViewById(org.smartregister.chw.R.id.btn_cancel);
+        TextView btnCancel = dialogView.findViewById(org.smartregister.chw.R.id.btn_cancel);
 
         AlertDialog dialog = new AlertDialog.Builder(this)
                 .setView(dialogView)
                 .create();
         if (dialog.getWindow() != null) {
-            dialog.getWindow().setBackgroundDrawable(new android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT));
+            dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         }
         listView.setOnItemClickListener((parent, view, position, id) -> {
             if (position >= 0 && position < headedFamilies.size()) {
@@ -478,7 +492,7 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
         dialog.show();
     }
 
-    private void openFamilyProfile(org.smartregister.chw.model.FamilyDetailsModel family) {
+    private void openFamilyProfile(FamilyDetailsModel family) {
         try {
             Intent intent = new Intent(this, FamilyProfileActivity.class);
             intent.putExtra(org.smartregister.family.util.Constants.INTENT_KEY.FAMILY_BASE_ENTITY_ID, family.getBaseEntityId());
@@ -499,56 +513,6 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
             Timber.e(e);
         }
     }
-
-    private static class HouseholdsAdapter extends android.widget.BaseAdapter {
-        private final java.util.List<org.smartregister.chw.model.FamilyDetailsModel> data;
-        private final android.view.LayoutInflater inflater;
-        private final android.content.Context context;
-
-        HouseholdsAdapter(android.content.Context context, java.util.List<org.smartregister.chw.model.FamilyDetailsModel> data) {
-            this.context = context;
-            this.inflater = android.view.LayoutInflater.from(context);
-            this.data = data != null ? data : java.util.Collections.emptyList();
-        }
-
-        @Override
-        public int getCount() { return data.size(); }
-
-        @Override
-        public Object getItem(int position) { return data.get(position); }
-
-        @Override
-        public long getItemId(int position) { return position; }
-
-        @Override
-        public android.view.View getView(int position, android.view.View convertView, android.view.ViewGroup parent) {
-            ViewHolder holder;
-            if (convertView == null) {
-                convertView = inflater.inflate(org.smartregister.chw.R.layout.item_household_row, parent, false);
-                holder = new ViewHolder();
-                holder.title = convertView.findViewById(org.smartregister.chw.R.id.tv_title);
-                holder.subtitle = convertView.findViewById(org.smartregister.chw.R.id.tv_subtitle);
-                convertView.setTag(holder);
-            } else {
-                holder = (ViewHolder) convertView.getTag();
-            }
-
-            org.smartregister.chw.model.FamilyDetailsModel item = data.get(position);
-            String name = item != null ? item.getFamilyName() : "";
-            String village = item != null ? item.getVillageTown() : "";
-
-            holder.title.setText(!android.text.TextUtils.isEmpty(name) ? name : context.getString(org.smartregister.chw.R.string.family_profile_title, ""));
-            holder.subtitle.setText(village);
-            convertView.setContentDescription(name + ", " + village);
-            return convertView;
-        }
-
-        static class ViewHolder {
-            android.widget.TextView title;
-            android.widget.TextView subtitle;
-        }
-    }
-
 
     protected void startTbLeprosyScreening() {
         TbLeprosyRegisterActivity.startRegistration(HpsMemberProfileActivity.this, memberObject.getBaseEntityId());
@@ -649,5 +613,60 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
     @Override
     public void onReceivedNotifications(List<Pair<String, String>> notifications) {
         handleReceivedNotifications(this, notifications, notificationListAdapter);
+    }
+
+    private static class HouseholdsAdapter extends BaseAdapter {
+        private final List<FamilyDetailsModel> data;
+        private final LayoutInflater inflater;
+        private final Context context;
+
+        HouseholdsAdapter(Context context, List<FamilyDetailsModel> data) {
+            this.context = context;
+            this.inflater = LayoutInflater.from(context);
+            this.data = data != null ? data : Collections.emptyList();
+        }
+
+        @Override
+        public int getCount() {
+            return data.size();
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return data.get(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            ViewHolder holder;
+            if (convertView == null) {
+                convertView = inflater.inflate(org.smartregister.chw.R.layout.item_household_row, parent, false);
+                holder = new ViewHolder();
+                holder.title = convertView.findViewById(org.smartregister.chw.R.id.tv_title);
+                holder.subtitle = convertView.findViewById(org.smartregister.chw.R.id.tv_subtitle);
+                convertView.setTag(holder);
+            } else {
+                holder = (ViewHolder) convertView.getTag();
+            }
+
+            FamilyDetailsModel item = data.get(position);
+            String name = item != null ? item.getFamilyName() : "";
+            String village = item != null ? item.getVillageTown() : "";
+
+            holder.title.setText(!TextUtils.isEmpty(name) ? name : context.getString(org.smartregister.chw.R.string.family_profile_title, ""));
+            holder.subtitle.setText(village);
+            convertView.setContentDescription(name + ", " + village);
+            return convertView;
+        }
+
+        static class ViewHolder {
+            TextView title;
+            TextView subtitle;
+        }
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwApplication.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/application/ChwApplication.java
@@ -74,6 +74,7 @@ import org.smartregister.chw.core.service.CoreAuthorizationService;
 import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.FormUtils;
 import org.smartregister.chw.custom_view.NavigationMenuFlv;
+import org.smartregister.chw.event.LocationSyncCompleteEvent;
 import org.smartregister.chw.fp.FpLibrary;
 import org.smartregister.chw.hiv.HivLibrary;
 import org.smartregister.chw.hivst.HivstLibrary;
@@ -97,6 +98,8 @@ import org.smartregister.chw.util.ChwLocationBasedClassifier;
 import org.smartregister.chw.util.FailSafeRecalledID;
 import org.smartregister.chw.util.FileUtils;
 import org.smartregister.chw.util.JsonFormUtils;
+import org.smartregister.chw.util.LocationUtils;
+import org.smartregister.chw.util.NavigationDrawerRefreshUtils;
 import org.smartregister.chw.util.Utils;
 import org.smartregister.commonregistry.CommonFtsObject;
 import org.smartregister.configurableviews.ConfigurableViewsLibrary;
@@ -492,8 +495,8 @@ public class ChwApplication extends CoreChwApplication {
         return flavor.hasTB();
     }
 
-    public boolean hasADDO(){
-        return flavor.hasADDO();
+    public boolean hasADDO() {
+        return LocationUtils.hasADDO();
     }
 
 
@@ -512,6 +515,11 @@ public class ChwApplication extends CoreChwApplication {
 
             ChildAlertService.updateAlerts(visit.getBaseEntityId());
         }
+    }
+
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onLocationSyncComplete(LocationSyncCompleteEvent event) {
+        NavigationDrawerRefreshUtils.refreshNavigationDrawer();
     }
 
     public AppExecutors getAppExecutors() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/application/DefaultChwApplicationFlv.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/application/DefaultChwApplicationFlv.java
@@ -2,6 +2,7 @@ package org.smartregister.chw.application;
 
 import org.smartregister.chw.core.utils.ChildDBConstants;
 import org.smartregister.chw.core.utils.CoreConstants;
+import org.smartregister.chw.util.LocationUtils;
 import org.smartregister.family.util.DBConstants;
 
 import java.util.HashMap;
@@ -259,7 +260,7 @@ public abstract class DefaultChwApplicationFlv implements ChwApplication.Flavor 
 
     @Override
     public boolean hasADDO() {
-        return true;
+        return LocationUtils.hasADDO();
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/custom_view/AncFloatingMenu.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/custom_view/AncFloatingMenu.java
@@ -20,6 +20,12 @@ public class AncFloatingMenu extends CoreAncFloatingMenu {
     protected void initUi() {
         super.initUi();
         this.referLayout.setVisibility(ChwApplication.getApplicationFlavor().hasReferrals() ? VISIBLE : GONE);
+
+        if (ChwApplication.getApplicationFlavor().hasADDO()) {
+            linkageLayout.setVisibility(VISIBLE);
+        } else {
+            linkageLayout.setVisibility(GONE);
+        }
     }
 
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/event/LocationSyncCompleteEvent.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/event/LocationSyncCompleteEvent.java
@@ -1,0 +1,4 @@
+package org.smartregister.chw.event;
+
+public class LocationSyncCompleteEvent {
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/job/ChwJobCreator.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/job/ChwJobCreator.java
@@ -61,7 +61,7 @@ public class ChwJobCreator implements JobCreator {
             case ScheduleJob.TAG:
                 return new ScheduleJob();
             case SyncLocationsByLevelAndTagsServiceJob.TAG:
-                return new SyncLocationsByLevelAndTagsServiceJob();
+                return new ChwSyncLocationsByLevelAndTagsServiceJob();
             case StockUsageReportJob.TAG:
                 return new StockUsageReportJob();
             case SyncTaskWithClientEventsServiceJob.TAG:

--- a/opensrp-chw/src/main/java/org/smartregister/chw/job/ChwSyncLocationsByLevelAndTagsServiceJob.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/job/ChwSyncLocationsByLevelAndTagsServiceJob.java
@@ -1,0 +1,30 @@
+package org.smartregister.chw.job;
+
+import android.content.Intent;
+
+import com.evernote.android.job.Job;
+
+import org.smartregister.chw.sync.intent.ChwSyncLocationsByLevelAndTagsIntentService;
+import org.smartregister.job.BaseJob;
+import org.smartregister.job.SyncLocationsByLevelAndTagsServiceJob;
+
+public class ChwSyncLocationsByLevelAndTagsServiceJob extends BaseJob {
+
+    private static final String TO_RESCHEDULE = "to_reschedule";
+
+    @Override
+    protected Job.Result onRunJob(Job.Params params) {
+        Intent intent = new Intent(getApplicationContext(), ChwSyncLocationsByLevelAndTagsIntentService.class);
+        getApplicationContext().startService(intent);
+
+        if (params != null && params.getExtras().getBoolean(TO_RESCHEDULE, false)) {
+            return Job.Result.RESCHEDULE;
+        }
+
+        return Job.Result.SUCCESS;
+    }
+
+    public static void scheduleJobImmediately() {
+        SyncLocationsByLevelAndTagsServiceJob.scheduleJobImmediately(SyncLocationsByLevelAndTagsServiceJob.TAG);
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/intent/ChwSyncLocationsByLevelAndTagsIntentService.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/intent/ChwSyncLocationsByLevelAndTagsIntentService.java
@@ -1,0 +1,40 @@
+package org.smartregister.chw.sync.intent;
+
+import android.content.Intent;
+
+import org.greenrobot.eventbus.EventBus;
+import org.smartregister.chw.event.LocationSyncCompleteEvent;
+import org.smartregister.sync.helper.LocationServiceHelper;
+import org.smartregister.sync.intent.BaseSyncIntentService;
+
+import timber.log.Timber;
+
+public class ChwSyncLocationsByLevelAndTagsIntentService extends BaseSyncIntentService {
+
+    public ChwSyncLocationsByLevelAndTagsIntentService() {
+        super("ChwSyncLocationsByLevelAndTagsIntentService");
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        try {
+            prepareSync(intent);
+            syncLocationsByLevelAndTags();
+            notifyLocationSyncComplete();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+    protected void prepareSync(Intent intent) {
+        super.onHandleIntent(intent);
+    }
+
+    protected void syncLocationsByLevelAndTags() throws Exception {
+        LocationServiceHelper.getInstance().fetchLocationsByLevelAndTags();
+    }
+
+    protected void notifyLocationSyncComplete() {
+        EventBus.getDefault().post(new LocationSyncCompleteEvent());
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/LocationUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/LocationUtils.java
@@ -1,0 +1,195 @@
+package org.smartregister.chw.util;
+
+import org.smartregister.AllConstants;
+import org.smartregister.Context;
+import org.smartregister.CoreLibrary;
+import org.smartregister.domain.Location;
+import org.smartregister.domain.LocationTag;
+import org.smartregister.domain.jsonmapping.util.LocationTree;
+import org.smartregister.domain.jsonmapping.util.TreeNode;
+import org.smartregister.repository.LocationRepository;
+import org.smartregister.repository.LocationTagRepository;
+import org.smartregister.util.AssetHandler;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import timber.log.Timber;
+
+public final class LocationUtils {
+    private static final String WARD_TAG = "Ward";
+    private static final String HAS_ADDO_TAG = "has_addo";
+
+    private LocationUtils() {
+    }
+
+    public static boolean hasADDO() {
+        try {
+            LocationRepository locationRepository = new LocationRepository();
+            List<Location> locations = locationRepository.getAllLocations();
+            List<LocationTag> locationTags = new LocationTagRepository().getAllLocationTags();
+            String wardLocationId = getWard(locations, locationTags);
+
+            if (isBlank(wardLocationId)) {
+                return false;
+            }
+
+            Location wardLocation = locationRepository.getLocationById(wardLocationId);
+            return hasADDO(wardLocation, locationTags);
+        } catch (Exception e) {
+            Timber.e(e);
+            return false;
+        }
+    }
+
+    public static String getWard() {
+        try {
+            LocationRepository locationRepository = new LocationRepository();
+            List<Location> locations = locationRepository.getAllLocations();
+            List<LocationTag> locationTags = new LocationTagRepository().getAllLocationTags();
+            return getWard(locations, locationTags);
+        } catch (Exception e) {
+            Timber.e(e);
+            return null;
+        }
+    }
+
+    static boolean hasADDO(Location wardLocation, List<LocationTag> locationTags) {
+        return wardLocation != null && hasLocationTag(locationTags, wardLocation.getId(), HAS_ADDO_TAG);
+    }
+
+    static String getWard(List<Location> locations, List<LocationTag> locationTags) {
+        String locationId = Context.getInstance().allSharedPreferences().getPreference(AllConstants.CURRENT_LOCATION_ID);
+        String locationData = CoreLibrary.getInstance().context().anmLocationController().get();
+        return getWard(locations, locationTags, locationId, locationData);
+    }
+
+    static String getWard(List<Location> locations, List<LocationTag> locationTags, String locationId, String locationData) {
+        if (isBlank(locationId)) {
+            return null;
+        }
+
+        if (isBlank(locationData)) {
+            return getParentLocationIdWithTags(locations, locationTags, locationId, WARD_TAG);
+        }
+
+        try {
+            LocationTree locationTree = AssetHandler.jsonStringToJava(locationData, LocationTree.class);
+            if (locationTree == null || locationTree.getLocationsHierarchy() == null) {
+                return getParentLocationIdWithTags(locations, locationTags, locationId, WARD_TAG);
+            }
+
+            TreeNode<String, org.smartregister.domain.jsonmapping.Location> locationNode =
+                    findLocationNode(locationTree.getLocationsHierarchy(), locationId);
+            if (locationNode == null || locationNode.getParent() == null) {
+                return getParentLocationIdWithTags(locations, locationTags, locationId, WARD_TAG);
+            }
+
+            String parentLocationId = locationNode.getParent();
+            if (hasLocationTag(locations, locationTags, parentLocationId, WARD_TAG)) {
+                return parentLocationId;
+            }
+
+            return getParentLocationIdWithTags(locations, locationTags, parentLocationId, WARD_TAG);
+        } catch (Exception e) {
+            Timber.e(e);
+            return getParentLocationIdWithTags(locations, locationTags, locationId, WARD_TAG);
+        }
+    }
+
+    static TreeNode<String, org.smartregister.domain.jsonmapping.Location> findLocationNode(
+            LinkedHashMap<String, TreeNode<String, org.smartregister.domain.jsonmapping.Location>> locationMap,
+            String locationId) {
+        if (locationMap == null || isBlank(locationId)) {
+            return null;
+        }
+
+        for (Map.Entry<String, TreeNode<String, org.smartregister.domain.jsonmapping.Location>> entry : locationMap.entrySet()) {
+            TreeNode<String, org.smartregister.domain.jsonmapping.Location> treeNode = entry.getValue();
+            if (treeNode == null) {
+                continue;
+            }
+            if (locationId.equals(treeNode.getId())) {
+                return treeNode;
+            }
+
+            TreeNode<String, org.smartregister.domain.jsonmapping.Location> childTreeNode =
+                    findLocationNode(treeNode.getChildren(), locationId);
+            if (childTreeNode != null) {
+                return childTreeNode;
+            }
+        }
+        return null;
+    }
+
+    static boolean hasLocationTag(List<LocationTag> locationTags, String locationId, String tagName) {
+        if (locationTags == null || isBlank(locationId) || isBlank(tagName)) {
+            return false;
+        }
+
+        for (LocationTag locationTag : locationTags) {
+            if (locationTag == null) {
+                continue;
+            }
+            if (locationId.equals(locationTag.getLocationId()) && tagName.equalsIgnoreCase(locationTag.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean hasLocationTag(List<Location> locations, List<LocationTag> locationTags, String locationId, String tagName) {
+        if (!hasLocation(locations, locationId)) {
+            return false;
+        }
+        return hasLocationTag(locationTags, locationId, tagName);
+    }
+
+    static String getParentLocationIdWithTags(List<Location> locations, List<LocationTag> locationTags, String locationId, String tagName) {
+        return getParentLocationIdWithTags(locations, locationTags, locationId, tagName, new HashSet<String>());
+    }
+
+    private static String getParentLocationIdWithTags(List<Location> locations, List<LocationTag> locationTags, String locationId, String tagName, Set<String> visitedLocationIds) {
+        if (locations == null || isBlank(locationId) || isBlank(tagName) || visitedLocationIds.contains(locationId)) {
+            return null;
+        }
+
+        visitedLocationIds.add(locationId);
+        for (Location location : locations) {
+            if (location == null || !locationId.equals(location.getId())) {
+                continue;
+            }
+
+            if (hasLocationTag(locationTags, location.getId(), tagName)) {
+                return location.getId();
+            }
+
+            if (location.getProperties() == null || isBlank(location.getProperties().getParentId())) {
+                return null;
+            }
+
+            return getParentLocationIdWithTags(locations, locationTags, location.getProperties().getParentId(), tagName, visitedLocationIds);
+        }
+        return null;
+    }
+
+    private static boolean hasLocation(List<Location> locations, String locationId) {
+        if (locations == null || isBlank(locationId)) {
+            return false;
+        }
+
+        for (Location location : locations) {
+            if (location != null && locationId.equals(location.getId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/NavigationDrawerRefreshUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/NavigationDrawerRefreshUtils.java
@@ -1,0 +1,37 @@
+package org.smartregister.chw.util;
+
+import org.smartregister.chw.core.custom_views.NavigationMenu;
+import org.smartregister.chw.model.NavigationModelFlv;
+
+import java.lang.reflect.Field;
+
+import timber.log.Timber;
+
+public final class NavigationDrawerRefreshUtils {
+
+    private static final String NAVIGATION_MENU_INSTANCE_FIELD = "instance";
+
+    private NavigationDrawerRefreshUtils() {
+    }
+
+    public static void refreshNavigationDrawer() {
+        try {
+            NavigationModelFlv.refreshNavigationOptions();
+
+            NavigationMenu navigationMenu = getCurrentNavigationMenu();
+            if (navigationMenu == null || navigationMenu.getNavigationAdapter() == null) {
+                return;
+            }
+
+            navigationMenu.refreshCount();
+        } catch (Exception e) {
+            Timber.e(e);
+        }
+    }
+
+    static NavigationMenu getCurrentNavigationMenu() throws NoSuchFieldException, IllegalAccessException {
+        Field instanceField = NavigationMenu.class.getDeclaredField(NAVIGATION_MENU_INSTANCE_FIELD);
+        instanceField.setAccessible(true);
+        return (NavigationMenu) instanceField.get(null);
+    }
+}

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/model/NavigationModelFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/model/NavigationModelFlv.java
@@ -21,6 +21,15 @@ public class NavigationModelFlv implements NavigationModel.Flavor {
 
     private static final List<NavigationOption> navigationOptions = new ArrayList<>();
 
+    public static void resetNavigationOptions() {
+        navigationOptions.clear();
+    }
+
+    public static List<NavigationOption> refreshNavigationOptions() {
+        resetNavigationOptions();
+        return new NavigationModelFlv().getNavigationItems();
+    }
+
     @Override
     public List<NavigationOption> getNavigationItems() {
         if (navigationOptions.isEmpty()) {

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/util/ReferralUtils.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/util/ReferralUtils.java
@@ -2,9 +2,6 @@ package org.smartregister.chw.util;
 
 import org.joda.time.DateTime;
 import org.json.JSONObject;
-import org.smartregister.AllConstants;
-import org.smartregister.Context;
-import org.smartregister.CoreLibrary;
 import org.smartregister.chw.anc.util.JsonFormUtils;
 import org.smartregister.chw.anc.util.NCUtils;
 import org.smartregister.chw.core.application.CoreChwApplication;
@@ -12,22 +9,13 @@ import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.core.utils.CoreReferralUtils;
 import org.smartregister.clientandeventmodel.Event;
 import org.smartregister.clientandeventmodel.Obs;
-import org.smartregister.domain.Location;
-import org.smartregister.domain.LocationTag;
 import org.smartregister.domain.Task;
-import org.smartregister.domain.jsonmapping.util.LocationTree;
-import org.smartregister.domain.jsonmapping.util.TreeNode;
 import org.smartregister.repository.AllSharedPreferences;
 import org.smartregister.repository.BaseRepository;
-import org.smartregister.repository.LocationRepository;
-import org.smartregister.repository.LocationTagRepository;
-import org.smartregister.util.AssetHandler;
 
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -131,98 +119,7 @@ public class ReferralUtils extends CoreReferralUtils {
     }
 
     private static String getWard() {
-        LocationRepository locationRepository = new LocationRepository();
-        List<Location> locations = locationRepository.getAllLocations();
-        String locationId = Context.getInstance().allSharedPreferences().getPreference(AllConstants.CURRENT_LOCATION_ID);
-
-        String locationData = CoreLibrary.getInstance().context().anmLocationController().get();
-        if (locationData == null || locationData.trim().isEmpty()) {
-            return getParentLocationIdWithTags(locations, locationId, "Ward");
-        }
-
-        try {
-            LocationTree locationTree = AssetHandler.jsonStringToJava(locationData, LocationTree.class);
-            if (locationTree == null || locationTree.getLocationsHierarchy() == null) {
-                return getParentLocationIdWithTags(locations, locationId, "Ward");
-            }
-
-            TreeNode<String, org.smartregister.domain.jsonmapping.Location> locationNode =
-                    findLocationNode(locationTree.getLocationsHierarchy(), locationId);
-            if (locationNode == null || locationNode.getParent() == null) {
-                return getParentLocationIdWithTags(locations, locationId, "Ward");
-            }
-
-            String parentLocationId = locationNode.getParent();
-            if (hasLocationTag(locations, parentLocationId, "Ward")) {
-                return parentLocationId;
-            }
-
-            return getParentLocationIdWithTags(locations, parentLocationId, "Ward");
-        } catch (Exception e) {
-            return getParentLocationIdWithTags(locations, locationId, "Ward");
-        }
-    }
-
-    private static TreeNode<String, org.smartregister.domain.jsonmapping.Location> findLocationNode(
-            LinkedHashMap<String, TreeNode<String, org.smartregister.domain.jsonmapping.Location>> locationMap,
-            String locationId) {
-        if (locationMap == null || locationId == null) {
-            return null;
-        }
-
-        for (Map.Entry<String, TreeNode<String, org.smartregister.domain.jsonmapping.Location>> entry : locationMap.entrySet()) {
-            TreeNode<String, org.smartregister.domain.jsonmapping.Location> treeNode = entry.getValue();
-            if (treeNode == null) {
-                continue;
-            }
-            if (locationId.equals(treeNode.getId())) {
-                return treeNode;
-            }
-
-            TreeNode<String, org.smartregister.domain.jsonmapping.Location> childTreeNode =
-                    findLocationNode(treeNode.getChildren(), locationId);
-            if (childTreeNode != null) {
-                return childTreeNode;
-            }
-        }
-        return null;
-    }
-
-    private static boolean hasLocationTag(List<Location> locations, String locationId, String tagName) {
-        LocationTagRepository locationTagReposity = new LocationTagRepository();
-        List<LocationTag> allLocationTags = locationTagReposity.getAllLocationTags();
-        for (Location location : locations) {
-            if (location.getId().equals(locationId)) {
-                for (LocationTag locationTag : allLocationTags) {
-                    if (locationId.equals(locationTag.getLocationId()) && tagName.equalsIgnoreCase(locationTag.getName())) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private static String getParentLocationIdWithTags(List<Location> locations, String locationId, String tagName) {
-        LocationTagRepository locationTagReposity = new LocationTagRepository();
-        List<LocationTag> allLocationTags = locationTagReposity.getAllLocationTags();
-        for (Location location : locations) {
-            List<LocationTag> locationTags = new ArrayList<>();
-            for (LocationTag locationTag : allLocationTags) {
-                if (locationTag.getLocationId().equals(location.getId())) {
-                    locationTags.add(locationTag);
-                }
-            }
-            if (location.getId().equals(locationId)) {
-                for (LocationTag locationTag : locationTags) {
-                    if (locationTag.getName().equalsIgnoreCase(tagName))
-                        return location.getId();
-                    else
-                        return getParentLocationIdWithTags(locations, location.getProperties().getParentId(), tagName);
-                }
-            }
-        }
-        return null;
+        return LocationUtils.getWard();
     }
 
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/job/ChwJobCreatorTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/job/ChwJobCreatorTest.java
@@ -1,0 +1,17 @@
+package org.smartregister.chw.job;
+
+import com.evernote.android.job.Job;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.job.SyncLocationsByLevelAndTagsServiceJob;
+
+public class ChwJobCreatorTest {
+
+    @Test
+    public void createReturnsChwLocationSyncJobForLocationSyncTag() {
+        Job job = new ChwJobCreator().create(SyncLocationsByLevelAndTagsServiceJob.TAG);
+
+        Assert.assertTrue(job instanceof ChwSyncLocationsByLevelAndTagsServiceJob);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/model/NavigationModelFlvTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/model/NavigationModelFlvTest.java
@@ -1,0 +1,46 @@
+package org.smartregister.chw.model;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.robolectric.util.ReflectionHelpers;
+import org.smartregister.chw.BaseUnitTest;
+import org.smartregister.chw.application.ChwApplication;
+import org.smartregister.chw.application.ChwApplicationFlv;
+import org.smartregister.chw.core.model.NavigationOption;
+import org.smartregister.chw.core.utils.CoreConstants;
+
+import java.util.List;
+
+public class NavigationModelFlvTest extends BaseUnitTest {
+
+    @After
+    public void tearDown() {
+        ReflectionHelpers.setStaticField(ChwApplication.class, "flavor", new ChwApplicationFlv());
+        NavigationModelFlv.resetNavigationOptions();
+    }
+
+    @Test
+    public void refreshNavigationOptionsRebuildsAddoItemVisibility() {
+        ChwApplicationFlv flavor = Mockito.spy(new ChwApplicationFlv());
+        ReflectionHelpers.setStaticField(ChwApplication.class, "flavor", flavor);
+
+        Mockito.doReturn(false).when(flavor).hasADDO();
+        List<NavigationOption> optionsWithoutAddo = NavigationModelFlv.refreshNavigationOptions();
+        Assert.assertFalse(hasMenuOption(optionsWithoutAddo, CoreConstants.DrawerMenu.ADDO_LINKAGE));
+
+        Mockito.doReturn(true).when(flavor).hasADDO();
+        List<NavigationOption> optionsWithAddo = NavigationModelFlv.refreshNavigationOptions();
+        Assert.assertTrue(hasMenuOption(optionsWithAddo, CoreConstants.DrawerMenu.ADDO_LINKAGE));
+    }
+
+    private boolean hasMenuOption(List<NavigationOption> navigationOptions, String menuTitle) {
+        for (NavigationOption navigationOption : navigationOptions) {
+            if (menuTitle.equals(navigationOption.getMenuTitle())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/sync/intent/ChwSyncLocationsByLevelAndTagsIntentServiceTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/sync/intent/ChwSyncLocationsByLevelAndTagsIntentServiceTest.java
@@ -1,0 +1,59 @@
+package org.smartregister.chw.sync.intent;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChwSyncLocationsByLevelAndTagsIntentServiceTest {
+
+    @Test
+    public void onHandleIntentNotifiesAfterSuccessfulLocationSync() {
+        TestSyncLocationsByLevelAndTagsIntentService service = new TestSyncLocationsByLevelAndTagsIntentService(false);
+
+        service.runSync();
+
+        Assert.assertTrue(service.syncStarted);
+        Assert.assertTrue(service.notified);
+    }
+
+    @Test
+    public void onHandleIntentDoesNotNotifyWhenLocationSyncFails() {
+        TestSyncLocationsByLevelAndTagsIntentService service = new TestSyncLocationsByLevelAndTagsIntentService(true);
+
+        service.runSync();
+
+        Assert.assertTrue(service.syncStarted);
+        Assert.assertFalse(service.notified);
+    }
+
+    private static class TestSyncLocationsByLevelAndTagsIntentService extends ChwSyncLocationsByLevelAndTagsIntentService {
+        private final boolean failSync;
+        private boolean syncStarted;
+        private boolean notified;
+
+        private TestSyncLocationsByLevelAndTagsIntentService(boolean failSync) {
+            this.failSync = failSync;
+        }
+
+        private void runSync() {
+            onHandleIntent(null);
+        }
+
+        @Override
+        protected void prepareSync(android.content.Intent intent) {
+            // no-op for unit test
+        }
+
+        @Override
+        protected void syncLocationsByLevelAndTags() throws Exception {
+            syncStarted = true;
+            if (failSync) {
+                throw new Exception("Location sync failed");
+            }
+        }
+
+        @Override
+        protected void notifyLocationSyncComplete() {
+            notified = true;
+        }
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/LocationUtilsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/LocationUtilsTest.java
@@ -1,0 +1,78 @@
+package org.smartregister.chw.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.domain.Location;
+import org.smartregister.domain.LocationProperty;
+import org.smartregister.domain.LocationTag;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class LocationUtilsTest {
+
+    @Test
+    public void hasADDOReturnsTrueWhenWardHasADDOTag() {
+        Location ward = location("ward-id", null);
+        List<LocationTag> locationTags = Collections.singletonList(locationTag("ward-id", "has_addo"));
+
+        Assert.assertTrue(LocationUtils.hasADDO(ward, locationTags));
+    }
+
+    @Test
+    public void hasADDOReturnsFalseWhenWardDoesNotHaveADDOTag() {
+        Location ward = location("ward-id", null);
+        List<LocationTag> locationTags = Collections.singletonList(locationTag("ward-id", "Ward"));
+
+        Assert.assertFalse(LocationUtils.hasADDO(ward, locationTags));
+    }
+
+    @Test
+    public void getWardReturnsCurrentLocationWhenCurrentLocationHasWardTag() {
+        Location ward = location("ward-id", "district-id");
+        List<LocationTag> locationTags = Collections.singletonList(locationTag("ward-id", "Ward"));
+
+        String wardId = LocationUtils.getWard(Collections.singletonList(ward), locationTags, "ward-id", null);
+
+        Assert.assertEquals("ward-id", wardId);
+    }
+
+    @Test
+    public void getWardReturnsParentWardWhenCurrentLocationIsBelowWard() {
+        Location ward = location("ward-id", "district-id");
+        Location village = location("village-id", "ward-id");
+        List<Location> locations = Arrays.asList(ward, village);
+        List<LocationTag> locationTags = Collections.singletonList(locationTag("ward-id", "Ward"));
+
+        String wardId = LocationUtils.getWard(locations, locationTags, "village-id", null);
+
+        Assert.assertEquals("ward-id", wardId);
+    }
+
+    @Test
+    public void getWardReturnsNullWhenWardCannotBeResolved() {
+        Location village = location("village-id", "missing-parent-id");
+
+        String wardId = LocationUtils.getWard(Collections.singletonList(village), Collections.<LocationTag>emptyList(), "village-id", null);
+
+        Assert.assertNull(wardId);
+    }
+
+    private Location location(String id, String parentId) {
+        Location location = new Location();
+        location.setId(id);
+
+        LocationProperty locationProperty = new LocationProperty();
+        locationProperty.setParentId(parentId);
+        location.setProperties(locationProperty);
+        return location;
+    }
+
+    private LocationTag locationTag(String locationId, String name) {
+        LocationTag locationTag = new LocationTag();
+        locationTag.setLocationId(locationId);
+        locationTag.setName(name);
+        return locationTag;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `LocationUtils` to resolve the current ward and check for the `has_addo` location tag.
- Route `ChwApplication.hasADDO()` and the default flavor ADDO check through the new location/tag-based implementation.
- Move NACP referral ward resolution to the shared utility.
- Add an app-owned location sync job/service that posts `LocationSyncCompleteEvent` only after `fetchLocationsByLevelAndTags()` succeeds.
- Rebuild cached NACP navigation options and notify the active drawer adapter when location sync completes so ADDO navigation visibility updates without app restart.

## Why

ADDO drawer visibility depends on `ChwApplication.getApplicationFlavor().hasADDO()`, which now relies on synced location tags. Without refreshing navigation after location sync, the drawer can keep stale ADDO visibility until the app is restarted.

## Validation

```bash
JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.util.LocationUtilsTest --tests org.smartregister.chw.application.CoreChwApplicationTest

JAVA_HOME="$(/usr/libexec/java_home -v 17)" ./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.sync.intent.ChwSyncLocationsByLevelAndTagsIntentServiceTest --tests org.smartregister.chw.job.ChwJobCreatorTest --tests org.smartregister.chw.model.NavigationModelFlvTest --tests org.smartregister.chw.application.CoreChwApplicationTest
```

Both focused test runs passed. The manifest still emits existing duplicate-service warnings, but they do not block compilation or tests.