### PR TITLE
✨ chore: support location info visibility for independent clients

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
@@ -4,6 +4,7 @@ import static org.smartregister.AllConstants.TEAM_ROLE_IDENTIFIER;
 import static org.smartregister.chw.core.utils.CoreConstants.INTENT_KEY.CLIENT;
 import static org.smartregister.chw.core.utils.Utils.getDuration;
 import static org.smartregister.chw.core.utils.Utils.passToolbarTitle;
+import static org.smartregister.chw.util.Constants.ENTITY_TYPE_EC_INDEPENDENT_CLIENT;
 import static org.smartregister.opd.utils.OpdDbConstants.KEY.REGISTER_TYPE;
 import static org.smartregister.util.Utils.showShortToast;
 
@@ -239,6 +240,7 @@ public class AllClientsUtils {
         String baseEntityId = commonPersonObject.entityId();
         FamilyOtherMemberProfileActivity.Flavor flavor = new FamilyOtherMemberProfileActivityFlv();
         String gender = org.smartregister.chw.util.Utils.getValue(commonPersonObject.getColumnmaps(), DBConstants.KEY.GENDER, false);
+        String entityType = org.smartregister.chw.util.Utils.getValue(commonPersonObject.getColumnmaps(), DBConstants.KEY.ENTITY_TYPE, false);
 
         // Cache menu items to avoid multiple lookups
         MenuItem locationInfo = menu.findItem(R.id.action_location_info);
@@ -248,7 +250,7 @@ public class AllClientsUtils {
         MenuItem removeMember = menu.findItem(R.id.action_remove_member);
 
         // Set visibility for the common items
-        if (locationInfo != null) locationInfo.setVisible(true);
+        if (locationInfo != null && entityType.equalsIgnoreCase(ENTITY_TYPE_EC_INDEPENDENT_CLIENT)) locationInfo.setVisible(true);
         if (tbRegistration != null) tbRegistration.setVisible(false);
         if (sickChildFollowUp != null) sickChildFollowUp.setVisible(false);
         if (malariaDiagnosis != null) malariaDiagnosis.setVisible(false);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -35,6 +35,7 @@ public class Constants extends CoreConstants {
     public static String ENABLE_DATE_RANGE_FILTER = "ENABLE_DATE_RANGE_FILTER";
     public static String ENTITY_TYPE_EC_FAMILY_MEMBER = "ec_family_member";
     public static String ENTITY_TYPE_EC_FAMILY = "ec_family";
+    public static String ENTITY_TYPE_EC_INDEPENDENT_CLIENT = "ec_independent_client";
 
     public static int REQUEST_FILTERS = 2004;
 


### PR DESCRIPTION
Add `ENTITY_TYPE_EC_INDEPENDENT_CLIENT` constant and update `AllClientsUtils` to conditionally show the location info menu item based on the client's entity type.

- ⚙️ **Constants**: add `ENTITY_TYPE_EC_INDEPENDENT_CLIENT` string
- 🛠️ **AllClientsUtils**: update `setupMenu` logic to only display `action_location_info` if the entity type matches an independent client

"Closes #753" and "Closes #214"