### PR TITLE
Update Harm Reduction HIV tested translation

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -738,7 +738,7 @@
     <string name="harm_reduction_hiv_aids">VVU na UKIMWI</string>
     <string name="harm_reduction_hiv_results">Matokeo ya kipimo cha VVU</string>
     <string name="harm_reduction_hiv_test_location">Upimaji ulipofanyika</string>
-    <string name="harm_reduction_hiv_tested">Je, mpokea huduma amewahi kupima VVU?</string>
+    <string name="harm_reduction_hiv_tested">Je, mpokea huduma amepima VVU?</string>
     <string name="harm_reduction_hiv_testing">Upimaji wa VVU</string>
     <string name="harm_reduction_home">Nyumbani</string>
     <string name="harm_reduction_iec_communicable_diseases">Magonjwa ya kuambukiza</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -309,7 +309,7 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_hiv_aids", "VVU na UKIMWI");
         values.put("harm_reduction_hiv_results", "Matokeo ya kipimo cha VVU");
         values.put("harm_reduction_hiv_test_location", "Upimaji ulipofanyika");
-        values.put("harm_reduction_hiv_tested", "Je, mpokea huduma amewahi kupima VVU?");
+        values.put("harm_reduction_hiv_tested", "Je, mpokea huduma amepima VVU?");
         values.put("harm_reduction_hiv_testing", "Upimaji wa VVU");
         values.put("harm_reduction_home", "Nyumbani");
         values.put("harm_reduction_iec_communicable_diseases", "Magonjwa ya kuambukiza");


### PR DESCRIPTION
## Root cause
The NACP app Swahili visit-history label for `harm_reduction_hiv_tested` still used `amewahi kupima VVU`, which is inconsistent with the corrected current-testing wording requested in #876.

## Changes
- Updated the Swahili `harm_reduction_hiv_tested` string to `Je, mpokea huduma amepima VVU?`.
- Updated the Harm Reduction visit-history translation test expectation.

## Verification
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest` passed.

Refs #876