### PR TITLE
Fix iCCM report derived totals

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/domain/iccm_reports/IccmClientsReportObject.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/domain/iccm_reports/IccmClientsReportObject.java
@@ -4,43 +4,39 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.smartregister.chw.dao.ReportDao;
 import org.smartregister.chw.domain.ReportObject;
-import java.util.ArrayList;
+
 import java.util.Date;
-import java.util.List;
 
 public class IccmClientsReportObject extends ReportObject {
-    private final List<String> indicatorCodesWithAgeGroups = new ArrayList<>();
-
     private static final String[] INDICATOR_CODES = {"iccm-1", "iccm-2", "iccm-3", "iccm-4", "iccm-5", "iccm-6"};
 
     private static final String[] INDICATOR_AGE_GROUPS = {"less-than-1-month", "less-than-1-year", "between-1-to-5-years", "between-5-to-60-years", "60-and-above-years"};
 
-    private static final String[] INDICATOR_SEX_GROUPS = {"ME", "KE", "jumla"};
+    private static final String MALE = "ME";
+    private static final String FEMALE = "KE";
+
+    private static final String[] INDICATOR_SEX_GROUPS = {MALE, FEMALE};
 
     private final Date reportDate;
 
     public IccmClientsReportObject(Date reportDate) {
         super(reportDate);
         this.reportDate = reportDate;
-        setIndicatorCodesWithAgeGroups();
-    }
-
-    private void setIndicatorCodesWithAgeGroups() {
-        for (String indicatorCode : INDICATOR_CODES) {
-            for (String indicatorKey : INDICATOR_AGE_GROUPS) {
-                for (String indicatorSex : INDICATOR_SEX_GROUPS) {
-                    indicatorCodesWithAgeGroups.add(indicatorCode + "-" + indicatorKey + "-" + indicatorSex);
-                }
-            }
-        }
     }
 
 
     @Override
     public JSONObject getIndicatorData() throws JSONException {
         JSONObject indicatorDataObject = new JSONObject();
-        for (String indicatorCode : indicatorCodesWithAgeGroups) {
-            indicatorDataObject.put(indicatorCode, ReportDao.getReportPerIndicatorCode(indicatorCode, reportDate));
+        for (String indicatorCode : INDICATOR_CODES) {
+            for (String ageGroup : INDICATOR_AGE_GROUPS) {
+                int maleCount = ReportDao.getReportPerIndicatorCode(indicatorCode + "-" + ageGroup + "-" + MALE, reportDate);
+                int femaleCount = ReportDao.getReportPerIndicatorCode(indicatorCode + "-" + ageGroup + "-" + FEMALE, reportDate);
+
+                indicatorDataObject.put(indicatorCode + "-" + ageGroup + "-" + MALE, maleCount);
+                indicatorDataObject.put(indicatorCode + "-" + ageGroup + "-" + FEMALE, femaleCount);
+                indicatorDataObject.put(indicatorCode + "-" + ageGroup + "-jumla", maleCount + femaleCount);
+            }
         }
 
         for (String indicatorCode : INDICATOR_CODES) {
@@ -58,7 +54,7 @@ public class IccmClientsReportObject extends ReportObject {
         for (String ageGroup : INDICATOR_AGE_GROUPS) {
             int sumMe = ReportDao.getReportPerIndicatorCode("iccm-2-" + ageGroup + "-ME", reportDate) + ReportDao.getReportPerIndicatorCode("iccm-3-" + ageGroup + "-ME", reportDate);
             int sumKe = ReportDao.getReportPerIndicatorCode("iccm-2-" + ageGroup + "-KE", reportDate) + ReportDao.getReportPerIndicatorCode("iccm-3-" + ageGroup + "-KE", reportDate);
-            int sumJumla = ReportDao.getReportPerIndicatorCode("iccm-2-" + ageGroup + "-jumla", reportDate) + ReportDao.getReportPerIndicatorCode("iccm-3-" + ageGroup + "-jumla", reportDate);
+            int sumJumla = sumMe + sumKe;
             sumMeJumla += sumMe;
             sumKeJumla += sumKe;
             indicatorDataObject.put("iccm-2+3-" + ageGroup + "-ME", sumMe);

--- a/opensrp-chw/src/test/java/org/smartregister/chw/domain/IccmClientsReportObjectTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/domain/IccmClientsReportObjectTest.java
@@ -1,0 +1,57 @@
+package org.smartregister.chw.domain;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.smartregister.chw.dao.ReportDao;
+import org.smartregister.chw.domain.iccm_reports.IccmClientsReportObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class IccmClientsReportObjectTest {
+
+    private Date reportDate;
+
+    @Before
+    public void setUp() throws ParseException {
+        reportDate = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse("2026-04-01");
+    }
+
+    @Test
+    public void testGetIndicatorDataDerivesIccmAgeAndSexTotals() throws JSONException {
+        try (MockedStatic<ReportDao> reportDao = Mockito.mockStatic(ReportDao.class)) {
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-1-less-than-1-month-ME", reportDate))
+                    .thenReturn(2);
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-1-less-than-1-month-KE", reportDate))
+                    .thenReturn(3);
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-2-less-than-1-month-ME", reportDate))
+                    .thenReturn(4);
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-2-less-than-1-month-KE", reportDate))
+                    .thenReturn(6);
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-3-less-than-1-month-ME", reportDate))
+                    .thenReturn(1);
+            reportDao.when(() -> ReportDao.getReportPerIndicatorCode("iccm-3-less-than-1-month-KE", reportDate))
+                    .thenReturn(2);
+
+            JSONObject indicatorData = new IccmClientsReportObject(reportDate).getIndicatorData();
+
+            assertEquals(5, indicatorData.getInt("iccm-1-less-than-1-month-jumla"));
+            assertEquals(2, indicatorData.getInt("iccm-1-ME-jumla"));
+            assertEquals(3, indicatorData.getInt("iccm-1-KE-jumla"));
+            assertEquals(5, indicatorData.getInt("iccm-1-jumla"));
+
+            assertEquals(5, indicatorData.getInt("iccm-2+3-less-than-1-month-ME"));
+            assertEquals(8, indicatorData.getInt("iccm-2+3-less-than-1-month-KE"));
+            assertEquals(13, indicatorData.getInt("iccm-2+3-less-than-1-month-jumla"));
+            assertEquals(13, indicatorData.getInt("iccm-2+3-jumla"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Derive iCCM client report `jumla` values from the YAML-backed `ME` and `KE` indicators instead of querying nonexistent `*-jumla` indicator codes.
- Fix the combined `iccm-2+3` age-group totals to use the computed male and female totals.
- Add a focused unit test covering derived `jumla` values and combined iCCM report totals.

## Root Cause

`iccm-monthly-report.yml` defines sex-specific indicators such as `ME` and `KE`, but it does not define separate `*-jumla` indicator codes. The report object queried `*-jumla` directly, so the UI could render zeros/blanks even when the underlying iCCM indicators had been computed and persisted correctly.

## Validation

- `JAVA_HOME=/Users/ilakozejumanne/Library/Java/JavaVirtualMachines/corretto-17.0.11/Contents/Home ./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.domain.IccmClientsReportObjectTest --console=plain`
- Built and installed the NACP debug app on `emulator-5554` with the companion patched core artifact.
- Logged in with `Johndeo` / `Afya2026`, opened Reports, and verified iCCM report screens rendered real values.
- Pulled `drishti.db`, read the stored SharedPreferences `CURRENT_LOCATION_ID` value, and used it as the SQLCipher passphrase.
- Verified iCCM `indicator_queries` count was 90 and iCCM `indicator_daily_tally` rows were present.
- Cross-checked selected YAML-backed SQL results against persisted tallies and UI values, including `iccm-2-less-than-1-month-ME = 9`, `iccm-2-less-than-1-month-KE = 9`, derived `jumla = 18`, and `iccm-dispensing-2-3-8 = 24`.

## Device Note

Attempted to create fresh iCCM data through the iCCHW module. The flow reached the iCCM Services visit location form and recorded GPS, but pressing Next hit an existing native form threading crash in the form/GPS validation path (`CalledFromWrongThreadException`). Existing device iCCM data was used to verify the report generation and rendering path.

## Companion Change

Depends on the runtime scheduling fix in https://github.com/Digital-Square-Tanzania/opensrp-client-chw-core/pull/69.