### PR TITLE
Reassign stopped MAT clients to Harm Reduction

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwClientProcessor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/sync/ChwClientProcessor.java
@@ -227,7 +227,7 @@ public class ChwClientProcessor extends CoreClientProcessor {
                     processVisitEvent(eventClient);
                     processEvent(eventClient.getEvent(), eventClient.getClient(), clientClassification);
                     if (HARM_REDUCTION_MAT_CLIENTS_FOLLOWUP.equals(eventType)) {
-                        reclassifyCompletedMethadoneTreatmentClient(eventClient.getEvent());
+                        processMatFollowupTreatmentStatus(eventClient.getEvent());
                     }
                     break;
                 case org.smartregister.chw.ayp.util.Constants.EVENT_TYPE.AYP_GROUP_DETAILS:
@@ -341,19 +341,22 @@ public class ChwClientProcessor extends CoreClientProcessor {
         }
     }
 
-    private void reclassifyCompletedMethadoneTreatmentClient(Event event) {
+    private void processMatFollowupTreatmentStatus(Event event) {
         if (event == null) {
             return;
         }
 
         String methadoneTreatmentStatus = getFormValue(event, METHADONE_TREATMENT_STATUS_FIELD);
-        if (!HarmReductionDao.isCompletedMethadoneTreatment(methadoneTreatmentStatus)
-                || StringUtils.isBlank(event.getBaseEntityId())) {
+        if (StringUtils.isBlank(event.getBaseEntityId())) {
             return;
         }
 
         try {
-            HarmReductionDao.closeCompletedMethadoneTreatmentRiskAssessment(event.getBaseEntityId());
+            if (HarmReductionDao.isCompletedMethadoneTreatment(methadoneTreatmentStatus)) {
+                HarmReductionDao.closeCompletedMethadoneTreatmentRiskAssessment(event.getBaseEntityId());
+            } else if (HarmReductionDao.isStoppedUsingMethadone(methadoneTreatmentStatus)) {
+                HarmReductionDao.reassignStoppedMethadoneTreatmentRiskAssessment(event.getBaseEntityId());
+            }
         } catch (Exception e) {
             Timber.w(e);
         }


### PR DESCRIPTION
## Summary
- Handles MAT follow-up treatment status after sync for both completed treatment and stopped Methadone outcomes.
- Calls the harm-reduction DAO reassignment path when `Tiba ya Methadone` is answered `Ameacha kutumia Methadone`.
- Keeps the existing completed-treatment behavior unchanged.

## Root Cause
The CHW client processor only reclassified completed Methadone treatment events. When a MAT client stopped using Methadone, the event synced without clearing the active MAT register flags, so the client remained in the MAT clients list instead of returning to Harm Reduction community services.

## Dependency
- Requires Digital-Square-Tanzania/opensrp-client-chw-harm-reduction#76 for the new DAO API. The updated harm-reduction SNAPSHOT was published to GitHub Packages.

## Validation
- `./gradlew --refresh-dependencies :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.presenter.HarmReductionMatClientsRegisterFragmentPresenterTest`
- `./gradlew :opensrp-chw:assembleNacpDebug`

Fixes #886