### PR TITLE
Fix Harm Reduction report and history issues

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
@@ -64,11 +64,7 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity extend
             "maskani_name",
             "collection_site_gps",
             "number_of_used_needles_and_syringes_collected",
-            "issues_challenges_related_to_collection_of_used_needles_and_syringes",
-            "total_safety_boxes_collected",
-            "other_collection",
-            "fixed_bins",
-            "name_of_ow"
+            "issues_challenges_related_to_collection_of_used_needles_and_syringes"
     };
 
     private final Flavor flavor = new UsedNeedlesAndSyringesCollectionDetailsActivityFlv();

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
@@ -329,9 +329,9 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
                 return;
             }
 
-            if (StringUtils.isNotBlank(getMapValue(vals, valueKey))) {
-                SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
-                spannableStringBuilder.append(context.getString(viewTitleStringResource), boldSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE).append("\n");
+                if (StringUtils.isNotBlank(getMapValue(vals, valueKey))) {
+                    SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+                    spannableStringBuilder.append(getViewTitle(context, vals, valueKey, viewTitleStringResource), boldSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE).append("\n");
 
                 List<String> parsedValues = parseHistoryValues(getMapValue(vals, valueKey));
                 if (parsedValues.size() > 1) {
@@ -345,8 +345,39 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
                 tv.setText(spannableStringBuilder);
             } else {
                 tv.setVisibility(View.GONE);
+                }
             }
-        }
+
+            private String getViewTitle(Context context, Map<String, String> vals, String valueKey, int viewTitleStringResource) {
+                String title = context.getString(viewTitleStringResource);
+                if (!isSubstanceUsedDisplayField(valueKey)) {
+                    return title;
+                }
+
+                String methods = getTranslatedMethods(context, getMapValue(vals, "substance_use_methods"));
+                if (StringUtils.isBlank(methods)) {
+                    return title;
+                }
+                return title + " (" + methods + ")";
+            }
+
+            private boolean isSubstanceUsedDisplayField(String valueKey) {
+                return SUBSTANCES_USED.equals(valueKey)
+                        || "substances_used_all".equals(valueKey)
+                        || "substances_used_injecting_only".equals(valueKey)
+                        || "substances_used_non_injecting_only".equals(valueKey);
+            }
+
+            private String getTranslatedMethods(Context context, String rawMethods) {
+                List<String> translatedMethods = new ArrayList<>();
+                for (String method : parseHistoryValues(rawMethods)) {
+                    String translatedMethod = getStringResource(context, method);
+                    if (StringUtils.isNotBlank(translatedMethod)) {
+                        translatedMethods.add(translatedMethod);
+                    }
+                }
+                return StringUtils.join(translatedMethods, " / ");
+            }
 
         private String getMapValue(Map<String, String> map, String key) {
             if (map.containsKey(key)) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObject.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObject.java
@@ -1,50 +1,371 @@
 package org.smartregister.chw.domain.harm_reduction_reports;
 
+import androidx.annotation.NonNull;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.smartregister.chw.dao.ReportDao;
 import org.smartregister.chw.domain.ReportObject;
 
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class HarmReductionReportObject extends ReportObject {
-    private final Date reportDate;
 
-    private final List<String> indicatorCodes = Arrays.asList(
-            "hr-1",
-            "hr-2",
-            "hr-3",
-            "hr-4",
-            "hr-5",
-            "hr-6",
-            "hr-7",
-            "hr-8",
-            "hr-9",
-            "hr-10",
-            "hr-11",
-            "hr-12",
-            "hr-12a",
-            "hr-12b",
-            "hr-12c",
-            "hr-12d",
-            "hr-12e",
-            "hr-13",
-            "hr-14"
-    );
+    private static final SimpleDateFormat QUERY_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH);
+
+    private static final String RISK_ASSESSMENT_ID_COLUMN = "ehra.base_entity_id";
+    private static final String FOLLOWUP_ID_COLUMN = "ehfv.entity_id";
+    private static final String SOURCE_ID_COLUMN = "source.client_id";
+
+    private static final String FAMILY_MEMBER_JOIN = " LEFT JOIN ec_family_member efm ";
+    private static final String RISK_ASSESSMENT_FROM_CLAUSE =
+            "ec_harm_reduction_risk_assessment ehra" + FAMILY_MEMBER_JOIN +
+                    "ON efm.base_entity_id = ehra.base_entity_id AND efm.date_removed IS NULL";
+    private static final String FOLLOWUP_FROM_CLAUSE =
+            "ec_harm_reduction_followup_visit ehfv" + FAMILY_MEMBER_JOIN +
+                    "ON efm.base_entity_id = ehfv.entity_id AND efm.date_removed IS NULL";
+    private static final String MAT_REFERRAL_FROM_CLAUSE =
+            "(SELECT ehfv.entity_id AS client_id, " +
+                    "CASE WHEN lower(ifnull(ehfv.is_idu, '')) = 'yes' OR lower(ifnull(ehfv.substance_use_methods, '')) LIKE '%injecting%' " +
+                    "THEN 'idu' ELSE 'nidu' END AS roc_group_type, " +
+                    "ehfv.last_interacted_with AS last_interacted_with " +
+                    "FROM ec_harm_reduction_followup_visit ehfv " +
+                    "WHERE lower(ifnull(ehfv.referrals_provided, '')) LIKE '%methadone_services%' " +
+                    "OR lower(ifnull(ehfv.roc_consent_joining_mat_services, '')) = 'yes' " +
+                    "UNION " +
+                    "SELECT ehra.base_entity_id AS client_id, " +
+                    "CASE WHEN lower(ifnull(ehra.roc_group_type, '')) = 'idu' OR lower(ifnull(ehra.route_of_substance_use, '')) LIKE '%injecting%' " +
+                    "THEN 'idu' ELSE 'nidu' END AS roc_group_type, " +
+                    "ehra.last_interacted_with AS last_interacted_with " +
+                    "FROM ec_harm_reduction_risk_assessment ehra " +
+                    "WHERE lower(ifnull(ehra.client_started_mat, '')) = 'yes') source" + FAMILY_MEMBER_JOIN +
+                    "ON efm.base_entity_id = source.client_id AND efm.date_removed IS NULL";
+
+    private static final String RISK_ASSESSMENT_IDU_CONDITION =
+            "(lower(ifnull(ehra.roc_group_type, '')) = 'idu' OR lower(ifnull(ehra.route_of_substance_use, '')) LIKE '%injecting%')";
+    private static final String RISK_ASSESSMENT_NIDU_CONDITION =
+            "NOT " + RISK_ASSESSMENT_IDU_CONDITION;
+    private static final String FOLLOWUP_IDU_CONDITION =
+            "(lower(ifnull(ehfv.is_idu, '')) = 'yes' OR lower(ifnull(ehfv.substance_use_methods, '')) LIKE '%injecting%')";
+    private static final String FOLLOWUP_NIDU_CONDITION =
+            "NOT " + FOLLOWUP_IDU_CONDITION;
+    private static final String SOURCE_IDU_CONDITION =
+            "lower(ifnull(source.roc_group_type, '')) = 'idu'";
+    private static final String SOURCE_NIDU_CONDITION =
+            "lower(ifnull(source.roc_group_type, '')) = 'nidu'";
+
+    private static final String RECEIVED_HR_SERVICE_CONDITION =
+            "(trim(ifnull(ehfv.health_education_provided, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.iec_materials_provided, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.safe_injection_tools, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.referrals_provided, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.hiv_tested, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.tb_screening, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.stds_screening, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.hepatitis_bc_screening, '')) <> '')";
+    private static final String IDU_RECEIVED_SYRINGES_CONDITION =
+            FOLLOWUP_IDU_CONDITION + " AND (" +
+                    "lower(ifnull(ehfv.safe_injection_tools, '')) LIKE '%syringes%' OR " +
+                    numericExpression("ehfv.qty_syringes") + " > 0)";
+
+    private static final List<BreakdownColumn> BREAKDOWN_COLUMNS = createBreakdownColumns();
+    private static final List<String> RESULT_COLUMNS = createResultColumns();
+    private static final List<IndicatorDefinition> INDICATOR_DEFINITIONS = createIndicatorDefinitions();
 
     public HarmReductionReportObject(Date reportDate) {
         super(reportDate);
-        this.reportDate = reportDate;
     }
 
     @Override
     public JSONObject getIndicatorData() throws JSONException {
         JSONObject indicatorDataObject = new JSONObject();
-        for (String indicatorCode : indicatorCodes) {
-            indicatorDataObject.put(indicatorCode, ReportDao.getReportPerIndicatorCode(indicatorCode, reportDate));
+        String reportMonth = QUERY_DATE_FORMAT.format(getReportDate());
+
+        for (IndicatorDefinition definition : INDICATOR_DEFINITIONS) {
+            Map<String, Integer> breakdown = ReportDao.getReportBreakdown(
+                    buildIndicatorQuery(definition, reportMonth),
+                    RESULT_COLUMNS
+            );
+            putIndicatorValues(indicatorDataObject, definition.getKey(), breakdown);
         }
+
         return indicatorDataObject;
+    }
+
+    private void putIndicatorValues(JSONObject indicatorDataObject, String indicatorKey, Map<String, Integer> breakdown) throws JSONException {
+        indicatorDataObject.put(indicatorKey, getValueOrZero(breakdown, "total"));
+        for (BreakdownColumn breakdownColumn : BREAKDOWN_COLUMNS) {
+            indicatorDataObject.put(
+                    indicatorKey + "-" + breakdownColumn.getJsonSuffix(),
+                    getValueOrZero(breakdown, breakdownColumn.getColumnAlias())
+            );
+        }
+    }
+
+    private int getValueOrZero(Map<String, Integer> breakdown, String key) {
+        Integer value = breakdown.get(key);
+        return value == null ? 0 : value;
+    }
+
+    @NonNull
+    private String buildIndicatorQuery(IndicatorDefinition definition, String reportMonth) {
+        StringBuilder queryBuilder = new StringBuilder("SELECT ");
+        appendAggregateSelect(queryBuilder, definition, "1 = 1", "total");
+
+        String ageExpression = buildAgeExpression(reportMonth);
+        for (BreakdownColumn breakdownColumn : BREAKDOWN_COLUMNS) {
+            queryBuilder.append(", ");
+            appendAggregateSelect(
+                    queryBuilder,
+                    definition,
+                    breakdownColumn.getCondition(definition, ageExpression),
+                    breakdownColumn.getColumnAlias()
+            );
+        }
+
+        queryBuilder.append(" FROM ")
+                .append(definition.getFromClause())
+                .append(" WHERE ")
+                .append(definition.getWhereClause())
+                .append(" AND ")
+                .append(buildMonthClause(definition.getMonthColumn(), reportMonth));
+
+        return queryBuilder.toString();
+    }
+
+    private void appendAggregateSelect(StringBuilder queryBuilder,
+                                       IndicatorDefinition definition,
+                                       String condition,
+                                       String alias) {
+        if (definition.isSum()) {
+            queryBuilder.append("COALESCE(SUM(CASE WHEN ")
+                    .append(condition)
+                    .append(" THEN ")
+                    .append(definition.getValueExpression())
+                    .append(" ELSE 0 END), 0) AS ")
+                    .append(alias);
+            return;
+        }
+
+        queryBuilder.append("COUNT(DISTINCT CASE WHEN ")
+                .append(condition)
+                .append(" THEN ")
+                .append(definition.getIdColumn())
+                .append(" END) AS ")
+                .append(alias);
+    }
+
+    @NonNull
+    private String buildAgeExpression(String reportMonth) {
+        return "CAST((julianday(date('" + reportMonth + "', 'start of month', '+1 month', '-1 day')) - " +
+                "julianday(efm.dob)) / 365.25 AS INTEGER)";
+    }
+
+    @NonNull
+    private String buildMonthClause(String monthColumn, String reportMonth) {
+        return "strftime('%Y-%m', datetime(" + monthColumn + " / 1000, 'unixepoch', 'localtime')) = " +
+                "strftime('%Y-%m', '" + reportMonth + "')";
+    }
+
+    private static String numericExpression(String column) {
+        return "CAST(CASE WHEN trim(ifnull(" + column + ", '')) = '' THEN '0' ELSE " + column + " END AS INTEGER)";
+    }
+
+    @NonNull
+    private static List<BreakdownColumn> createBreakdownColumns() {
+        return Collections.unmodifiableList(Arrays.asList(
+                new BreakdownColumn("idu_female_le_15", "idu-female-le-15", "idu", "lower(ifnull(efm.gender, '')) = 'female' AND %s <= 15"),
+                new BreakdownColumn("idu_female_15_24", "idu-female-15-24", "idu", "lower(ifnull(efm.gender, '')) = 'female' AND %s BETWEEN 16 AND 24"),
+                new BreakdownColumn("idu_female_25_49", "idu-female-25-49", "idu", "lower(ifnull(efm.gender, '')) = 'female' AND %s BETWEEN 25 AND 49"),
+                new BreakdownColumn("idu_female_50_plus", "idu-female-50-plus", "idu", "lower(ifnull(efm.gender, '')) = 'female' AND %s >= 50"),
+                new BreakdownColumn("idu_female_total", "idu-female-total", "idu", "lower(ifnull(efm.gender, '')) = 'female'"),
+                new BreakdownColumn("idu_male_le_18", "idu-male-le-18", "idu", "lower(ifnull(efm.gender, '')) = 'male' AND %s <= 18"),
+                new BreakdownColumn("idu_male_19_24", "idu-male-19-24", "idu", "lower(ifnull(efm.gender, '')) = 'male' AND %s BETWEEN 19 AND 24"),
+                new BreakdownColumn("idu_male_25_49", "idu-male-25-49", "idu", "lower(ifnull(efm.gender, '')) = 'male' AND %s BETWEEN 25 AND 49"),
+                new BreakdownColumn("idu_male_50_plus", "idu-male-50-plus", "idu", "lower(ifnull(efm.gender, '')) = 'male' AND %s >= 50"),
+                new BreakdownColumn("idu_male_total", "idu-male-total", "idu", "lower(ifnull(efm.gender, '')) = 'male'"),
+                new BreakdownColumn("idu_total", "idu-total", "idu", "1 = 1"),
+                new BreakdownColumn("nidu_female_le_15", "nidu-female-le-15", "nidu", "lower(ifnull(efm.gender, '')) = 'female' AND %s <= 15"),
+                new BreakdownColumn("nidu_female_15_24", "nidu-female-15-24", "nidu", "lower(ifnull(efm.gender, '')) = 'female' AND %s BETWEEN 16 AND 24"),
+                new BreakdownColumn("nidu_female_25_49", "nidu-female-25-49", "nidu", "lower(ifnull(efm.gender, '')) = 'female' AND %s BETWEEN 25 AND 49"),
+                new BreakdownColumn("nidu_female_50_plus", "nidu-female-50-plus", "nidu", "lower(ifnull(efm.gender, '')) = 'female' AND %s >= 50"),
+                new BreakdownColumn("nidu_female_total", "nidu-female-total", "nidu", "lower(ifnull(efm.gender, '')) = 'female'"),
+                new BreakdownColumn("nidu_male_le_15", "nidu-male-le-15", "nidu", "lower(ifnull(efm.gender, '')) = 'male' AND %s <= 15"),
+                new BreakdownColumn("nidu_male_15_24", "nidu-male-15-24", "nidu", "lower(ifnull(efm.gender, '')) = 'male' AND %s BETWEEN 16 AND 24"),
+                new BreakdownColumn("nidu_male_25_49", "nidu-male-25-49", "nidu", "lower(ifnull(efm.gender, '')) = 'male' AND %s BETWEEN 25 AND 49"),
+                new BreakdownColumn("nidu_male_50_plus", "nidu-male-50-plus", "nidu", "lower(ifnull(efm.gender, '')) = 'male' AND %s >= 50"),
+                new BreakdownColumn("nidu_male_total", "nidu-male-total", "nidu", "lower(ifnull(efm.gender, '')) = 'male'"),
+                new BreakdownColumn("nidu_total", "nidu-total", "nidu", "1 = 1")
+        ));
+    }
+
+    @NonNull
+    private static List<String> createResultColumns() {
+        return Collections.unmodifiableList(Arrays.asList(
+                "total",
+                "idu_female_le_15",
+                "idu_female_15_24",
+                "idu_female_25_49",
+                "idu_female_50_plus",
+                "idu_female_total",
+                "idu_male_le_18",
+                "idu_male_19_24",
+                "idu_male_25_49",
+                "idu_male_50_plus",
+                "idu_male_total",
+                "idu_total",
+                "nidu_female_le_15",
+                "nidu_female_15_24",
+                "nidu_female_25_49",
+                "nidu_female_50_plus",
+                "nidu_female_total",
+                "nidu_male_le_15",
+                "nidu_male_15_24",
+                "nidu_male_25_49",
+                "nidu_male_50_plus",
+                "nidu_male_total",
+                "nidu_total"
+        ));
+    }
+
+    @NonNull
+    private static List<IndicatorDefinition> createIndicatorDefinitions() {
+        return Collections.unmodifiableList(Arrays.asList(
+                riskAssessmentCount("hr-1", "ifnull(ehra.is_closed, 0) = 0"),
+                followupCount("hr-2", RECEIVED_HR_SERVICE_CONDITION),
+                riskAssessmentCount("hr-3", "lower(ifnull(ehra.client_status, '')) IN ('new_client', 'new')"),
+                followupCount("hr-4", IDU_RECEIVED_SYRINGES_CONDITION),
+                followupSum("hr-5", "1 = 1", numericExpression("ehfv.qty_syringes")),
+                followupSum("hr-6", "1 = 1", numericExpression("ehfv.qty_needles")),
+                new IndicatorDefinition("hr-7", MAT_REFERRAL_FROM_CLAUSE, SOURCE_ID_COLUMN, "source.last_interacted_with",
+                        "1 = 1", SOURCE_IDU_CONDITION, SOURCE_NIDU_CONDITION, null),
+                followupCount("hr-8", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hiv_testing%' OR lower(ifnull(ehfv.hiv_tested, '')) = 'yes')"),
+                followupCount("hr-9", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%tb_leprosy%' OR lower(ifnull(ehfv.tb_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
+                followupCount("hr-10", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%stis_stds%' OR lower(ifnull(ehfv.stds_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
+                followupCount("hr-11", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hepatitis_bc%' OR lower(ifnull(ehfv.hepatitis_bc_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
+                followupCount("hr-12", "trim(ifnull(ehfv.referrals_provided, '')) <> '' AND lower(ifnull(ehfv.referrals_provided, '')) NOT LIKE '%none%'"),
+                followupCount("hr-12a", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%income_generating%'"),
+                followupCount("hr-12b", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%sober_house%'"),
+                followupCount("hr-12c", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%mental_health%'"),
+                followupCount("hr-12d", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%legal_issues%'"),
+                followupCount("hr-12e", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%other%' OR trim(ifnull(ehfv.referrals_other_specify, '')) <> '')"),
+                followupCount("hr-13", "(lower(ifnull(ehfv.client_status, '')) LIKE '%overdose%' OR lower(ifnull(ehfv.cause_of_death, '')) LIKE '%overdose%')"),
+                followupCount("hr-14", "lower(ifnull(ehfv.client_status, '')) LIKE '%client_deceased%' AND lower(ifnull(ehfv.cause_of_death, '')) LIKE '%overdose%'")
+        ));
+    }
+
+    private static IndicatorDefinition riskAssessmentCount(String key, String whereClause) {
+        return new IndicatorDefinition(key, RISK_ASSESSMENT_FROM_CLAUSE, RISK_ASSESSMENT_ID_COLUMN, "ehra.last_interacted_with",
+                whereClause, RISK_ASSESSMENT_IDU_CONDITION, RISK_ASSESSMENT_NIDU_CONDITION, null);
+    }
+
+    private static IndicatorDefinition followupCount(String key, String whereClause) {
+        return new IndicatorDefinition(key, FOLLOWUP_FROM_CLAUSE, FOLLOWUP_ID_COLUMN, "ehfv.last_interacted_with",
+                whereClause, FOLLOWUP_IDU_CONDITION, FOLLOWUP_NIDU_CONDITION, null);
+    }
+
+    private static IndicatorDefinition followupSum(String key, String whereClause, String valueExpression) {
+        return new IndicatorDefinition(key, FOLLOWUP_FROM_CLAUSE, FOLLOWUP_ID_COLUMN, "ehfv.last_interacted_with",
+                whereClause, FOLLOWUP_IDU_CONDITION, FOLLOWUP_NIDU_CONDITION, valueExpression);
+    }
+
+    private static class BreakdownColumn {
+        private final String columnAlias;
+        private final String jsonSuffix;
+        private final String groupType;
+        private final String conditionTemplate;
+
+        BreakdownColumn(String columnAlias, String jsonSuffix, String groupType, String conditionTemplate) {
+            this.columnAlias = columnAlias;
+            this.jsonSuffix = jsonSuffix;
+            this.groupType = groupType;
+            this.conditionTemplate = conditionTemplate;
+        }
+
+        String getColumnAlias() {
+            return columnAlias;
+        }
+
+        String getJsonSuffix() {
+            return jsonSuffix;
+        }
+
+        String getCondition(IndicatorDefinition definition, String ageExpression) {
+            String groupCondition = "idu".equals(groupType)
+                    ? definition.getIduCondition()
+                    : definition.getNiduCondition();
+            return groupCondition + " AND " + String.format(Locale.ENGLISH, conditionTemplate, ageExpression);
+        }
+    }
+
+    private static class IndicatorDefinition {
+        private final String key;
+        private final String fromClause;
+        private final String idColumn;
+        private final String monthColumn;
+        private final String whereClause;
+        private final String iduCondition;
+        private final String niduCondition;
+        private final String valueExpression;
+
+        IndicatorDefinition(String key,
+                            String fromClause,
+                            String idColumn,
+                            String monthColumn,
+                            String whereClause,
+                            String iduCondition,
+                            String niduCondition,
+                            String valueExpression) {
+            this.key = key;
+            this.fromClause = fromClause;
+            this.idColumn = idColumn;
+            this.monthColumn = monthColumn;
+            this.whereClause = whereClause;
+            this.iduCondition = iduCondition;
+            this.niduCondition = niduCondition;
+            this.valueExpression = valueExpression;
+        }
+
+        String getKey() {
+            return key;
+        }
+
+        String getFromClause() {
+            return fromClause;
+        }
+
+        String getIdColumn() {
+            return idColumn;
+        }
+
+        String getMonthColumn() {
+            return monthColumn;
+        }
+
+        String getWhereClause() {
+            return whereClause;
+        }
+
+        String getIduCondition() {
+            return iduCondition;
+        }
+
+        String getNiduCondition() {
+            return niduCondition;
+        }
+
+        String getValueExpression() {
+            return valueExpression;
+        }
+
+        boolean isSum() {
+            return valueExpression != null;
+        }
     }
 }

--- a/opensrp-chw/src/nacp/assets/reports/harm_reduction_reports/harm-reduction-report.html
+++ b/opensrp-chw/src/nacp/assets/reports/harm_reduction_reports/harm-reduction-report.html
@@ -35,6 +35,10 @@
             margin-top: 10px;
         }
 
+        .report-table {
+            min-width: 1800px;
+        }
+
         th,
         td {
             border: 1px solid #000;
@@ -60,7 +64,11 @@
 
         .value-cell {
             text-align: center;
-            width: 100px;
+            min-width: 56px;
+        }
+
+        .indicator-cell {
+            min-width: 360px;
         }
     </style>
 </head>
@@ -69,44 +77,160 @@
 <h2>Taarifa ya [Mwezi/Mwaka]: <span id="report_period"></span></h2>
 <h2>Kituo: <span id="reporting_facility"></span></h2>
 
-<table>
+<table class="report-table">
     <thead>
     <tr>
-        <th style="width: 60px;">S/N</th>
-        <th>Kiashiria</th>
-        <th style="width: 110px;">Jumla</th>
+        <th rowspan="4" style="width: 45px;">S/N</th>
+        <th rowspan="4" class="indicator-cell">Kiashiria</th>
+        <th rowspan="4">Jumla</th>
+        <th colspan="11">IDU</th>
+        <th colspan="10">NIDU</th>
+    </tr>
+    <tr>
+        <th colspan="5">Wanawake (KE)</th>
+        <th colspan="5">Wanaume (ME)</th>
+        <th rowspan="3">Jumla IDU</th>
+        <th colspan="5">Wanawake (KE)</th>
+        <th colspan="5">Wanaume (ME)</th>
+    </tr>
+    <tr>
+        <th colspan="4">Umri</th>
+        <th rowspan="2">Jumla (KE)</th>
+        <th colspan="4">Umri</th>
+        <th rowspan="2">Jumla (ME)</th>
+        <th colspan="4">Umri</th>
+        <th rowspan="2">Jumla (KE)</th>
+        <th colspan="4">Umri</th>
+        <th rowspan="2">Jumla (ME)</th>
+    </tr>
+    <tr>
+        <th>&lt;=15</th>
+        <th>15-24</th>
+        <th>25-49</th>
+        <th>&gt;=50</th>
+        <th>&lt;=18</th>
+        <th>19-24</th>
+        <th>25-49</th>
+        <th>&gt;=50</th>
+        <th>&lt;=15</th>
+        <th>15-24</th>
+        <th>25-49</th>
+        <th>&gt;=50</th>
+        <th>&lt;=15</th>
+        <th>15-24</th>
+        <th>25-49</th>
+        <th>&gt;=50</th>
     </tr>
     </thead>
-    <tbody>
-    <tr class="section-row"><td colspan="3">Matokeo 1: Ufikiaji wa wanufaika katika maeneo lengwa ya mradi</td></tr>
-    <tr><td>1</td><td>Idadi ya PWUD waliowahi kuandikishwa katika huduma za Kupunguza Madhara (HR) katika ngazi ya jamii</td><td id="hr-1" class="value-cell"></td></tr>
-    <tr><td>2</td><td>Idadi ya PWUD waliopokea angalau huduma moja ya Kupunguza Madhara (HR) katika ngazi ya jamii</td><td id="hr-2" class="value-cell"></td></tr>
-    <tr><td>3</td><td>Idadi ya PWUD wapya walioandikishwa</td><td id="hr-3" class="value-cell"></td></tr>
-
-    <tr class="section-row"><td colspan="3">Matokeo 2: Utoaji na ukusanyaji wa vifaa vya kinga kwa wanufaika kwa kiwango cha kutosha</td></tr>
-    <tr><td>4</td><td>Idadi ya IDU waliopokea sindano katika kipindi cha ripoti</td><td id="hr-4" class="value-cell"></td></tr>
-    <tr><td>5</td><td>Idadi ya sindano (NS) zilizogawanywa</td><td id="hr-5" class="value-cell"></td></tr>
-    <tr><td>6</td><td>Idadi ya sindano (NS) zilizotumika zilizokusanywa na kutupwa</td><td id="hr-6" class="value-cell"></td></tr>
-
-    <tr class="section-row"><td colspan="3">Matokeo 3: Kuimarishwa kwa upatikanaji wa huduma na rufaa kulingana na mahitaji ya walengwa</td></tr>
-    <tr><td>7</td><td>Idadi ya PWUD waliotayarishwa na kupewa rufaa ya MAT</td><td id="hr-7" class="value-cell"></td></tr>
-    <tr><td>8</td><td>Idadi ya PWUD ambao wamehamasishwa na kupewa rufaa ya upimaji wa VVU</td><td id="hr-8" class="value-cell"></td></tr>
-    <tr><td>9</td><td>Idadi ya PWUD ambao wamechunguzwa na kupewa rufaa ya upimaji wa Kifua Kikuu</td><td id="hr-9" class="value-cell"></td></tr>
-    <tr><td>10</td><td>Idadi ya PWUD ambao wamepatiwa elimu na/au wamechunguzwa na kupewa rufaa ya upimaji wa Magonjwa ya Zinaa</td><td id="hr-10" class="value-cell"></td></tr>
-    <tr><td>11</td><td>Idadi ya PWUD ambao wamehamasishwa na kupewa rufaa kwa upimaji na chanjo ya Homa ya Ini</td><td id="hr-11" class="value-cell"></td></tr>
-    <tr><td>12</td><td>Idadi ya PWUD ambao wamepokea au kupewa rufaa ya huduma nyingine</td><td id="hr-12" class="value-cell"></td></tr>
-    <tr class="sub-row"><td>12a</td><td>Walioshiriki katika shughuli za kuzalisha kipato (IGA)</td><td id="hr-12a" class="value-cell"></td></tr>
-    <tr class="sub-row"><td>12b</td><td>Waliounganishwa na nyumba za upataji nafuu wa dawa za kulevya</td><td id="hr-12b" class="value-cell"></td></tr>
-    <tr class="sub-row"><td>12c</td><td>Afya ya Akili</td><td id="hr-12c" class="value-cell"></td></tr>
-    <tr class="sub-row"><td>12d</td><td>Msaada wa kisheria</td><td id="hr-12d" class="value-cell"></td></tr>
-    <tr class="sub-row"><td>12e</td><td>Huduma Nyinginezo</td><td id="hr-12e" class="value-cell"></td></tr>
-    <tr><td>13</td><td>Idadi ya kesi za kuzidisha kiasi cha dawa kinachohitajiwa zilizoripotiwa katika jamii</td><td id="hr-13" class="value-cell"></td></tr>
-    <tr><td>14</td><td>Idadi ya vifo vilivyosababishwa na kuzidisha kiasi cha dawa kinachohitajiwa vilivyoripotiwa katika jamii</td><td id="hr-14" class="value-cell"></td></tr>
-    </tbody>
+    <tbody id="report_body"></tbody>
 </table>
 
 <script>
+    const breakdownColumns = [
+        "idu-female-le-15",
+        "idu-female-15-24",
+        "idu-female-25-49",
+        "idu-female-50-plus",
+        "idu-female-total",
+        "idu-male-le-18",
+        "idu-male-19-24",
+        "idu-male-25-49",
+        "idu-male-50-plus",
+        "idu-male-total",
+        "idu-total",
+        "nidu-female-le-15",
+        "nidu-female-15-24",
+        "nidu-female-25-49",
+        "nidu-female-50-plus",
+        "nidu-female-total",
+        "nidu-male-le-15",
+        "nidu-male-15-24",
+        "nidu-male-25-49",
+        "nidu-male-50-plus",
+        "nidu-male-total"
+    ];
+
+    const reportSections = [
+        {
+            title: "Matokeo 1: Ufikiaji wa wanufaika katika maeneo lengwa ya mradi",
+            rows: [
+                ["1", "hr-1", "Idadi ya PWUD waliowahi kuandikishwa katika huduma za Kupunguza Madhara (HR) katika ngazi ya jamii"],
+                ["2", "hr-2", "Idadi ya PWUD waliopokea angalau huduma moja ya Kupunguza Madhara (HR) katika ngazi ya jamii"],
+                ["3", "hr-3", "Idadi ya PWUD wapya walioandikishwa"]
+            ]
+        },
+        {
+            title: "Matokeo 2: Utoaji na ukusanyaji wa vifaa vya kinga kwa wanufaika kwa kiwango cha kutosha",
+            rows: [
+                ["4", "hr-4", "Idadi ya IDU waliopokea sindano katika kipindi cha ripoti"],
+                ["5", "hr-5", "Idadi ya sindano (NS) zilizogawanywa"],
+                ["6", "hr-6", "Idadi ya sindano (NS) zilizotumika zilizokusanywa na kutupwa"]
+            ]
+        },
+        {
+            title: "Matokeo 3: Kuimarishwa kwa upatikanaji wa huduma na rufaa kulingana na mahitaji ya walengwa",
+            rows: [
+                ["7", "hr-7", "Idadi ya PWUD waliotayarishwa na kupewa rufaa ya MAT"],
+                ["8", "hr-8", "Idadi ya PWUD ambao wamehamasishwa na kupewa rufaa ya upimaji wa VVU"],
+                ["9", "hr-9", "Idadi ya PWUD ambao wamechunguzwa na kupewa rufaa ya upimaji wa Kifua Kikuu"],
+                ["10", "hr-10", "Idadi ya PWUD ambao wamepatiwa elimu na/au wamechunguzwa na kupewa rufaa ya upimaji wa Magonjwa ya Zinaa"],
+                ["11", "hr-11", "Idadi ya PWUD ambao wamehamasishwa na kupewa rufaa kwa upimaji na chanjo ya Homa ya Ini"],
+                ["12", "hr-12", "Idadi ya PWUD ambao wamepokea au kupewa rufaa ya huduma nyingine"],
+                ["12a", "hr-12a", "Walioshiriki katika shughuli za kuzalisha kipato (IGA)"],
+                ["12b", "hr-12b", "Waliounganishwa na nyumba za upataji nafuu wa dawa za kulevya"],
+                ["12c", "hr-12c", "Afya ya Akili"],
+                ["12d", "hr-12d", "Msaada wa kisheria"],
+                ["12e", "hr-12e", "Huduma Nyinginezo"],
+                ["13", "hr-13", "Idadi ya kesi za kuzidisha kiasi cha dawa kinachohitajiwa zilizoripotiwa katika jamii"],
+                ["14", "hr-14", "Idadi ya vifo vilivyosababishwa na kuzidisha kiasi cha dawa kinachohitajiwa vilivyoripotiwa katika jamii"]
+            ]
+        }
+    ];
+
+    function renderReportRows() {
+        const tbody = document.getElementById("report_body");
+        if (!tbody || tbody.children.length > 0) {
+            return;
+        }
+
+        reportSections.forEach((section) => {
+            const sectionRow = document.createElement("tr");
+            sectionRow.className = "section-row";
+            const sectionCell = document.createElement("td");
+            sectionCell.colSpan = 24;
+            sectionCell.innerHTML = section.title;
+            sectionRow.appendChild(sectionCell);
+            tbody.appendChild(sectionRow);
+
+            section.rows.forEach((row) => {
+                const reportRow = document.createElement("tr");
+                const serialCell = document.createElement("td");
+                serialCell.innerHTML = row[0];
+                reportRow.appendChild(serialCell);
+
+                const indicatorCell = document.createElement("td");
+                indicatorCell.className = "indicator-cell";
+                indicatorCell.innerHTML = row[2];
+                reportRow.appendChild(indicatorCell);
+
+                const totalCell = document.createElement("td");
+                totalCell.id = row[1];
+                totalCell.className = "value-cell";
+                reportRow.appendChild(totalCell);
+
+                breakdownColumns.forEach((column) => {
+                    const valueCell = document.createElement("td");
+                    valueCell.id = row[1] + "-" + column;
+                    valueCell.className = "value-cell";
+                    reportRow.appendChild(valueCell);
+                });
+                tbody.appendChild(reportRow);
+            });
+        });
+    }
+
     function loadData() {
+        renderReportRows();
         const data = JSON.parse(Android.getData("clients-monthly-report") || "{}");
         const values = data.nameValuePairs || {};
         const keys = Object.keys(values);

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -699,7 +699,7 @@
     <string name="harm_reduction_cause_of_death_other_specify">Taja sababu nyingine ya kifo</string>
     <string name="harm_reduction_client_deceased">Amefariki</string>
     <string name="harm_reduction_client_started_mat">Je, mpokea huduma ameanza MAT?</string>
-    <string name="harm_reduction_cocaine">Cocaine</string>
+    <string name="harm_reduction_cocaine">Kokeini</string>
     <string name="harm_reduction_communicable_diseases">Magonjwa ya kuambukiza</string>
     <string name="harm_reduction_community">Ngazi ya jamii</string>
     <string name="harm_reduction_condom_education_prompt">Mwongozo</string>
@@ -731,7 +731,7 @@
     <string name="harm_reduction_hashish">Hashish</string>
     <string name="harm_reduction_hepatitis_bc">Homa ya Ini</string>
     <string name="harm_reduction_hepatitis_bc_screening">Uchunguzi wa Homa ya Ini B/C</string>
-    <string name="harm_reduction_heroine">Heroine</string>
+    <string name="harm_reduction_heroine">Heroini</string>
     <string name="harm_reduction_hiv_aids">VVU na UKIMWI</string>
     <string name="harm_reduction_hiv_results">Matokeo ya kipimo cha VVU</string>
     <string name="harm_reduction_hiv_test_location">Upimaji ulipofanyika</string>
@@ -796,13 +796,13 @@
     <string name="harm_reduction_legal_issues">Masuala ya kisheria</string>
     <string name="harm_reduction_lost">Amepotea</string>
     <string name="harm_reduction_lowering_infection_risk">Kupunguza hatari ya maambukizi</string>
-    <string name="harm_reduction_marijuana">Bangi</string>
+    <string name="harm_reduction_marijuana">Bhangi</string>
     <string name="harm_reduction_maskani">Maskani</string>
     <string name="harm_reduction_mat_clients">Wapokea Huduma wa MAT</string>
     <string name="harm_reduction_mental_health">Afya ya akili</string>
     <string name="harm_reduction_methadone_services">Huduma ya Methadone (MAT)</string>
     <string name="harm_reduction_methadone_use">Matumizi ya Methadone</string>
-    <string name="harm_reduction_methamphetamine">Methamphetamine</string>
+    <string name="harm_reduction_methamphetamine">Meth (Chumvi)</string>
     <string name="harm_reduction_mirungi">Mirungi</string>
     <string name="harm_reduction_moved">Amehama</string>
     <string name="harm_reduction_needles">Sindano</string>
@@ -864,6 +864,7 @@
     <string name="harm_reduction_substance_abuse">Matumizi ya dawa za kulevya</string>
     <string name="harm_reduction_substance_use_methods">Njia za matumizi ya dawa za kulevya</string>
     <string name="harm_reduction_substance_use_methods_other_specify">Taja njia nyingine za matumizi ya dawa za kulevya</string>
+    <string name="harm_reduction_substances_used">Dawa anayotumia</string>
     <string name="harm_reduction_substances_used_all">Dawa anayotumia</string>
     <string name="harm_reduction_substances_used_injecting_only">Dawa anayotumia</string>
     <string name="harm_reduction_substances_used_non_injecting_only">Dawa anayotumia</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObjectTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObjectTest.java
@@ -1,0 +1,126 @@
+package org.smartregister.chw.domain.harm_reduction_reports;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.smartregister.chw.dao.ReportDao;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class HarmReductionReportObjectTest {
+
+    @Test
+    public void getIndicatorDataShouldExposeAgeGenderAndRocGroupBreakdown() throws Exception {
+        HarmReductionReportObject reportObject = new HarmReductionReportObject(
+                new SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH).parse("2026-03-01")
+        );
+        List<String> capturedSql = new ArrayList<>();
+
+        try (MockedStatic<ReportDao> reportDao = Mockito.mockStatic(ReportDao.class)) {
+            reportDao.when(() -> ReportDao.getReportBreakdown(Mockito.anyString(), ArgumentMatchers.<String>anyList()))
+                    .thenAnswer(invocation -> {
+                        String sql = invocation.getArgument(0);
+                        capturedSql.add(sql);
+                        List<String> columns = invocation.getArgument(1);
+                        Map<String, Integer> values = emptyBreakdown(columns);
+
+                        if (sql.contains("ec_harm_reduction_risk_assessment ehra")) {
+                            values.put("total", 12);
+                            values.put("idu_female_le_15", 1);
+                            values.put("idu_male_19_24", 2);
+                            values.put("idu_total", 6);
+                            values.put("nidu_female_total", 4);
+                            values.put("nidu_male_25_49", 2);
+                        } else if (sql.contains("qty_syringes")) {
+                            values.put("total", 40);
+                            values.put("idu_female_total", 10);
+                            values.put("nidu_male_total", 30);
+                        }
+
+                        return values;
+                    });
+
+            JSONObject indicatorDataObject = reportObject.getIndicatorData();
+
+            assertEquals(12, indicatorDataObject.getInt("hr-1"));
+            assertEquals(1, indicatorDataObject.getInt("hr-1-idu-female-le-15"));
+            assertEquals(2, indicatorDataObject.getInt("hr-1-idu-male-19-24"));
+            assertEquals(6, indicatorDataObject.getInt("hr-1-idu-total"));
+            assertEquals(4, indicatorDataObject.getInt("hr-1-nidu-female-total"));
+            assertEquals(2, indicatorDataObject.getInt("hr-1-nidu-male-25-49"));
+
+            assertEquals(40, indicatorDataObject.getInt("hr-5"));
+            assertEquals(10, indicatorDataObject.getInt("hr-5-idu-female-total"));
+            assertEquals(30, indicatorDataObject.getInt("hr-5-nidu-male-total"));
+        }
+
+        assertTrue(containsSql(capturedSql, "ec_family_member efm"));
+        assertTrue(containsSql(capturedSql, "julianday(efm.dob"));
+        assertTrue(containsSql(capturedSql, "COUNT(DISTINCT CASE WHEN"));
+        assertTrue(containsSql(capturedSql, "COALESCE(SUM(CASE WHEN"));
+        assertTrue(containsSql(capturedSql, "ec_harm_reduction_followup_visit ehfv"));
+        assertTrue(containsSql(capturedSql, "ec_harm_reduction_risk_assessment ehra"));
+    }
+
+    @Test
+    public void reportTemplateShouldRenderDisaggregationColumns() throws Exception {
+        String reportTemplate = readText("src/nacp/assets/reports/harm_reduction_reports/harm-reduction-report.html");
+
+        assertTrue(reportTemplate.contains("idu-female-le-15"));
+        assertTrue(reportTemplate.contains("idu-male-le-18"));
+        assertTrue(reportTemplate.contains("nidu-female-15-24"));
+        assertTrue(reportTemplate.contains("nidu-male-total"));
+        assertTrue(reportTemplate.contains("\"hr-14\""));
+        assertTrue(reportTemplate.contains("colSpan = 24"));
+    }
+
+    private static Map<String, Integer> emptyBreakdown(List<String> columns) {
+        Map<String, Integer> values = new HashMap<>();
+        for (String column : columns) {
+            values.put(column, 0);
+        }
+        return values;
+    }
+
+    private static boolean containsSql(List<String> sqlQueries, String expectedSql) {
+        for (String sql : sqlQueries) {
+            if (sql.contains(expectedSql)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String readText(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionUsedNeedlesCollectionConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionUsedNeedlesCollectionConfigTest.java
@@ -37,7 +37,7 @@ public class HarmReductionUsedNeedlesCollectionConfigTest {
     }
 
     @Test
-    public void shouldShowRevisedFieldsBeforeLegacyFallbacksInCollectionDetails() throws Exception {
+    public void shouldShowOnlyRevisedFieldsInCollectionDetails() throws Exception {
         Field field = HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.class.getDeclaredField("COLLECTION_FIELDS");
         field.setAccessible(true);
 
@@ -47,11 +47,7 @@ public class HarmReductionUsedNeedlesCollectionConfigTest {
                 "maskani_name",
                 "collection_site_gps",
                 "number_of_used_needles_and_syringes_collected",
-                "issues_challenges_related_to_collection_of_used_needles_and_syringes",
-                "total_safety_boxes_collected",
-                "other_collection",
-                "fixed_bins",
-                "name_of_ow"
+                "issues_challenges_related_to_collection_of_used_needles_and_syringes"
         };
 
         Assert.assertArrayEquals(expected, actual);

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -269,7 +269,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_cause_of_death_other_specify", "Taja sababu nyingine ya kifo");
         values.put("harm_reduction_client_deceased", "Amefariki");
         values.put("harm_reduction_client_started_mat", "Je, mpokea huduma ameanza MAT?");
-        values.put("harm_reduction_cocaine", "Cocaine");
+        values.put("harm_reduction_cocaine", "Kokeini");
         values.put("harm_reduction_communicable_diseases", "Magonjwa ya kuambukiza");
         values.put("harm_reduction_community", "Ngazi ya jamii");
         values.put("harm_reduction_condom_education_prompt", "Mwongozo");
@@ -301,7 +301,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_health_services_advocacy", "Uhamasishaji wa huduma za Afya");
         values.put("harm_reduction_hepatitis_bc", "Homa ya Ini");
         values.put("harm_reduction_hepatitis_bc_screening", "Uchunguzi wa Homa ya Ini B/C");
-        values.put("harm_reduction_heroine", "Heroine");
+        values.put("harm_reduction_heroine", "Heroini");
         values.put("harm_reduction_hiv_aids", "VVU na UKIMWI");
         values.put("harm_reduction_hiv_results", "Matokeo ya kipimo cha VVU");
         values.put("harm_reduction_hiv_test_location", "Upimaji ulipofanyika");
@@ -366,12 +366,12 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_legal_issues", "Masuala ya kisheria");
         values.put("harm_reduction_lost", "Amepotea");
         values.put("harm_reduction_lowering_infection_risk", "Kupunguza hatari ya maambukizi");
-        values.put("harm_reduction_marijuana", "Bangi");
+        values.put("harm_reduction_marijuana", "Bhangi");
         values.put("harm_reduction_maskani", "Maskani");
         values.put("harm_reduction_mental_health", "Afya ya akili");
         values.put("harm_reduction_methadone_services", "Huduma ya Methadone (MAT)");
         values.put("harm_reduction_methadone_use", "Matumizi ya Methadone");
-        values.put("harm_reduction_methamphetamine", "Methamphetamine");
+        values.put("harm_reduction_methamphetamine", "Meth (Chumvi)");
         values.put("harm_reduction_mirungi", "Mirungi");
         values.put("harm_reduction_moved", "Amehama");
         values.put("harm_reduction_needles", "Sindano");
@@ -432,6 +432,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_substance_abuse", "Matumizi ya dawa za kulevya");
         values.put("harm_reduction_substance_use_methods", "Njia za matumizi ya dawa za kulevya");
         values.put("harm_reduction_substance_use_methods_other_specify", "Taja njia nyingine za matumizi ya dawa za kulevya");
+        values.put("harm_reduction_substances_used", "Dawa anayotumia");
         values.put("harm_reduction_substances_used_all", "Dawa anayotumia");
         values.put("harm_reduction_substances_used_injecting_only", "Dawa anayotumia");
         values.put("harm_reduction_substances_used_non_injecting_only", "Dawa anayotumia");


### PR DESCRIPTION
## Summary
- Add HR report IDU/NIDU age and gender disaggregation for issues #872 and #873.
- Improve HR visit history rendering for translated substance/method labels for #777.
- Keep used-needle collection details aligned with the revised safety-box schema for #832.

## Tests
- ./gradlew :opensrp-chw:testNacpDebugUnitTest --tests "org.smartregister.chw.domain.harm_reduction_reports.HarmReductionReportObjectTest" --tests "org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest" --tests "org.smartregister.chw.resources.HarmReductionUsedNeedlesCollectionConfigTest"
- ./gradlew :opensrp-chw:assembleNacpDebug
- Emulator: installed NACP debug APK, logged in as markchw, opened Harm Reduction Report, confirmed horizontal IDU/NIDU age disaggregation columns render on-device.