### PR TITLE
General APK Merge Fixes and Improvements

### DIFF
--- a/opensrp-chw/src/main/AndroidManifest.xml
+++ b/opensrp-chw/src/main/AndroidManifest.xml
@@ -297,6 +297,9 @@
             android:name=".activity.AncRegisterActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity
+            android:name=".activity.AncJsonWizardFormActivity"
+            android:theme="@style/ChwTheme.NoActionBar" />
+        <activity
             android:name=".activity.AncMemberProfileActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/AncJsonWizardFormActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/AncJsonWizardFormActivity.java
@@ -1,0 +1,18 @@
+package org.smartregister.chw.activity;
+
+import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+
+import org.smartregister.chw.fragment.AncJsonWizardFormFragment;
+import org.smartregister.family.activity.FamilyWizardFormActivity;
+
+public class AncJsonWizardFormActivity extends FamilyWizardFormActivity {
+
+    @Override
+    public synchronized void initializeFormFragment() {
+        AncJsonWizardFormFragment formFragment = AncJsonWizardFormFragment.getFormFragment(JsonFormConstants.FIRST_STEP_NAME);
+        getSupportFragmentManager().beginTransaction()
+                .add(R.id.container, formFragment)
+                .commit();
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/AncRegisterActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/AncRegisterActivity.java
@@ -27,7 +27,6 @@ import org.smartregister.chw.fragment.AncPartnerFollowupRegisterFragment;
 import org.smartregister.chw.fragment.AncRegisterFragment;
 import org.smartregister.chw.schedulers.ChwScheduleTaskExecutor;
 import org.smartregister.family.util.JsonFormUtils;
-import org.smartregister.family.util.Utils;
 import org.smartregister.helper.BottomNavigationHelper;
 import org.smartregister.job.SyncServiceJob;
 import org.smartregister.view.fragment.BaseRegisterFragment;
@@ -100,7 +99,7 @@ public class AncRegisterActivity extends CoreAncRegisterActivity implements Bott
 
             FormUtils.updateFormField(jsonArray, values);
 
-            Intent intent = new Intent(this, Utils.metadata().familyMemberFormActivity);
+            Intent intent = new Intent(this, AncJsonWizardFormActivity.class);
             intent.putExtra(org.smartregister.family.util.Constants.JSON_FORM_EXTRA.JSON, jsonForm.toString());
 
             Form form = new Form();

--- a/opensrp-chw/src/main/java/org/smartregister/chw/fragment/AncJsonWizardFormFragment.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/fragment/AncJsonWizardFormFragment.java
@@ -1,0 +1,25 @@
+package org.smartregister.chw.fragment;
+
+import android.os.Bundle;
+
+import com.vijay.jsonwizard.fragments.JsonWizardFormFragment;
+import com.vijay.jsonwizard.interactors.JsonFormInteractor;
+import com.vijay.jsonwizard.presenters.JsonFormFragmentPresenter;
+
+import org.smartregister.chw.presenter.AncJsonWizardFormFragmentPresenter;
+
+public class AncJsonWizardFormFragment extends JsonWizardFormFragment {
+
+    public static AncJsonWizardFormFragment getFormFragment(String stepName) {
+        AncJsonWizardFormFragment formFragment = new AncJsonWizardFormFragment();
+        Bundle bundle = new Bundle();
+        bundle.putString("stepName", stepName);
+        formFragment.setArguments(bundle);
+        return formFragment;
+    }
+
+    @Override
+    protected JsonFormFragmentPresenter createPresenter() {
+        return new AncJsonWizardFormFragmentPresenter(this, JsonFormInteractor.getInstance());
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
@@ -30,8 +30,6 @@ public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
 
     private static final String LMP_FIELD = "last_menstrual_period";
     private static final String FIRST_CLINIC_VISIT_FIELD = "first_clinic_visit_date";
-    private static final String INVALID_DATE_FIELD_ERROR = "Invalid date";
-    private static final String INVALID_DATE_SNACKBAR_ERROR = "First ANC visit must be 28+ days after LMP";
     private static final int MINIMUM_DAYS_AFTER_LMP = 28;
 
     public AncJsonWizardFormFragmentPresenter(JsonFormFragment formFragment, JsonFormInteractor jsonFormInteractor) {
@@ -143,8 +141,8 @@ public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
     }
 
     private void showFieldError() {
-        String fieldError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_error, INVALID_DATE_FIELD_ERROR);
-        String snackBarError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_snackbar_error, INVALID_DATE_SNACKBAR_ERROR);
+        String fieldError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_error, "");
+        String snackBarError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_snackbar_error, "");
         View fieldView = getFieldView(FIRST_CLINIC_VISIT_FIELD);
         if (fieldView instanceof MaterialEditText) {
             MaterialEditText editText = (MaterialEditText) fieldView;

--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
@@ -141,8 +141,8 @@ public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
     }
 
     private void showFieldError() {
-        String fieldError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_error, "");
-        String snackBarError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_snackbar_error, "");
+        String fieldError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_error);
+        String snackBarError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_snackbar_error);
         View fieldView = getFieldView(FIRST_CLINIC_VISIT_FIELD);
         if (fieldView instanceof MaterialEditText) {
             MaterialEditText editText = (MaterialEditText) fieldView;
@@ -159,10 +159,10 @@ public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
         }
     }
 
-    private String getString(int resId, String fallback) {
+    private String getString(int resId) {
         return getFormFragment() != null && getFormFragment().getContext() != null
                 ? getFormFragment().getContext().getString(resId)
-                : fallback;
+                : "";
     }
 
     private void clearFieldError() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
@@ -1,0 +1,216 @@
+package org.smartregister.chw.presenter;
+
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.Toast;
+
+import com.rengwuxian.materialedittext.MaterialEditText;
+import com.vijay.jsonwizard.R;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.fragments.JsonFormFragment;
+import com.vijay.jsonwizard.interactors.JsonFormInteractor;
+import com.vijay.jsonwizard.interfaces.JsonApi;
+import com.vijay.jsonwizard.presenters.JsonWizardFormFragmentPresenter;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+import timber.log.Timber;
+
+public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPresenter {
+
+    private static final String LMP_FIELD = "last_menstrual_period";
+    private static final String FIRST_CLINIC_VISIT_FIELD = "first_clinic_visit_date";
+    private static final String INVALID_DATE_FIELD_ERROR = "Invalid date";
+    private static final String INVALID_DATE_SNACKBAR_ERROR = "First ANC visit must be 28+ days after LMP";
+    private static final int MINIMUM_DAYS_AFTER_LMP = 28;
+
+    public AncJsonWizardFormFragmentPresenter(JsonFormFragment formFragment, JsonFormInteractor jsonFormInteractor) {
+        super(formFragment, jsonFormInteractor);
+    }
+
+    @Override
+    protected boolean moveToNextWizardStep() {
+        if (JsonFormConstants.FIRST_STEP_NAME.equals(mStepName) && !validateStepOneBeforeNext()) {
+            return false;
+        }
+        return super.moveToNextWizardStep();
+    }
+
+    private boolean validateStepOneBeforeNext() {
+        String lmpDate = getFormFieldValue(LMP_FIELD);
+        String firstClinicVisitDate = getFormFieldValue(FIRST_CLINIC_VISIT_FIELD);
+
+        if (TextUtils.isEmpty(lmpDate) || TextUtils.isEmpty(firstClinicVisitDate)) {
+            return true;
+        }
+
+        try {
+            Date lmp = parseOpenSrpDate(lmpDate);
+            Date firstVisit = parseOpenSrpDate(firstClinicVisitDate);
+
+            long diffMillis = firstVisit.getTime() - lmp.getTime();
+            long diffDays = TimeUnit.MILLISECONDS.toDays(diffMillis);
+
+            if (diffDays < MINIMUM_DAYS_AFTER_LMP) {
+                showFieldError();
+                return false;
+            }
+
+            clearFieldError();
+            return true;
+        } catch (Exception e) {
+            Timber.e(e);
+            showFieldError();
+            return false;
+        }
+    }
+
+    private String getFormFieldValue(String fieldKey) {
+        String value = getFieldValueFromStep(fieldKey);
+        if (!TextUtils.isEmpty(value)) {
+            return value.trim();
+        }
+
+        View fieldView = getFieldView(fieldKey);
+        if (fieldView instanceof MaterialEditText) {
+            CharSequence text = ((MaterialEditText) fieldView).getText();
+            return text == null ? "" : text.toString().trim();
+        }
+
+        return "";
+    }
+
+    private String getFieldValueFromStep(String fieldKey) {
+        try {
+            JsonApi jsonApi = getFormFragment().getJsonApi();
+            if (jsonApi == null) {
+                return "";
+            }
+
+            JSONObject stepOne = jsonApi.getStep(JsonFormConstants.FIRST_STEP_NAME);
+            if (stepOne == null) {
+                return "";
+            }
+
+            JSONArray fields = stepOne.optJSONArray(JsonFormConstants.FIELDS);
+            if (fields == null) {
+                return "";
+            }
+
+            JSONObject field = getField(fields, fieldKey);
+            return field == null ? "" : field.optString(JsonFormConstants.VALUE, "");
+        } catch (Exception e) {
+            Timber.e(e);
+            return "";
+        }
+    }
+
+    private JSONObject getField(JSONArray fields, String fieldKey) {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (fieldKey.equals(field == null ? null : field.optString(JsonFormConstants.KEY))) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    private Date parseOpenSrpDate(String value) throws ParseException {
+        List<String> formats = Arrays.asList("dd-MM-yyyy", "yyyy-MM-dd");
+        ParseException parseException = null;
+
+        for (String format : formats) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat(format, Locale.US);
+                sdf.setLenient(false);
+                return sdf.parse(value);
+            } catch (ParseException e) {
+                parseException = e;
+            }
+        }
+
+        throw parseException == null ? new ParseException("Unsupported date format: " + value, 0) : parseException;
+    }
+
+    private void showFieldError() {
+        String fieldError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_error, INVALID_DATE_FIELD_ERROR);
+        String snackBarError = getString(org.smartregister.chw.R.string.invalid_first_clinic_visit_date_snackbar_error, INVALID_DATE_SNACKBAR_ERROR);
+        View fieldView = getFieldView(FIRST_CLINIC_VISIT_FIELD);
+        if (fieldView instanceof MaterialEditText) {
+            MaterialEditText editText = (MaterialEditText) fieldView;
+            editText.setError(fieldError);
+            editText.requestFocus();
+            getFormFragment().scrollToView(editText);
+        }
+
+        if (getFormFragment() != null) {
+            getFormFragment().showSnackBar(snackBarError);
+            if (!(fieldView instanceof MaterialEditText) && getFormFragment().getContext() != null) {
+                Toast.makeText(getFormFragment().getContext(), snackBarError, Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    private String getString(int resId, String fallback) {
+        return getFormFragment() != null && getFormFragment().getContext() != null
+                ? getFormFragment().getContext().getString(resId)
+                : fallback;
+    }
+
+    private void clearFieldError() {
+        View fieldView = getFieldView(FIRST_CLINIC_VISIT_FIELD);
+        if (fieldView instanceof MaterialEditText) {
+            ((MaterialEditText) fieldView).setError(null);
+        }
+    }
+
+    private View getFieldView(String fieldKey) {
+        try {
+            JsonApi jsonApi = getFormFragment().getJsonApi();
+            if (jsonApi == null) {
+                return null;
+            }
+
+            View fieldView = jsonApi.getFormDataView(JsonFormConstants.FIRST_STEP_NAME + ":" + fieldKey);
+            if (fieldView != null) {
+                return fieldView;
+            }
+
+            fieldView = jsonApi.getFormDataView(mStepName + ":" + fieldKey);
+            if (fieldView != null) {
+                return fieldView;
+            }
+
+            fieldView = jsonApi.getFormDataView(fieldKey);
+            if (fieldView != null) {
+                return fieldView;
+            }
+
+            Collection<View> formDataViews = jsonApi.getFormDataViews();
+            if (formDataViews == null) {
+                return null;
+            }
+
+            for (View view : formDataViews) {
+                if (view != null && fieldKey.equals(view.getTag(R.id.key))) {
+                    return view;
+                }
+            }
+
+            return null;
+        } catch (Exception e) {
+            Timber.e(e);
+            return null;
+        }
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/presenter/AncJsonWizardFormFragmentPresenter.java
@@ -30,7 +30,7 @@ public class AncJsonWizardFormFragmentPresenter extends JsonWizardFormFragmentPr
 
     private static final String LMP_FIELD = "last_menstrual_period";
     private static final String FIRST_CLINIC_VISIT_FIELD = "first_clinic_visit_date";
-    private static final int MINIMUM_DAYS_AFTER_LMP = 28;
+    private static final int MINIMUM_DAYS_AFTER_LMP = 22;
 
     public AncJsonWizardFormFragmentPresenter(JsonFormFragment formFragment, JsonFormInteractor jsonFormInteractor) {
         super(formFragment, jsonFormInteractor);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/JsonFormUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/JsonFormUtils.java
@@ -8,11 +8,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.smartregister.client.utils.constants.JsonFormConstants.STEP1;
 
 import android.content.Context;
+import android.content.Intent;
 import android.util.Pair;
 
 import com.google.common.reflect.TypeToken;
 import com.nerdstone.neatformcore.domain.model.NFormViewData;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
+import com.vijay.jsonwizard.domain.Form;
 
 import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
@@ -23,6 +25,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.smartregister.AllConstants;
+import org.smartregister.chw.activity.AncJsonWizardFormActivity;
 import org.smartregister.chw.application.ChwApplication;
 import org.smartregister.chw.core.domain.FamilyMember;
 import org.smartregister.chw.core.domain.ParentClient;
@@ -73,6 +76,8 @@ import timber.log.Timber;
 public class JsonFormUtils extends CoreJsonFormUtils {
     public static final String METADATA = "metadata";
     public static final String ENCOUNTER_TYPE = "encounter_type";
+    private static final String LAST_MENSTRUAL_PERIOD = "last_menstrual_period";
+    private static final String FIRST_CLINIC_VISIT_DATE = "first_clinic_visit_date";
     public static final int REQUEST_CODE_GET_JSON = 2244;
     public static final int REQUEST_CODE_GET_JSON_WASH = 22444;
     public static final int REQUEST_CODE_GET_JSON_FAMILY_KIT = 22447;
@@ -138,6 +143,56 @@ public class JsonFormUtils extends CoreJsonFormUtils {
             Timber.e(e);
             return null;
         }
+    }
+
+    public static Intent getAncPncStartFormIntent(JSONObject jsonForm, Context context) {
+        if (!isAncRegistrationDateAlignmentForm(jsonForm)) {
+            return CoreJsonFormUtils.getAncPncStartFormIntent(jsonForm, context);
+        }
+
+        Intent intent = new Intent(context, AncJsonWizardFormActivity.class);
+        intent.putExtra(org.smartregister.family.util.Constants.JSON_FORM_EXTRA.JSON, jsonForm.toString());
+
+        Form form = new Form();
+        form.setActionBarBackground(org.smartregister.chw.core.R.color.family_actionbar);
+        form.setNavigationBackground(org.smartregister.chw.core.R.color.family_navigation);
+        form.setWizard(true);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.FORM, form);
+        return intent;
+    }
+
+    private static boolean isAncRegistrationDateAlignmentForm(JSONObject jsonForm) {
+        if (jsonForm == null) {
+            return false;
+        }
+
+        JSONObject stepOne = jsonForm.optJSONObject(JsonFormConstants.STEP1);
+        if (stepOne == null) {
+            return false;
+        }
+
+        JSONArray fields = stepOne.optJSONArray(JsonFormConstants.FIELDS);
+        if (fields == null) {
+            return false;
+        }
+
+        boolean hasLmp = false;
+        boolean hasFirstClinicVisit = false;
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field == null) {
+                continue;
+            }
+
+            String key = field.optString(JsonFormConstants.KEY);
+            if (LAST_MENSTRUAL_PERIOD.equals(key)) {
+                hasLmp = true;
+            } else if (FIRST_CLINIC_VISIT_DATE.equals(key)) {
+                hasFirstClinicVisit = true;
+            }
+        }
+
+        return hasLmp && hasFirstClinicVisit;
     }
 
     public static Event tagSyncMetadata(AllSharedPreferences allSharedPreferences, Event event) {

--- a/opensrp-chw/src/nacp/assets/json.form-sw/anc_hv_health_facility_visit.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/anc_hv_health_facility_visit.json
@@ -59,44 +59,6 @@
         "text_color": "#000000"
       },
       {
-        "key": "clinic_attendance_intro_1",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "clinic_attendance_intro_1",
-        "type": "label",
-        "text": "KUMBUSHO KWA MJA: Muombe mama kadi ya kliniki.",
-        "text_color": "#000000"
-      },
-      {
-        "key": "first_clinic_visit",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "first_clinic_visit",
-        "openmrs_data_type": "text",
-        "type": "edit_text",
-        "hint": "Je, ulikuwa na ujauzito wa wiki ngapi ulipohudhuria kliniki ya wajawazito kwa mara ya kwanza?",
-        "v_numeric_integer": {
-          "value": "true",
-          "err": "Jibu lazima liwe namba kamili"
-        },
-        "v_numeric": {
-          "value": "true",
-          "err": "Jibu lazima liwe namba"
-        },
-        "v_min": {
-          "value": "0",
-          "err": "Jibu la kiwango cha chini"
-        },
-        "v_max": {
-          "value": "40",
-          "err": "Jibu la kiwango cha juu"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Jibu linahitajika"
-        }
-      },
-      {
         "key": "anc_hf_visit",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/anc_member_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/anc_member_registration.json
@@ -58,6 +58,15 @@
         "type": "hidden"
       },
       {
+        "key": "clinic_card_reminder_info",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "clinic_card_reminder_info",
+        "type": "label",
+        "text": "KUMBUSHO KWA MJA: Muombe mama kadi ya kliniki.",
+        "text_color": "#000000"
+      },
+      {
         "key": "last_menstrual_period",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -121,10 +130,57 @@
         }
       },
       {
+        "key": "first_clinic_visit_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_date",
+        "type": "date_picker",
+        "hint": "Tarehe ya Hudhurio la Kwanza la Kliniki ya Ujauzito Huu",
+        "label_info_title": "Tarehe ya Hudhurio la Kwanza la Kliniki ya Ujauzito Huu",
+        "label_info_text": "Tarehe ya Hudhurio la Kwanza la Kliniki ya Ujauzito Huu = Siku ya kwanza mama mjamzito alipohudhuria kliniki kwa ujauzito wa sasa.",
+        "expanded": false,
+        "max_date": "today",
+        "min_date": "today-50w",
+        "v_required": {
+          "value": "true",
+          "err": "Tarehe ya Hudhurio la Kwanza la Kliniki ya Ujauzito Huu inahitajika kujazwa"
+        }
+      },
+      {
+        "key": "first_clinic_visit_age_note",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_age_note",
+        "type": "edit_text",
+        "hint": "Umri wa ujauzito kwa wiki wakati mama alipohudhuria kliniki kwa mara ya kwanza",
+        "read_only": true,
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "anc_member_registration_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "gest_age",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
         "openmrs_entity_id": "gest_age",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "anc_member_registration_calculation.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "first_clinic_visit_gest_age",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_gest_age",
         "type": "hidden",
         "calculation": {
           "rules-engine": {

--- a/opensrp-chw/src/nacp/assets/json.form/anc_hv_health_facility_visit.json
+++ b/opensrp-chw/src/nacp/assets/json.form/anc_hv_health_facility_visit.json
@@ -59,44 +59,6 @@
         "text_color": "#000000"
       },
       {
-        "key": "clinic_attendance_intro_1",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "clinic_attendance_intro_1",
-        "type": "label",
-        "text": "Reminder for CHW: Ask pregnant woman for the ANC clinic booklet",
-        "text_color": "#000000"
-      },
-      {
-        "key": "first_clinic_visit",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "first_clinic_visit",
-        "openmrs_data_type": "text",
-        "type": "edit_text",
-        "hint": "How many weeks pregnant were you when you first received antenatal care for this current pregnancy?",
-        "v_numeric_integer": {
-          "value": "true",
-          "err": "Value has to be an integer"
-        },
-        "v_numeric": {
-          "value": "true",
-          "err": "Value has to be a number"
-        },
-        "v_min": {
-          "value": "0",
-          "err": "Value below the minimum"
-        },
-        "v_max": {
-          "value": "40",
-          "err": "Value above the maximum"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Value required"
-        }
-      },
-      {
         "key": "anc_hf_visit",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/anc_member_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form/anc_member_registration.json
@@ -58,6 +58,15 @@
         "type": "hidden"
       },
       {
+        "key": "clinic_card_reminder_info",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "clinic_card_reminder_info",
+        "type": "label",
+        "text": "Reminder for CHW: Ask pregnant woman for the ANC clinic booklet",
+        "text_color": "#000000"
+      },
+      {
         "key": "last_menstrual_period",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -121,10 +130,57 @@
         }
       },
       {
+        "key": "first_clinic_visit_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_date",
+        "type": "date_picker",
+        "hint": "Date of first clinic attendance for this pregnancy",
+        "label_info_title": "Date of first clinic attendance for this pregnancy",
+        "label_info_text": "Date of first clinic attendance for this pregnancy = The Date of the first day the pregnant woman attended the clinic for the current pregnancy",
+        "expanded": false,
+        "max_date": "today",
+        "min_date": "today-50w",
+        "v_required": {
+          "value": "true",
+          "err": "Date of first clinic attendance for this pregnancy"
+        }
+      },
+      {
+        "key": "first_clinic_visit_age_note",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_age_note",
+        "type": "edit_text",
+        "hint": "Pregnancy age in weeks when the mother first attended the antenatal clinic",
+        "read_only": true,
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "anc_member_registration_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "gest_age",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
         "openmrs_entity_id": "gest_age",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "anc_member_registration_calculation.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "first_clinic_visit_gest_age",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "first_clinic_visit_gest_age",
         "type": "hidden",
         "calculation": {
           "rules-engine": {

--- a/opensrp-chw/src/nacp/assets/rule/anc_member_registration_calculation.yml
+++ b/opensrp-chw/src/nacp/assets/rule/anc_member_registration_calculation.yml
@@ -45,3 +45,19 @@ priority: 1
 condition: "step1_no_prev_preg == 1"
 actions:
   - "calculation = '0'"
+---
+name: step1_first_clinic_visit_gest_age
+description: First Clinic Visit Gestational age calculated
+priority: 1
+condition: "true"
+actions:
+  - "calculation = (helper.getDifferenceDays(step1_first_clinic_visit_date,step1_last_menstrual_period)) /7"
+#  - "calculation = (helper.getDifferenceDays(step1_edd != '' ? helper.subtractDuration(step1_edd,'280d')  : step1_last_menstrual_period)-helper.getDifferenceDays(helper.getDateToday())) /7"
+
+---
+name: step1_first_clinic_visit_age_note
+description: First Clinic Gestational age calculated
+priority: 1
+condition: "true"
+actions:
+  - "calculation = step1_first_clinic_visit_gest_age"

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -1831,6 +1831,6 @@
     <string name="anc_action_taken">Hatua iliyochukuliwa</string>
     <string name="anc_chw_comment_anc">Maoni</string>
     <string name="invalid_first_clinic_visit_date_error">Tarehe Sio Sahihi</string>
-    <string name="invalid_first_clinic_visit_date_snackbar_error">Hudhurio la kwanza la ujauzito lazima liwe angalau siku 28 baada ya tarehe ya hedhi ya mwisho.</string>
+    <string name="invalid_first_clinic_visit_date_snackbar_error">Hudhurio la kwanza la ujauzito lazima liwe angalau siku 22 baada ya tarehe ya hedhi ya mwisho.</string>
 
 </resources>

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -1831,6 +1831,6 @@
     <string name="anc_action_taken">Hatua iliyochukuliwa</string>
     <string name="anc_chw_comment_anc">Maoni</string>
     <string name="invalid_first_clinic_visit_date_error">Tarehe Sio Sahihi</string>
-    <string name="invalid_first_clinic_visit_date_snackbar_error">Hudhurio la kwanza la kwanza la Mjamzito lazima liwe siku 28 au zaidi baada ya tarehe ya hedhi ya mwisho</string>
+    <string name="invalid_first_clinic_visit_date_snackbar_error">Hudhurio la kwanza la ujauzito lazima liwe angalau siku 28 baada ya tarehe ya hedhi ya mwisho.</string>
 
 </resources>

--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -1830,5 +1830,7 @@
     <string name="anc_illness_description">Maelezo ya ugonjwa</string>
     <string name="anc_action_taken">Hatua iliyochukuliwa</string>
     <string name="anc_chw_comment_anc">Maoni</string>
+    <string name="invalid_first_clinic_visit_date_error">Tarehe Sio Sahihi</string>
+    <string name="invalid_first_clinic_visit_date_snackbar_error">Hudhurio la kwanza la kwanza la Mjamzito lazima liwe siku 28 au zaidi baada ya tarehe ya hedhi ya mwisho</string>
 
 </resources>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -1982,6 +1982,8 @@
     <string name="anc_illness_description">Illness description</string>
     <string name="anc_action_taken">Action taken</string>
     <string name="anc_chw_comment_anc">Remarks / comments</string>
+    <string name="invalid_first_clinic_visit_date_error">Invalid Date</string>
+    <string name="invalid_first_clinic_visit_date_snackbar_error">First ANC visit must be 28+ days after LMP</string>
 
 
 </resources>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -1983,7 +1983,7 @@
     <string name="anc_action_taken">Action taken</string>
     <string name="anc_chw_comment_anc">Remarks / comments</string>
     <string name="invalid_first_clinic_visit_date_error">Invalid Date</string>
-    <string name="invalid_first_clinic_visit_date_snackbar_error">First ANC visit must be 28+ days after LMP</string>
+    <string name="invalid_first_clinic_visit_date_snackbar_error">First ANC visit must be 22+ days after LMP</string>
 
 
 </resources>


### PR DESCRIPTION
Introduces a specialized form activity and presenter to validate that the first ANC clinic visit occurs at least 28 days after the Last Menstrual Period (LMP) during ANC registration.

⚙️ **Logic & Validation:**
- Create `AncJsonWizardFormActivity` and `AncJsonWizardFormFragmentPresenter` to handle custom ANC form logic.
- Implement `validateStepOneBeforeNext` to enforce a minimum 28-day gap between `last_menstrual_period` and `first_clinic_visit_date`.
- Add `AncJsonWizardFormFragment` to hook into the custom presenter.
- Update `JsonFormUtils` to route forms containing both LMP and visit date fields to the new `AncJsonWizardFormActivity`.

📋 **Form & Rule Updates:**
- **ANC Registration:** Added `first_clinic_visit_date`, `first_clinic_visit_age_note`, and `first_clinic_visit_gest_age` fields.
- **Rules:** Added `anc_member_registration_calculation.yml` logic to compute gestational age at the first visit.
- **ANC Health Facility Visit:** Removed legacy `first_clinic_visit` and reminder labels now handled during registration.
- **Localization:** Added error strings for date validation in English and Swahili.

🛠 **Internal Changes:**
- Update `AncRegisterActivity` to use `AncJsonWizardFormActivity`.
- Register `AncJsonWizardFormActivity` in `AndroidManifest.xml`.