### PR TITLE
Enable AYP out-of-school role access

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/InAppReportsActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/InAppReportsActivity.java
@@ -103,6 +103,9 @@ public class InAppReportsActivity extends SecuredActivity implements View.OnClic
                 case "iccm_provider":
                     iccmReports.setVisibility(View.VISIBLE);
                     break;
+                case "AYP_OUT_OF_SCHOOL":
+                    aypOutSchoolReports.setVisibility(View.VISIBLE);
+                    break;
                 default:
                     if (ChwApplication.getApplicationFlavor().hasHIV()) {
                         cbhsReportsLayout.setVisibility(View.VISIBLE);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/AllClientsUtils.java
@@ -285,6 +285,12 @@ public class AllClientsUtils {
                 case "iccm_provider":
                     updateIccmMenu(menu, baseEntityId, flavor);
                     break;
+                case "AYP_OUT_OF_SCHOOL":
+                    // Handle AYP Out of School menu items
+                    if (ChwApplication.getApplicationFlavor().hasAyp()) {
+                        setMenuItemVisibility(menu, R.id.action_ayp_out_school_enrollment, !AypDao.isRegisteredForAypOutSchoolServices(baseEntityId) && age >= 10 && age < 25);
+                    }
+                    break;
                 case "icchw": {
                     // Handle HPS menu items
                     if (ChwApplication.getApplicationFlavor().hasHps()) {

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/model/NavigationModelFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/model/NavigationModelFlv.java
@@ -80,6 +80,9 @@ public class NavigationModelFlv implements NavigationModel.Flavor {
                     case "rmncah_provider":
                         navigationOptions.addAll(Arrays.asList(op10, op1, op3, op5, op2, op25, op8, op9));
                         break;
+                    case "AYP_OUT_OF_SCHOOL":
+                        navigationOptions.addAll(Arrays.asList(op10, op28, op9, op8));
+                        break;
                     default:
                         navigationOptions.addAll(Arrays.asList(op10, op1, op11, op12, op3, op5, op2, op13));
                         if (ChwApplication.getApplicationFlavor().hasHIVST()) {


### PR DESCRIPTION
## Summary
- Show the AYP out-of-school monthly report for users with the `AYP_OUT_OF_SCHOOL` role.
- Add the AYP out-of-school drawer option for the NACP flavor role-specific navigation.
- Allow eligible clients to access AYP out-of-school enrollment from the all-clients menu.

## Review notes
- Fixed a switch fall-through risk so `iccm_provider` menu handling remains isolated from the new AYP out-of-school role branch.

## Validation
- `./gradlew :opensrp-chw:compileNacpDebugJavaWithJavac`