### PR TITLE
Update HR safe injection history labels

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -840,7 +840,7 @@
     <string name="harm_reduction_qty_needles">Idadi ya Sindano</string>
     <string name="harm_reduction_qty_plaster">Idadi ya Plasta</string>
     <string name="harm_reduction_qty_sterile_water">Idadi ya Maji</string>
-    <string name="harm_reduction_qty_syringes">Idadi ya Bomba</string>
+    <string name="harm_reduction_qty_syringes">Idadi ya Bomba na sindano</string>
     <string name="harm_reduction_referrals_other_specify">Ikiwa ni nyinginezo, taja</string>
     <string name="harm_reduction_referrals_provided">Rufaa zilizotolewa</string>
     <string name="harm_reduction_remarks_comments">Maoni</string>
@@ -869,7 +869,7 @@
     <string name="harm_reduction_substances_used_injecting_only">Dawa anayotumia</string>
     <string name="harm_reduction_substances_used_non_injecting_only">Dawa anayotumia</string>
     <string name="harm_reduction_substances_used_other_specify">Taja dawa nyingine za kulevya zilizotumika</string>
-    <string name="harm_reduction_syringes">Bomba</string>
+    <string name="harm_reduction_syringes">Bomba na sindano</string>
     <string name="harm_reduction_tb_leprosy">Kifua Kikuu/Ukoma</string>
     <string name="harm_reduction_tb_screening">Uchunguzi wa Kifua Kikuu</string>
     <string name="harm_reduction_tobacco">Tumbaku</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -683,7 +683,7 @@
     <string name="harm_reduction_qty_needles">Number of tools - Needles</string>
     <string name="harm_reduction_qty_plaster">Number of tools - Plaster</string>
     <string name="harm_reduction_qty_sterile_water">Number of tools - Sterile Water</string>
-    <string name="harm_reduction_qty_syringes">Number of tools - Syringes</string>
+    <string name="harm_reduction_qty_syringes">Number of tools - Needles and syringes</string>
     <string name="harm_reduction_referrals_other_specify">If others, specify</string>
     <string name="harm_reduction_referrals_provided">Referrals provided</string>
     <string name="harm_reduction_remarks_comments">Remarks/Comments</string>
@@ -713,7 +713,7 @@
     <string name="harm_reduction_substances_used_injecting_only">Substance used</string>
     <string name="harm_reduction_substances_used_non_injecting_only">Substance used</string>
     <string name="harm_reduction_substances_used_other_specify">Specify other substances used</string>
-    <string name="harm_reduction_syringes">Syringes</string>
+    <string name="harm_reduction_syringes">Needles and syringes</string>
     <string name="harm_reduction_tb_leprosy">TB/Leprosy</string>
     <string name="harm_reduction_tb_screening">TB Screening</string>
     <string name="harm_reduction_tobacco">Tobacco</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -214,7 +214,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_qty_needles", "Number of tools - Needles");
         values.put("harm_reduction_qty_plaster", "Number of tools - Plaster");
         values.put("harm_reduction_qty_sterile_water", "Number of tools - Sterile Water");
-        values.put("harm_reduction_qty_syringes", "Number of tools - Syringes");
+        values.put("harm_reduction_qty_syringes", "Number of tools - Needles and syringes");
         values.put("harm_reduction_referrals_other_specify", "If others, specify");
         values.put("harm_reduction_referrals_provided", "Referrals provided");
         values.put("harm_reduction_remarks_comments", "Remarks/Comments");
@@ -241,7 +241,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_substances_used_injecting_only", "Substance used");
         values.put("harm_reduction_substances_used_non_injecting_only", "Substance used");
         values.put("harm_reduction_substances_used_other_specify", "Specify other substances used");
-        values.put("harm_reduction_syringes", "Syringes");
+        values.put("harm_reduction_syringes", "Needles and syringes");
         values.put("harm_reduction_tb_leprosy", "TB/Leprosy");
         values.put("harm_reduction_tb_screening", "TB Screening");
         values.put("harm_reduction_tobacco", "Tobacco");
@@ -409,7 +409,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_qty_needles", "Idadi ya Sindano");
         values.put("harm_reduction_qty_plaster", "Idadi ya Plasta");
         values.put("harm_reduction_qty_sterile_water", "Idadi ya Maji");
-        values.put("harm_reduction_qty_syringes", "Idadi ya Bomba");
+        values.put("harm_reduction_qty_syringes", "Idadi ya Bomba na sindano");
         values.put("harm_reduction_referrals_other_specify", "Ikiwa ni nyinginezo, taja");
         values.put("harm_reduction_referrals_provided", "Rufaa zilizotolewa");
         values.put("harm_reduction_remarks_comments", "Maoni");
@@ -437,7 +437,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_substances_used_injecting_only", "Dawa anayotumia");
         values.put("harm_reduction_substances_used_non_injecting_only", "Dawa anayotumia");
         values.put("harm_reduction_substances_used_other_specify", "Taja dawa nyingine za kulevya zilizotumika");
-        values.put("harm_reduction_syringes", "Bomba");
+        values.put("harm_reduction_syringes", "Bomba na sindano");
         values.put("harm_reduction_tb_leprosy", "Kifua Kikuu/Ukoma");
         values.put("harm_reduction_tb_screening", "Uchunguzi wa Kifua Kikuu");
         values.put("harm_reduction_tobacco", "Tumbaku");


### PR DESCRIPTION
## Summary
- Update NACP visit-history labels for the existing `syringes` and `qty_syringes` keys to match the combined safe-injection component.
- Render the combined component as Bomba na sindano / Needles and syringes in visit history.
- Update the visit-history string resource test expectations.

## Root Cause
The form fix keeps the existing `syringes` storage key for compatibility, so the app resources also need to describe that key as the combined bomba-and-sindano component.

## Tests
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest`
- `./gradlew :opensrp-chw:assembleNacpDebug`

Related to Digital-Square-Tanzania/opensrp-client-chw#879