### PR TITLE
Fix Harm Reduction existing-client register visibility

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/HarmReductionMatClientsRegisterFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/HarmReductionMatClientsRegisterFragmentPresenter.java
@@ -20,7 +20,8 @@ public class HarmReductionMatClientsRegisterFragmentPresenter extends BaseHarmRe
 
     @Override
     public String getMainCondition() {
-        return getMainTable() + ".is_closed = 0 AND " + getMainTable() + ".client_started_mat = 'yes'";
+        return getMainTable() + ".is_closed = 0 AND (" + getMainTable() + ".client_started_mat = 'yes' OR " +
+                getMainTable() + ".follow_up_status = 'started_mat_services')";
     }
 
     @Override

--- a/opensrp-chw/src/test/java/org/smartregister/chw/presenter/HarmReductionMatClientsRegisterFragmentPresenterTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/presenter/HarmReductionMatClientsRegisterFragmentPresenterTest.java
@@ -1,0 +1,35 @@
+package org.smartregister.chw.presenter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.smartregister.chw.BaseUnitTest;
+import org.smartregister.chw.core.model.CoreHarmReductionRegisterFragmentModel;
+import org.smartregister.chw.harmreduction.contract.HarmReductionRegisterFragmentContract;
+
+public class HarmReductionMatClientsRegisterFragmentPresenterTest extends BaseUnitTest {
+
+    private HarmReductionMatClientsRegisterFragmentPresenter presenter;
+
+    @Mock
+    private HarmReductionRegisterFragmentContract.View view;
+
+    @Mock
+    private CoreHarmReductionRegisterFragmentModel model;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        presenter = new HarmReductionMatClientsRegisterFragmentPresenter(view, model, "");
+    }
+
+    @Test
+    public void testMainConditionFallsBackToFollowUpStatusWhenClientStartedMatIsBlank() {
+        Assert.assertEquals(
+                "ec_harm_reduction_risk_assessment.is_closed = 0 AND (ec_harm_reduction_risk_assessment.client_started_mat = 'yes' OR ec_harm_reduction_risk_assessment.follow_up_status = 'started_mat_services')",
+                presenter.getMainCondition()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- allow MAT register visibility when existing-client registrations only set follow-up status
- keep Harm Reduction register behavior aligned with existing-client registrations generated from the module flow
- add a presenter test covering existing-client follow-up visibility

## Testing
- ./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.presenter.HarmReductionMatClientsRegisterFragmentPresenterTest
- git diff --check

## Live validation
- logged into the NACP testing app with markchw/Nacp2022 on 2026-04-26
- confirmed the build reaches All Clients after authentication
- existing-client end-to-end validation remained blocked by an unrelated All Clients registration wizard save failure when creating a disposable client for the workflow