### PR TITLE
Fix KVP report indicators

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -273,7 +273,7 @@ android {
             buildConfigField "String", 'DEFAULT_LOCATION', '"Hamlet"'
             buildConfigField "String", 'DEFAULT_LOCATION_DEBUG', '"Hamlet"'
             buildConfigField "long", "MAPBOX_DOWNLOAD_TILE_LIMIT", "6001"
-            buildConfigField "int", "DATABASE_VERSION", '41'
+            buildConfigField "int", "DATABASE_VERSION", '44'
             buildConfigField "boolean", "ENABLE_REFERRAL_FOLLOWUP", "false"
         }
     }

--- a/opensrp-chw/src/nacp/assets/config/kvp-monthly-report.yml
+++ b/opensrp-chw/src/nacp/assets/config/kvp-monthly-report.yml
@@ -11,7 +11,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -24,7 +24,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -37,7 +37,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -50,7 +50,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -63,7 +63,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -76,7 +76,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -89,7 +89,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -102,7 +102,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -115,7 +115,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -127,7 +127,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -139,7 +139,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -152,7 +152,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -165,7 +165,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -178,7 +178,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -191,7 +191,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -204,7 +204,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -217,7 +217,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -230,7 +230,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -243,7 +243,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -255,7 +255,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -267,7 +267,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -280,7 +280,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -293,7 +293,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -306,7 +306,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -319,7 +319,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -332,7 +332,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -345,7 +345,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -358,7 +358,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -371,7 +371,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -383,7 +383,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -395,7 +395,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -408,7 +408,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -421,7 +421,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -434,7 +434,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -447,7 +447,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -460,7 +460,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -473,7 +473,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -486,7 +486,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -499,7 +499,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -511,7 +511,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -523,7 +523,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -536,7 +536,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -549,7 +549,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -562,7 +562,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -575,7 +575,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -588,7 +588,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -601,7 +601,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -614,7 +614,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -627,7 +627,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -639,7 +639,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -651,7 +651,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -664,7 +664,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -677,7 +677,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -690,7 +690,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -703,7 +703,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -716,7 +716,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -729,7 +729,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -742,7 +742,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -755,7 +755,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-msm-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -767,7 +767,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-1-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -780,7 +780,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -793,7 +793,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -806,7 +806,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -819,7 +819,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -832,7 +832,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -845,7 +845,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -858,7 +858,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -871,7 +871,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -884,7 +884,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -896,7 +896,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri <10"
@@ -908,7 +908,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 10-14"
@@ -921,7 +921,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 15-19"
@@ -934,7 +934,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 20-24"
@@ -947,7 +947,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 25-29"
@@ -960,7 +960,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 30-34"
@@ -973,7 +973,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 35-39"
@@ -986,7 +986,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 40-44"
@@ -999,7 +999,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri 45-49"
@@ -1012,7 +1012,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-1->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi wa wateja wapya waliosajiliwa katika kipindi cha ripoti Umri >50"
@@ -1024,7 +1024,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 2
 
@@ -1039,7 +1039,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1052,7 +1052,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1065,7 +1065,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1078,7 +1078,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1091,7 +1091,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1104,7 +1104,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1117,7 +1117,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1130,7 +1130,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1143,7 +1143,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1155,7 +1155,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1167,7 +1167,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1180,7 +1180,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1193,7 +1193,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1206,7 +1206,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1219,7 +1219,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1232,7 +1232,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1245,7 +1245,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1258,7 +1258,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1271,7 +1271,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1283,7 +1283,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1295,7 +1295,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1308,7 +1308,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1321,7 +1321,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1334,7 +1334,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1347,7 +1347,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1360,7 +1360,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1373,7 +1373,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1386,7 +1386,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1399,7 +1399,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1411,7 +1411,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1423,7 +1423,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1436,7 +1436,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1449,7 +1449,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1462,7 +1462,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1475,7 +1475,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1488,7 +1488,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1501,7 +1501,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1514,7 +1514,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1527,7 +1527,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1539,7 +1539,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1551,7 +1551,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1564,7 +1564,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1577,7 +1577,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1590,7 +1590,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1603,7 +1603,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1616,7 +1616,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1629,7 +1629,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1642,7 +1642,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1655,7 +1655,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1667,7 +1667,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1679,7 +1679,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1692,7 +1692,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1705,7 +1705,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1718,7 +1718,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1731,7 +1731,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1744,7 +1744,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1757,7 +1757,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1770,7 +1770,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1783,7 +1783,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1795,7 +1795,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-2-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -1808,7 +1808,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1821,7 +1821,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1834,7 +1834,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1847,7 +1847,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1860,7 +1860,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -1873,7 +1873,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -1886,7 +1886,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -1899,7 +1899,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -1912,7 +1912,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -1924,7 +1924,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -1936,7 +1936,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -1949,7 +1949,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -1962,7 +1962,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -1975,7 +1975,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -1988,7 +1988,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -2001,7 +2001,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -2014,7 +2014,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -2027,7 +2027,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -2040,7 +2040,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-2->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -2052,7 +2052,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 3
 
@@ -2067,7 +2067,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2080,7 +2080,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2093,7 +2093,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2106,7 +2106,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2119,7 +2119,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2132,7 +2132,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2145,7 +2145,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2158,7 +2158,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2171,7 +2171,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2183,7 +2183,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2195,7 +2195,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2208,7 +2208,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2221,7 +2221,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2234,7 +2234,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2247,7 +2247,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2260,7 +2260,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2273,7 +2273,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2286,7 +2286,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2299,7 +2299,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2311,7 +2311,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2323,7 +2323,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2336,7 +2336,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2349,7 +2349,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2362,7 +2362,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2375,7 +2375,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2388,7 +2388,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2401,7 +2401,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2414,7 +2414,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2427,7 +2427,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2439,7 +2439,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2451,7 +2451,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2464,7 +2464,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2477,7 +2477,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2490,7 +2490,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2503,7 +2503,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2516,7 +2516,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2529,7 +2529,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2542,7 +2542,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2555,7 +2555,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2567,7 +2567,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2579,7 +2579,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2592,7 +2592,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2605,7 +2605,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2618,7 +2618,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2631,7 +2631,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2644,7 +2644,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2657,7 +2657,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2670,7 +2670,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2683,7 +2683,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2695,7 +2695,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2707,7 +2707,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2720,7 +2720,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2733,7 +2733,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2746,7 +2746,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2759,7 +2759,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2772,7 +2772,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2785,7 +2785,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2798,7 +2798,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2811,7 +2811,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2823,7 +2823,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-3-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -2836,7 +2836,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2849,7 +2849,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2862,7 +2862,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -2875,7 +2875,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -2888,7 +2888,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -2901,7 +2901,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -2914,7 +2914,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -2927,7 +2927,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -2940,7 +2940,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -2952,7 +2952,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -2964,7 +2964,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -2977,7 +2977,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -2990,7 +2990,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -3003,7 +3003,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -3016,7 +3016,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -3029,7 +3029,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -3042,7 +3042,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -3055,7 +3055,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -3068,7 +3068,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-3->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -3080,7 +3080,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 5
 
@@ -3094,7 +3094,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3106,7 +3106,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3118,7 +3118,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3130,7 +3130,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3142,7 +3142,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3154,7 +3154,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3166,7 +3166,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3178,7 +3178,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3190,7 +3190,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3201,7 +3201,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3212,7 +3212,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3224,7 +3224,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3236,7 +3236,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3248,7 +3248,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3260,7 +3260,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3272,7 +3272,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3284,7 +3284,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3296,7 +3296,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3308,7 +3308,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3319,7 +3319,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3330,7 +3330,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3342,7 +3342,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3354,7 +3354,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3366,7 +3366,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3378,7 +3378,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3390,7 +3390,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3402,7 +3402,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3414,7 +3414,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3426,7 +3426,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3437,7 +3437,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3448,7 +3448,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3460,7 +3460,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3472,7 +3472,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3484,7 +3484,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3496,7 +3496,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3508,7 +3508,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3520,7 +3520,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3532,7 +3532,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3544,7 +3544,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3555,7 +3555,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3566,7 +3566,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3578,7 +3578,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3590,7 +3590,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3602,7 +3602,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3614,7 +3614,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3626,7 +3626,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3638,7 +3638,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3650,7 +3650,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3662,7 +3662,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3673,7 +3673,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3684,7 +3684,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3696,7 +3696,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3708,7 +3708,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3720,7 +3720,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3732,7 +3732,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3744,7 +3744,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3756,7 +3756,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3768,7 +3768,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3780,7 +3780,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3791,7 +3791,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-5-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -3803,7 +3803,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3815,7 +3815,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3827,7 +3827,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3839,7 +3839,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3851,7 +3851,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3863,7 +3863,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3875,7 +3875,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -3887,7 +3887,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -3899,7 +3899,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -3910,7 +3910,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -3921,7 +3921,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -3933,7 +3933,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -3945,7 +3945,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -3957,7 +3957,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -3969,7 +3969,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -3981,7 +3981,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -3993,7 +3993,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4005,7 +4005,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4017,7 +4017,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-5->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya kondomu zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4028,7 +4028,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 6
 
@@ -4047,7 +4047,7 @@ indicators:
                       date(substr(ehr.collection_date, 7, 4) || '-' || substr(ehr.collection_date, 4, 2) || '-' || '01')
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-6-10-14-pwid-ME"
     grouping: "KVP"
@@ -4067,7 +4067,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -4085,7 +4085,7 @@ indicators:
                       
                       
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -4103,7 +4103,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -4122,7 +4122,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -4141,7 +4141,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -4160,7 +4160,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4179,7 +4179,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4198,7 +4198,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4216,7 +4216,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -4234,7 +4234,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -4253,7 +4253,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -4272,7 +4272,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -4291,7 +4291,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -4310,7 +4310,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -4329,7 +4329,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -4348,7 +4348,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4367,7 +4367,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4386,7 +4386,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4404,7 +4404,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -4422,7 +4422,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -4441,7 +4441,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -4460,7 +4460,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -4479,7 +4479,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -4498,7 +4498,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -4517,7 +4517,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -4536,7 +4536,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4555,7 +4555,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4574,7 +4574,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4592,7 +4592,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -4610,7 +4610,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -4629,7 +4629,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -4648,7 +4648,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -4667,7 +4667,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -4686,7 +4686,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -4705,7 +4705,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -4724,7 +4724,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4743,7 +4743,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4762,7 +4762,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4780,7 +4780,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -4798,7 +4798,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -4817,7 +4817,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -4836,7 +4836,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -4855,7 +4855,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -4874,7 +4874,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -4893,7 +4893,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -4912,7 +4912,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -4931,7 +4931,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -4950,7 +4950,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -4968,7 +4968,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -4986,7 +4986,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -5005,7 +5005,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -5024,7 +5024,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -5043,7 +5043,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -5062,7 +5062,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -5081,7 +5081,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -5100,7 +5100,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -5119,7 +5119,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -5138,7 +5138,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -5156,7 +5156,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-6-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -5175,7 +5175,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -5194,7 +5194,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -5212,7 +5212,7 @@ indicators:
                       
                       
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -5231,7 +5231,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -5250,7 +5250,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -5269,7 +5269,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -5288,7 +5288,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -5307,7 +5307,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -5326,7 +5326,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -5344,7 +5344,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri <10"
@@ -5362,7 +5362,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 10-14"
@@ -5381,7 +5381,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 15-19"
@@ -5400,7 +5400,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 20-24"
@@ -5419,7 +5419,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 25-29"
@@ -5438,7 +5438,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 30-34"
@@ -5457,7 +5457,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 35-39"
@@ -5476,7 +5476,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 40-44"
@@ -5495,7 +5495,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri 45-49"
@@ -5514,7 +5514,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-6->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya vitepe zilizogawiwa kwa makundi maalum  katika kipindi cha ripoti Umri >50"
@@ -5532,7 +5532,7 @@ indicators:
                       
                       
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 7
 
@@ -5547,7 +5547,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -5560,7 +5560,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -5573,7 +5573,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -5586,7 +5586,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -5599,7 +5599,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -5612,7 +5612,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -5625,7 +5625,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -5638,7 +5638,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -5651,7 +5651,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -5663,7 +5663,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -5675,7 +5675,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -5688,7 +5688,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -5701,7 +5701,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -5714,7 +5714,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -5727,7 +5727,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -5740,7 +5740,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -5753,7 +5753,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -5766,7 +5766,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -5779,7 +5779,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -5791,7 +5791,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -5803,7 +5803,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -5816,7 +5816,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -5829,7 +5829,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -5842,7 +5842,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -5855,7 +5855,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -5868,7 +5868,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -5881,7 +5881,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -5894,7 +5894,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -5907,7 +5907,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -5919,7 +5919,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -5931,7 +5931,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -5944,7 +5944,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -5957,7 +5957,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -5970,7 +5970,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -5983,7 +5983,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -5996,7 +5996,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6009,7 +6009,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6022,7 +6022,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6035,7 +6035,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6047,7 +6047,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6059,7 +6059,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6072,7 +6072,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6085,7 +6085,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6098,7 +6098,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6111,7 +6111,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6124,7 +6124,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6137,7 +6137,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6150,7 +6150,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6163,7 +6163,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6175,7 +6175,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6187,7 +6187,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6200,7 +6200,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6213,7 +6213,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6226,7 +6226,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6239,7 +6239,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6252,7 +6252,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6265,7 +6265,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6278,7 +6278,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6291,7 +6291,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6303,7 +6303,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-7-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -6316,7 +6316,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6329,7 +6329,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6342,7 +6342,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6355,7 +6355,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6368,7 +6368,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6381,7 +6381,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6394,7 +6394,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6407,7 +6407,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6420,7 +6420,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6432,7 +6432,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6444,7 +6444,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6457,7 +6457,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6470,7 +6470,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6483,7 +6483,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6496,7 +6496,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6509,7 +6509,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6522,7 +6522,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6535,7 +6535,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6548,7 +6548,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-7->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6560,7 +6560,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 8
 
@@ -6574,7 +6574,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6586,7 +6586,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6599,7 +6599,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6611,7 +6611,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6623,7 +6623,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6635,7 +6635,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6647,7 +6647,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6659,7 +6659,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6671,7 +6671,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6682,7 +6682,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6693,7 +6693,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6705,7 +6705,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6717,7 +6717,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6729,7 +6729,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6741,7 +6741,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6753,7 +6753,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6765,7 +6765,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6777,7 +6777,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6789,7 +6789,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6800,7 +6800,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6811,7 +6811,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6823,7 +6823,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6835,7 +6835,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6847,7 +6847,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6859,7 +6859,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6871,7 +6871,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -6883,7 +6883,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -6895,7 +6895,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -6907,7 +6907,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -6918,7 +6918,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -6929,7 +6929,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -6941,7 +6941,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -6953,7 +6953,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -6965,7 +6965,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -6977,7 +6977,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -6989,7 +6989,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7001,7 +7001,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7013,7 +7013,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7025,7 +7025,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7036,7 +7036,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7047,7 +7047,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7059,7 +7059,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7071,7 +7071,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7083,7 +7083,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7095,7 +7095,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7107,7 +7107,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7119,7 +7119,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7131,7 +7131,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7143,7 +7143,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7154,7 +7154,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7165,7 +7165,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7177,7 +7177,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7189,7 +7189,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7201,7 +7201,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7213,7 +7213,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7225,7 +7225,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7237,7 +7237,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7249,7 +7249,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7261,7 +7261,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7272,7 +7272,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-8-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -7284,7 +7284,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7296,7 +7296,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7309,7 +7309,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7321,7 +7321,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7333,7 +7333,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7345,7 +7345,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7357,7 +7357,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7369,7 +7369,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7381,7 +7381,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7392,7 +7392,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7403,7 +7403,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7415,7 +7415,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7427,7 +7427,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7439,7 +7439,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7451,7 +7451,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7463,7 +7463,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7475,7 +7475,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7487,7 +7487,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7499,7 +7499,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-8->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7510,7 +7510,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 9
 
@@ -7524,7 +7524,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7536,7 +7536,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7549,7 +7549,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7561,7 +7561,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7573,7 +7573,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7585,7 +7585,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7597,7 +7597,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7609,7 +7609,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7621,7 +7621,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-pwid-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7632,7 +7632,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7643,7 +7643,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7655,7 +7655,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7667,7 +7667,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7679,7 +7679,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7691,7 +7691,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7703,7 +7703,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7715,7 +7715,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7727,7 +7727,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7739,7 +7739,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-pwid-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7750,7 +7750,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7761,7 +7761,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7773,7 +7773,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7785,7 +7785,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7797,7 +7797,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7809,7 +7809,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7821,7 +7821,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7833,7 +7833,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7845,7 +7845,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7857,7 +7857,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-pwud-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7868,7 +7868,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7879,7 +7879,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -7891,7 +7891,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -7903,7 +7903,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -7915,7 +7915,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -7927,7 +7927,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -7939,7 +7939,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -7951,7 +7951,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -7963,7 +7963,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -7975,7 +7975,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-pwud-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -7986,7 +7986,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -7997,7 +7997,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -8009,7 +8009,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -8021,7 +8021,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -8033,7 +8033,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -8045,7 +8045,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -8057,7 +8057,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -8069,7 +8069,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -8081,7 +8081,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -8093,7 +8093,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-fsw-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -8104,7 +8104,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -8115,7 +8115,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -8127,7 +8127,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -8139,7 +8139,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -8151,7 +8151,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -8163,7 +8163,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -8175,7 +8175,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -8187,7 +8187,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -8199,7 +8199,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -8211,7 +8211,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-msm-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -8222,7 +8222,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-9-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -8234,7 +8234,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -8246,7 +8246,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -8259,7 +8259,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -8271,7 +8271,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -8283,7 +8283,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -8295,7 +8295,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -8307,7 +8307,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -8319,7 +8319,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -8331,7 +8331,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -8342,7 +8342,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri <10"
@@ -8353,7 +8353,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 10-14"
@@ -8365,7 +8365,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 15-19"
@@ -8377,7 +8377,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 20-24"
@@ -8389,7 +8389,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 25-29"
@@ -8401,7 +8401,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 30-34"
@@ -8413,7 +8413,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 35-39"
@@ -8425,7 +8425,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 40-44"
@@ -8437,7 +8437,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri 45-49"
@@ -8449,7 +8449,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-9->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Idadi ya wateja wa makundi maalumu wanaoendelea na huduma katika kipindi cha ripoti Umri >50"
@@ -8460,7 +8460,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 10
 
@@ -8475,7 +8475,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -8488,7 +8488,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -8501,7 +8501,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -8514,7 +8514,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -8527,7 +8527,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -8540,7 +8540,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -8553,7 +8553,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -8566,7 +8566,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -8579,7 +8579,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-pwid-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -8591,7 +8591,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -8603,7 +8603,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -8616,7 +8616,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -8629,7 +8629,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -8642,7 +8642,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -8655,7 +8655,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -8668,7 +8668,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -8681,7 +8681,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -8694,7 +8694,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -8707,7 +8707,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-pwid-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -8719,7 +8719,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -8731,7 +8731,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -8744,7 +8744,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -8757,7 +8757,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -8770,7 +8770,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -8783,7 +8783,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -8796,7 +8796,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -8809,7 +8809,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -8822,7 +8822,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -8835,7 +8835,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-pwud-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -8847,7 +8847,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -8859,7 +8859,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -8872,7 +8872,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -8885,7 +8885,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -8898,7 +8898,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -8911,7 +8911,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -8924,7 +8924,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -8937,7 +8937,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -8950,7 +8950,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -8963,7 +8963,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-pwud-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -8975,7 +8975,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -8987,7 +8987,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -9000,7 +9000,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -9013,7 +9013,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -9026,7 +9026,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -9039,7 +9039,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -9052,7 +9052,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -9065,7 +9065,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -9078,7 +9078,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -9091,7 +9091,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-fsw-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -9103,7 +9103,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -9115,7 +9115,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -9128,7 +9128,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -9141,7 +9141,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -9154,7 +9154,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -9167,7 +9167,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -9180,7 +9180,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -9193,7 +9193,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -9206,7 +9206,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -9219,7 +9219,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-msm-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -9231,7 +9231,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   - key: "kvp-10-<10-other_vulnerable_population-ME"
     grouping: "KVP"
@@ -9244,7 +9244,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -9257,7 +9257,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -9270,7 +9270,7 @@ indicators:
                         AND (date(efm.dob, '+20 years') > date('now'))
                         AND (efm.gender='Male')
                         AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                        date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                        date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -9283,7 +9283,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -9296,7 +9296,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -9309,7 +9309,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -9322,7 +9322,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -9335,7 +9335,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -9348,7 +9348,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-other_vulnerable_population-ME"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -9360,7 +9360,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Male')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-<10-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri <10"
@@ -9372,7 +9372,7 @@ indicators:
                       AND (date('now')-date(efm.dob))<10
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-10-14-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 10-14"
@@ -9385,7 +9385,7 @@ indicators:
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-15-19-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 15-19"
@@ -9398,7 +9398,7 @@ indicators:
                       AND (date(efm.dob, '+20 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-20-24-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 20-24"
@@ -9411,7 +9411,7 @@ indicators:
                       AND (date(efm.dob, '+25 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-25-29-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 25-29"
@@ -9424,7 +9424,7 @@ indicators:
                       AND (date(efm.dob, '+30 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-30-34-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 30-34"
@@ -9437,7 +9437,7 @@ indicators:
                       AND (date(efm.dob, '+35 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-35-39-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 35-39"
@@ -9450,7 +9450,7 @@ indicators:
                       AND (date(efm.dob, '+40 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-40-44-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 40-44"
@@ -9463,7 +9463,7 @@ indicators:
                       AND (date(efm.dob, '+45 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10-45-49-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri 45-49"
@@ -9476,7 +9476,7 @@ indicators:
                       AND (date(efm.dob, '+50 years') > date('now'))
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
   - key: "kvp-10->50-other_vulnerable_population-KE"
     grouping: "KVP"
     description: "Jumla ya wateja waliofikiwa na huduma katika kipindi cha ripoti(1+2) Umri >50"
@@ -9488,7 +9488,7 @@ indicators:
                       AND (date('now')-date(efm.dob))>=50
                       AND (efm.gender='Female')
                       AND date((substr('%s', 1, 4) || '-' || substr('%s', 6, 2) || '-' || '01')) =
-                      date(substr(ekpf.kvp_visit_date, 7, 4) || '-' || substr(ekpf.kvp_visit_date, 4, 2) || '-' || '01')"
+                      date(substr(ekpf.kvp_visit_date, 1, 4) || '-' || substr(ekpf.kvp_visit_date, 6, 2) || '-' || '01')"
 
   #Indicator 11
 
@@ -9536,7 +9536,7 @@ indicators:
                                INNER JOIN ec_family_member efm on efm.base_entity_id = ekr.base_entity_id
                                INNER JOIN task t on efm.base_entity_id = t.for
                       WHERE
-                      date(efm.dob, '+10 years') <= date('now'))
+                      (date(efm.dob, '+10 years') <= date('now'))
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND ekr.client_group ='pwid'
                       AND (efm.gender='Male')
@@ -9912,7 +9912,7 @@ indicators:
                                INNER JOIN ec_family_member efm on efm.base_entity_id = ekr.base_entity_id
                                INNER JOIN task t on efm.base_entity_id = t.for
                       WHERE
-                      date(efm.dob, '+10 years') <= date('now'))
+                      (date(efm.dob, '+10 years') <= date('now'))
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND ekr.client_group ='pwud'
                       AND (efm.gender='Male')
@@ -10440,7 +10440,7 @@ indicators:
                                INNER JOIN ec_family_member efm on efm.base_entity_id = ekr.base_entity_id
                                INNER JOIN task t on efm.base_entity_id = t.for
                       WHERE
-                      date(efm.dob, '+10 years') <= date('now'))
+                      (date(efm.dob, '+10 years') <= date('now'))
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND ekr.client_group ='msm'
                       AND (efm.gender='Male')
@@ -10647,7 +10647,7 @@ indicators:
                                INNER JOIN ec_family_member efm on efm.base_entity_id = ekr.base_entity_id
                                INNER JOIN task t on efm.base_entity_id = t.for
                       WHERE
-                      date(efm.dob, '+10 years') <= date('now'))
+                      (date(efm.dob, '+10 years') <= date('now'))
                       AND (date(efm.dob, '+15 years') > date('now'))
                       AND (ekr.client_group ='prisoners' OR ekr.client_group ='inmate' OR ekr.client_group ='discordant_couples' OR ekr.client_group ='fisherman' OR ekr.client_group ='truck_drivers' OR ekr.client_group ='miners' OR ekr.client_group ='other')
                       AND (efm.gender='Male')

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -5397,6 +5397,13 @@
           }
         },
         {
+          "column_name": "kvp_visit_date",
+          "type": "Event",
+          "json_mapping": {
+            "field": "eventDate"
+          }
+        },
+        {
           "column_name": "next_visit_date",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
@@ -157,6 +157,9 @@ public class ChwRepositoryFlv {
                 case 41:
                     upgradeToVersion41(db);
                     break;
+                case 44:
+                    upgradeToVersion44(db);
+                    break;
                 default:
                     break;
             }
@@ -821,6 +824,44 @@ public class ChwRepositoryFlv {
             if (cursor != null) {
                 cursor.close();
             }
+        }
+    }
+
+    private static void upgradeToVersion44(SQLiteDatabase db) {
+        applyKvpVisitDateReportFix(db, "upgradeToVersion44");
+    }
+
+    private static void applyKvpVisitDateReportFix(SQLiteDatabase db, String upgradeTag) {
+        try {
+            db.execSQL("ALTER TABLE ec_kvp_prep_followup ADD COLUMN kvp_visit_date VARCHAR;");
+        } catch (Exception e) {
+            Timber.e(e, upgradeTag + "-add-kvp-visit-date");
+        }
+
+        try {
+            db.execSQL("UPDATE ec_kvp_prep_followup " +
+                    "SET kvp_visit_date = (" +
+                    "SELECT event.eventDate FROM event " +
+                    "WHERE event.formSubmissionId = ec_kvp_prep_followup.base_entity_id " +
+                    "AND event.eventType = 'Kvp PrEP Follow-up Visit' " +
+                    "AND event.eventDate IS NOT NULL " +
+                    "AND event.eventDate != '' " +
+                    "ORDER BY event.updatedAt DESC, event.dateCreated DESC LIMIT 1) " +
+                    "WHERE kvp_visit_date IS NULL OR kvp_visit_date = '';");
+        } catch (Exception e) {
+            Timber.e(e, upgradeTag + "-backfill-kvp-visit-date");
+        }
+
+        try {
+            db.execSQL("DELETE FROM indicator_daily_tally WHERE indicator_code LIKE 'kvp-%';");
+            db.execSQL("DELETE FROM indicator_queries WHERE indicator_code LIKE 'kvp-%';");
+            db.execSQL("DELETE FROM indicators WHERE indicator_code LIKE 'kvp-%';");
+
+            ReportingLibrary reportingLibrary = ReportingLibrary.getInstance();
+            reportingLibrary.readConfigFile("config/kvp-monthly-report.yml", db);
+            reportingLibrary.getContext().allSharedPreferences().savePreference(appVersionCodePref, String.valueOf(VERSION_CODE));
+        } catch (Exception e) {
+            Timber.e(e, upgradeTag + "-config");
         }
     }
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HpsAnnualCensusReportConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HpsAnnualCensusReportConfigTest.java
@@ -65,7 +65,7 @@ public class HpsAnnualCensusReportConfigTest {
         );
         Assert.assertTrue(
                 "DATABASE_VERSION should be bumped so the annual census migration runs on upgrade",
-                buildGradle.contains("buildConfigField \"int\", \"DATABASE_VERSION\", '41'")
+                buildGradle.contains("buildConfigField \"int\", \"DATABASE_VERSION\", '44'")
         );
     }
 

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HpsCurativeServicesConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HpsCurativeServicesConfigTest.java
@@ -78,7 +78,7 @@ public class HpsCurativeServicesConfigTest {
         );
         Assert.assertTrue(
                 "DATABASE_VERSION should be bumped so the new migration runs on upgrade",
-                buildGradle.contains("buildConfigField \"int\", \"DATABASE_VERSION\", '41'")
+                buildGradle.contains("buildConfigField \"int\", \"DATABASE_VERSION\", '44'")
         );
     }
 

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpReportConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpReportConfigTest.java
@@ -1,0 +1,90 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class KvpReportConfigTest {
+
+    private static final String BUILD_GRADLE_PATH = "build.gradle";
+    private static final String EC_CLIENT_FIELDS_PATH = "src/nacp/assets/ec_client_fields.json";
+    private static final String KVP_REPORT_CONFIG_PATH = "src/nacp/assets/config/kvp-monthly-report.yml";
+    private static final String HPS_REPOSITORY_FLV_PATH = "src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java";
+
+    @Test
+    public void ecKvpPrepFollowupShouldMapKvpVisitDateFromEventDate() throws Exception {
+        JSONArray tables = new JSONObject(readFile(EC_CLIENT_FIELDS_PATH)).getJSONArray("bindobjects");
+        JSONObject kvpFollowup = findTable(tables, "ec_kvp_prep_followup");
+        Assert.assertNotNull("Missing ec_kvp_prep_followup table definition", kvpFollowup);
+
+        JSONObject kvpVisitDate = findColumn(kvpFollowup.getJSONArray("columns"), "kvp_visit_date");
+        Assert.assertNotNull("ec_kvp_prep_followup must include kvp_visit_date for KVP monthly reports", kvpVisitDate);
+        Assert.assertEquals("eventDate", kvpVisitDate.getJSONObject("json_mapping").getString("field"));
+    }
+
+    @Test
+    public void kvpMonthlyReportShouldUseIsoVisitDateParsing() throws Exception {
+        String kvpReportConfig = readFile(KVP_REPORT_CONFIG_PATH);
+
+        Assert.assertFalse(
+                "KVP monthly indicators should not parse kvp_visit_date as dd-MM-yyyy",
+                kvpReportConfig.contains("substr(ekpf.kvp_visit_date, 7, 4)")
+                        || kvpReportConfig.contains("substr(ekpf.kvp_visit_date, 4, 2)")
+        );
+        Assert.assertTrue(
+                "KVP monthly indicators should parse the ISO eventDate-backed kvp_visit_date",
+                kvpReportConfig.contains("substr(ekpf.kvp_visit_date, 1, 4)")
+                        && kvpReportConfig.contains("substr(ekpf.kvp_visit_date, 6, 2)")
+        );
+        Assert.assertFalse(
+                "KVP referral indicators should not contain an unmatched 10-14 age predicate",
+                kvpReportConfig.contains("WHERE\n                      date(efm.dob, '+10 years') <= date('now'))")
+        );
+    }
+
+    @Test
+    public void kvpMigrationShouldAddBackfillAndReloadReportConfig() throws Exception {
+        String repositoryFlv = readFile(HPS_REPOSITORY_FLV_PATH);
+        String buildGradle = readFile(BUILD_GRADLE_PATH);
+
+        Assert.assertTrue(repositoryFlv.contains("ALTER TABLE ec_kvp_prep_followup ADD COLUMN kvp_visit_date VARCHAR;"));
+        Assert.assertTrue(repositoryFlv.contains("case 44:"));
+        Assert.assertTrue(repositoryFlv.contains("event.formSubmissionId = ec_kvp_prep_followup.base_entity_id"));
+        Assert.assertTrue(repositoryFlv.contains("DELETE FROM indicator_queries WHERE indicator_code LIKE 'kvp-%';"));
+        Assert.assertTrue(repositoryFlv.contains("DELETE FROM indicator_daily_tally WHERE indicator_code LIKE 'kvp-%';"));
+        Assert.assertTrue(repositoryFlv.contains("reportingLibrary.readConfigFile(\"config/kvp-monthly-report.yml\", db)"));
+        Assert.assertTrue(
+                "DATABASE_VERSION should be bumped so the KVP migration runs on upgrade",
+                buildGradle.contains("buildConfigField \"int\", \"DATABASE_VERSION\", '44'")
+        );
+    }
+
+    private JSONObject findTable(JSONArray tables, String tableName) {
+        for (int i = 0; i < tables.length(); i++) {
+            JSONObject table = tables.optJSONObject(i);
+            if (table != null && tableName.equals(table.optString("name"))) {
+                return table;
+            }
+        }
+        return null;
+    }
+
+    private JSONObject findColumn(JSONArray columns, String columnName) {
+        for (int i = 0; i < columns.length(); i++) {
+            JSONObject column = columns.optJSONObject(i);
+            if (column != null && columnName.equals(column.optString("column_name"))) {
+                return column;
+            }
+        }
+        return null;
+    }
+
+    private String readFile(String path) throws Exception {
+        return new String(Files.readAllBytes(Paths.get(path)), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Root cause
KVP report indicators referenced `ec_kvp_prep_followup.kvp_visit_date`, but the KVP follow-up table did not map that column from event data on upgraded installs. The report config also parsed the value as `dd-MM-yyyy` even though the mapped event date is ISO formatted, and four KVP referral queries had malformed 10-14 male age predicates.

## Changes
- Added `kvp_visit_date` mapping from `eventDate` for KVP PrEP follow-up rows.
- Added a NACP DB migration to add/backfill `kvp_visit_date`, clear stale KVP report definitions/tallies, and reload the corrected KVP monthly report config.
- Updated KVP report date parsing to use the ISO event date year/month positions.
- Fixed malformed KVP referral indicator age predicates.
- Added resource tests covering the KVP mapping, report config, and migration wiring.

## Verification
- `./gradlew :opensrp-chw:assembleNacpDebug :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.KvpReportConfigTest --tests org.smartregister.chw.resources.HpsAnnualCensusReportConfigTest --tests org.smartregister.chw.resources.HpsCurativeServicesConfigTest` passed.
- Emulator UI traversal with `markchw:Nacp2022`: `All Clients -> Reports -> KVP REPORTS -> KVP Report` loads the report table.
- Emulator DB verification after login: `user_version=44`, `kvp_visit_date` column present, `old_kvp_date_parser_queries=0`, `malformed_referral_age_queries=0`, `kvp_indicator_queries=799`.
- Executed all 799 KVP indicator SQL queries from the migrated SQLCipher DB with 0 SQL errors.
- Full `./gradlew :opensrp-chw:testNacpDebugUnitTest` still fails in 5 pre-existing `AllClientsMemberProfileActivityTest` cases with `NullPointerException` at `AllClientsMemberProfileActivity.java:63`.

Closes #892