### PR TITLE
🐛 Fix diabetes screening risk score returning 0.0

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/rules/ChwRulesEngineFactory.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/rules/ChwRulesEngineFactory.java
@@ -49,7 +49,8 @@ public class ChwRulesEngineFactory extends RulesEngineFactory {
 
     @Override
     public boolean beforeEvaluate(Rule rule, Facts facts) {
-        return selectedRuleName != null && selectedRuleName.equals(rule.getName());
+        String selected = selectedRuleName;
+        return selected != null && selected.equals(rule.getName());
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/rules/ChwRulesEngineHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/rules/ChwRulesEngineHelper.java
@@ -22,6 +22,12 @@ public class ChwRulesEngineHelper extends RulesEngineHelper {
 
     public double getDiabesityRiskScore(String age, String familyHistory, String waistCircumference,
                                         String systolicBloodPressure, String diastolicBloodPressure) {
+        timber.log.Timber.d("DiabRisk inputs received → age=[%s], familyHistory=[%s], waist=[%s], systolic=[%s], diastolic=[%s]",
+                age, familyHistory, waistCircumference, systolicBloodPressure, diastolicBloodPressure);
+        if (android.text.TextUtils.isEmpty(systolicBloodPressure)) {
+            timber.log.Timber.w(new Throwable("STACK: systolic empty at calc time"),
+                    "Systolic empty — capturing stack trace");
+        }
         return DiabeticRiskCalculator.calculateDiabeticRiskScore(age, familyHistory, waistCircumference,
                 systolicBloodPressure, diastolicBloodPressure);
     }

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/presenter/NcdJsonWizardFormFragmentPresenter.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/presenter/NcdJsonWizardFormFragmentPresenter.java
@@ -1,6 +1,9 @@
 package org.smartregister.chw.presenter;
 
+import android.content.Context;
 import android.content.Intent;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
 
 import com.vijay.jsonwizard.fragments.JsonFormFragment;
@@ -23,6 +26,7 @@ public class NcdJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
 
     @Override
     public boolean onNextClick(LinearLayout mainView) {
+        commitPendingInput(mainView);
         validateAndWriteValues();
         checkAndStopCountdownAlarm();
         boolean validateOnSubmit = validateOnSubmit();
@@ -50,10 +54,14 @@ public class NcdJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
             getFormFragment().getJsonApi().invokeRefreshLogic(null, false, null, null, nextStep, true);
             if (!getFormFragment().getJsonApi().isNextStepRelevant()) {
                 com.vijay.jsonwizard.utils.Utils.checkIfStepHasNoSkipLogic(getFormFragment());
-                // Clear data for skipped step
-                clearStepData(nextStep);
             }
             isSkipped = getFormFragment().skipStepsOnNextPressed(nextStep);
+            // Only clear data if the step is actually being skipped — calling
+            // clearStepData when the step is shown causes a writeValue cascade
+            // that wipes legitimate prior-step values.
+            if (isSkipped) {
+                clearStepData(nextStep);
+            }
         }
         return isSkipped;
     }
@@ -89,6 +97,7 @@ public class NcdJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
 
     @Override
     public void onSaveClick(LinearLayout mainView) {
+        commitPendingInput(mainView);
         validateAndWriteValues();
         checkAndStopCountdownAlarm();
         boolean isFormValid = isFormValid();
@@ -109,6 +118,23 @@ public class NcdJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
                         .getString(com.vijay.jsonwizard.R.string.json_form_error_msg, getInvalidFields().size()));
 
             }
+        }
+    }
+
+    private void commitPendingInput(LinearLayout root) {
+        if (root == null) return;
+        if (android.os.Looper.myLooper() != android.os.Looper.getMainLooper()) {
+            return;
+        }
+        View focused = root.findFocus();
+        if (focused == null) return;
+
+        focused.clearFocus();
+
+        InputMethodManager imm = (InputMethodManager) focused.getContext()
+                .getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (imm != null) {
+            imm.hideSoftInputFromWindow(focused.getWindowToken(), 0);
         }
     }
 


### PR DESCRIPTION
Three combined fixes addressing an intermittent bug where the risk score on step4 displayed 0.0 even with valid inputs:

- ChwRulesEngineFactory.beforeEvaluate: cache selectedRuleName to a local variable to close a data race with concurrent calculation/relevance evaluations. The previous (non-volatile field read → null-check → re-read for .equals) pattern threw NPE under load, causing Easy Rules to silently skip the relevance rule and leaving isRelevant=false. The field is hidden and its value cleared, which cascades to clearing prior-step fields and producing a 0.0 score.

- NcdJsonWizardFormFragmentPresenter.executeRefreshLogicForNextStep: gate clearStepData on actual skipStepsOnNextPressed result. The previous logic cleared step4 data whenever isNextStepRelevant() was momentarily false — common because step4 toaster relevance rules depend on the still-async score calculation — triggering writeValue cascades that wiped step3 inputs.

- NcdJsonWizardFormFragmentPresenter.commitPendingInput: UI-thread guard prevents CalledFromWrongThreadException when onNextClick runs on the NextProgressDialogTask worker thread.

- ChwRulesEngineHelper.getDiabesityRiskScore: add diagnostic logging of inputs and a stack trace on empty systolic to support ongoing telemetry.