### PR TITLE
Support split HR Hepatitis B and C screening

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionVisitHistoryActivity.java
@@ -218,6 +218,8 @@ public class HarmReductionVisitHistoryActivity extends CoreAncMedicalHistoryActi
                 "drug_adherence_status_ctc",
                 "adherence_guidance_discontinued",
                 "adherence_guidance_not_started",
+                "hepatitis_b_screening",
+                "hepatitis_c_screening",
                 "hepatitis_bc_screening",
                 "tb_screening",
                 "stds_screening",

--- a/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObject.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObject.java
@@ -59,6 +59,14 @@ public class HarmReductionReportObject extends ReportObject {
             "lower(ifnull(source.roc_group_type, '')) = 'idu'";
     private static final String SOURCE_NIDU_CONDITION =
             "lower(ifnull(source.roc_group_type, '')) = 'nidu'";
+    private static final String HEPATITIS_SCREENING_HAS_VALUE_CONDITION =
+            "(trim(ifnull(ehfv.hepatitis_bc_screening, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.hepatitis_b_screening, '')) <> '' OR " +
+                    "trim(ifnull(ehfv.hepatitis_c_screening, '')) <> '')";
+    private static final String HEPATITIS_SCREENING_REQUIRES_REFERRAL_CONDITION =
+            "(lower(ifnull(ehfv.hepatitis_bc_screening, '')) IN ('has_symptoms', 'undergoing_treatment') OR " +
+                    "lower(ifnull(ehfv.hepatitis_b_screening, '')) IN ('has_symptoms', 'undergoing_treatment') OR " +
+                    "lower(ifnull(ehfv.hepatitis_c_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))";
 
     private static final String RECEIVED_HR_SERVICE_CONDITION =
             "(trim(ifnull(ehfv.health_education_provided, '')) <> '' OR " +
@@ -68,7 +76,7 @@ public class HarmReductionReportObject extends ReportObject {
                     "trim(ifnull(ehfv.hiv_tested, '')) <> '' OR " +
                     "trim(ifnull(ehfv.tb_screening, '')) <> '' OR " +
                     "trim(ifnull(ehfv.stds_screening, '')) <> '' OR " +
-                    "trim(ifnull(ehfv.hepatitis_bc_screening, '')) <> '')";
+                    HEPATITIS_SCREENING_HAS_VALUE_CONDITION + ")";
     private static final String IDU_RECEIVED_SYRINGES_CONDITION =
             FOLLOWUP_IDU_CONDITION + " AND (" +
                     "lower(ifnull(ehfv.safe_injection_tools, '')) LIKE '%syringes%' OR " +
@@ -248,7 +256,7 @@ public class HarmReductionReportObject extends ReportObject {
                 followupCount("hr-8", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hiv_testing%' OR lower(ifnull(ehfv.hiv_tested, '')) = 'yes')"),
                 followupCount("hr-9", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%tb_leprosy%' OR lower(ifnull(ehfv.tb_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
                 followupCount("hr-10", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%stis_stds%' OR lower(ifnull(ehfv.stds_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
-                followupCount("hr-11", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hepatitis_bc%' OR lower(ifnull(ehfv.hepatitis_bc_screening, '')) IN ('has_symptoms', 'undergoing_treatment'))"),
+                followupCount("hr-11", "(lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hepatitis_bc%' OR " + HEPATITIS_SCREENING_REQUIRES_REFERRAL_CONDITION + ")"),
                 followupCount("hr-12", "trim(ifnull(ehfv.referrals_provided, '')) <> '' AND lower(ifnull(ehfv.referrals_provided, '')) NOT LIKE '%none%'"),
                 followupCount("hr-12a", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%income_generating%'"),
                 followupCount("hr-12b", "lower(ifnull(ehfv.referrals_provided, '')) LIKE '%sober_house%'"),

--- a/opensrp-chw/src/nacp/assets/config/harm-reduction-monthly-report.yml
+++ b/opensrp-chw/src/nacp/assets/config/harm-reduction-monthly-report.yml
@@ -22,7 +22,9 @@ indicators:
                         trim(ifnull(ehfv.hiv_tested, '')) <> '' OR
                         trim(ifnull(ehfv.tb_screening, '')) <> '' OR
                         trim(ifnull(ehfv.stds_screening, '')) <> '' OR
-                        trim(ifnull(ehfv.hepatitis_bc_screening, '')) <> ''
+                        trim(ifnull(ehfv.hepatitis_bc_screening, '')) <> '' OR
+                        trim(ifnull(ehfv.hepatitis_b_screening, '')) <> '' OR
+                        trim(ifnull(ehfv.hepatitis_c_screening, '')) <> ''
                       )
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehfv.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||
@@ -147,7 +149,9 @@ indicators:
                       FROM ec_harm_reduction_followup_visit ehfv
                       WHERE (
                         lower(ifnull(ehfv.referrals_provided, '')) LIKE '%hepatitis_bc%' OR
-                        lower(ifnull(ehfv.hepatitis_bc_screening, '')) IN ('has_symptoms', 'undergoing_treatment')
+                        lower(ifnull(ehfv.hepatitis_bc_screening, '')) IN ('has_symptoms', 'undergoing_treatment') OR
+                        lower(ifnull(ehfv.hepatitis_b_screening, '')) IN ('has_symptoms', 'undergoing_treatment') OR
+                        lower(ifnull(ehfv.hepatitis_c_screening, '')) IN ('has_symptoms', 'undergoing_treatment')
                       )
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
                       date(substr(strftime('%Y-%m-%d', datetime(ehfv.last_interacted_with / 1000, 'unixepoch', 'localtime')), 1, 4) ||

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -11946,6 +11946,22 @@
           }
         },
         {
+          "column_name": "hepatitis_b_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "hepatitis_b_screening"
+          }
+        },
+        {
+          "column_name": "hepatitis_c_screening",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "hepatitis_c_screening"
+          }
+        },
+        {
           "column_name": "tb_screening",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -730,7 +730,9 @@
     <string name="harm_reduction_health_services_advocacy">Uhamasishaji wa huduma za Afya</string>
     <string name="harm_reduction_hashish">Hashish</string>
     <string name="harm_reduction_hepatitis_bc">Homa ya Ini</string>
+    <string name="harm_reduction_hepatitis_b_screening">Uchunguzi wa Homa ya Ini B</string>
     <string name="harm_reduction_hepatitis_bc_screening">Uchunguzi wa Homa ya Ini B/C</string>
+    <string name="harm_reduction_hepatitis_c_screening">Uchunguzi wa Homa ya Ini C</string>
     <string name="harm_reduction_heroine">Heroini</string>
     <string name="harm_reduction_hiv_aids">VVU na UKIMWI</string>
     <string name="harm_reduction_hiv_results">Matokeo ya kipimo cha VVU</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -571,7 +571,9 @@
     <string name="harm_reduction_health_services_advocacy">Health services advocacy</string>
     <string name="harm_reduction_hashish">Hashish</string>
     <string name="harm_reduction_hepatitis_bc">Hepatitis B/C</string>
+    <string name="harm_reduction_hepatitis_b_screening">Hepatitis B Screening</string>
     <string name="harm_reduction_hepatitis_bc_screening">Hepatitis B/C Screening</string>
+    <string name="harm_reduction_hepatitis_c_screening">Hepatitis C Screening</string>
     <string name="harm_reduction_heroine">Heroine</string>
     <string name="harm_reduction_hiv_aids">HIV and AIDS</string>
     <string name="harm_reduction_hiv_results">HIV results</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObjectTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/domain/harm_reduction_reports/HarmReductionReportObjectTest.java
@@ -75,6 +75,8 @@ public class HarmReductionReportObjectTest {
         assertTrue(containsSql(capturedSql, "COALESCE(SUM(CASE WHEN"));
         assertTrue(containsSql(capturedSql, "ec_harm_reduction_followup_visit ehfv"));
         assertTrue(containsSql(capturedSql, "ec_harm_reduction_risk_assessment ehra"));
+        assertTrue(containsSql(capturedSql, "ehfv.hepatitis_b_screening"));
+        assertTrue(containsSql(capturedSql, "ehfv.hepatitis_c_screening"));
     }
 
     @Test
@@ -87,6 +89,14 @@ public class HarmReductionReportObjectTest {
         assertTrue(reportTemplate.contains("nidu-male-total"));
         assertTrue(reportTemplate.contains("\"hr-14\""));
         assertTrue(reportTemplate.contains("colSpan = 24"));
+    }
+
+    @Test
+    public void monthlyReportConfigShouldUseSeparateHepatitisScreeningFields() throws Exception {
+        String reportConfig = readText("src/nacp/assets/config/harm-reduction-monthly-report.yml");
+
+        assertTrue(reportConfig.contains("ehfv.hepatitis_b_screening"));
+        assertTrue(reportConfig.contains("ehfv.hepatitis_c_screening"));
     }
 
     private static Map<String, Integer> emptyBreakdown(List<String> columns) {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionFollowupConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionFollowupConfigTest.java
@@ -1,0 +1,63 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HarmReductionFollowupConfigTest {
+
+    @Test
+    public void shouldMapSeparateHepatitisScreeningColumnsInNacpEcClientFields() throws Exception {
+        JSONObject file = new JSONObject(readText("src/nacp/assets/ec_client_fields.json"));
+        JSONObject bindObject = findBindObject(file.getJSONArray("bindobjects"), "ec_harm_reduction_followup_visit");
+        JSONArray columns = bindObject.getJSONArray("columns");
+
+        Assert.assertTrue(hasColumn(columns, "hepatitis_bc_screening"));
+        Assert.assertTrue(hasColumn(columns, "hepatitis_b_screening"));
+        Assert.assertTrue(hasColumn(columns, "hepatitis_c_screening"));
+    }
+
+    private static JSONObject findBindObject(JSONArray bindObjects, String name) throws Exception {
+        for (int i = 0; i < bindObjects.length(); i++) {
+            JSONObject bindObject = bindObjects.getJSONObject(i);
+            if (name.equals(bindObject.optString("name"))) {
+                return bindObject;
+            }
+        }
+
+        throw new AssertionError("Missing bind object: " + name);
+    }
+
+    private static boolean hasColumn(JSONArray columns, String columnName) throws Exception {
+        for (int i = 0; i < columns.length(); i++) {
+            if (columnName.equals(columns.getJSONObject(i).optString("column_name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -105,7 +105,9 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_health_education_provided", "Health education provided");
         values.put("harm_reduction_health_services_advocacy", "Health services advocacy");
         values.put("harm_reduction_hepatitis_bc", "Hepatitis B/C");
+        values.put("harm_reduction_hepatitis_b_screening", "Hepatitis B Screening");
         values.put("harm_reduction_hepatitis_bc_screening", "Hepatitis B/C Screening");
+        values.put("harm_reduction_hepatitis_c_screening", "Hepatitis C Screening");
         values.put("harm_reduction_heroine", "Heroine");
         values.put("harm_reduction_hiv_aids", "HIV and AIDS");
         values.put("harm_reduction_hiv_results", "HIV results");
@@ -300,7 +302,9 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_health_education_provided", "Elimu ya afya iliyotolewa");
         values.put("harm_reduction_health_services_advocacy", "Uhamasishaji wa huduma za Afya");
         values.put("harm_reduction_hepatitis_bc", "Homa ya Ini");
+        values.put("harm_reduction_hepatitis_b_screening", "Uchunguzi wa Homa ya Ini B");
         values.put("harm_reduction_hepatitis_bc_screening", "Uchunguzi wa Homa ya Ini B/C");
+        values.put("harm_reduction_hepatitis_c_screening", "Uchunguzi wa Homa ya Ini C");
         values.put("harm_reduction_heroine", "Heroini");
         values.put("harm_reduction_hiv_aids", "VVU na UKIMWI");
         values.put("harm_reduction_hiv_results", "Matokeo ya kipimo cha VVU");


### PR DESCRIPTION
## Summary
- Add NACP follow-up visit mappings for separate Hepatitis B and Hepatitis C screening fields.
- Include the split fields in Harm Reduction visit history with English and Swahili labels.
- Update Harm Reduction report predicates and monthly report config to count either split field, while retaining legacy `hepatitis_bc_screening` compatibility.
- Add config, report, and visit-history string regression tests.

## Root Cause
The app-side mappings, visit history, and reports only referenced the legacy combined `hepatitis_bc_screening` field, so the split form fields needed matching support.

## Tests
- `jq empty` on NACP `ec_client_fields.json`.
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionFollowupConfigTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest --tests org.smartregister.chw.domain.harm_reduction_reports.HarmReductionReportObjectTest`
- `./gradlew :opensrp-chw:assembleNacpDebug`

Related to Digital-Square-Tanzania/opensrp-client-chw#878