### PR TITLE
✨ feat: add caregiver relationship field to client registration and u…

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -273,7 +273,7 @@ android {
             buildConfigField "String", 'DEFAULT_LOCATION', '"Hamlet"'
             buildConfigField "String", 'DEFAULT_LOCATION_DEBUG', '"Hamlet"'
             buildConfigField "long", "MAPBOX_DOWNLOAD_TILE_LIMIT", "6001"
-            buildConfigField "int", "DATABASE_VERSION", '42'
+            buildConfigField "int", "DATABASE_VERSION", '43'
             buildConfigField "boolean", "ENABLE_REFERRAL_FOLLOWUP", "false"
         }
     }

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -362,6 +362,14 @@
           }
         },
         {
+          "column_name": "caregiver_relationship",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "caregiver_relationship"
+          }
+        },
+        {
           "column_name": "marital_status",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_registration_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_registration_form.json
@@ -924,6 +924,568 @@
         }
       },
       {
+        "key": "caregiver_relationship_base",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mother Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mke"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza",
+          "Mke"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mume"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza",
+          "Mume"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "caregiver_relationship",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "other_phone_number",
         "openmrs_entity_parent": "phone_number",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_update_registration_info_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/all_clients_update_registration_info_form.json
@@ -757,6 +757,568 @@
         }
       },
       {
+        "key": "caregiver_relationship_base",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mke"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza",
+          "Mke"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mume"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Chagua uhusiano wa mpokea huduma na mlezi",
+        "values": [
+          "Mama",
+          "Baba",
+          "Kaka",
+          "Dada",
+          "Babu",
+          "Bibi",
+          "Rafiki",
+          "Mjomba / Baba Mdogo",
+          "Shangazi / Mama Mdogo",
+          "Polisi",
+          "Mlezi",
+          "Shemeji wa Kiume",
+          "Shemeji wa Kike",
+          "Mtoto wa Kiume",
+          "Mtoto wa Kike",
+          "Mfanyakazi Mwenza",
+          "Mume"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua uhusiano"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "caregiver_relationship",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "other_phone_number",
         "openmrs_entity_parent": "phone_number",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/all_clients_registration_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/all_clients_registration_form.json
@@ -924,6 +924,568 @@
         }
       },
       {
+        "key": "caregiver_relationship_base",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "caregiver_relationship",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "other_phone_number",
         "openmrs_entity_parent": "phone_number",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/json.form/all_clients_update_registration_info_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/all_clients_update_registration_info_form.json
@@ -757,6 +757,568 @@
         }
       },
       {
+        "key": "caregiver_relationship_base",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_in_law_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_wife_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Wife"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Wife": "Wife"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship_husband_adult",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "spinner",
+        "hint": "Select the client's relationship to the caregiver",
+        "values": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "keys": [
+          "Mother",
+          "Father",
+          "Brother",
+          "Sister",
+          "Grandfather",
+          "Grandmother",
+          "Friend",
+          "Uncle",
+          "Aunt",
+          "Police",
+          "Guardian",
+          "Brother in Law",
+          "Sister in Law",
+          "Son",
+          "Daughter",
+          "Work Colleague",
+          "Husband"
+        ],
+        "openmrs_choice_ids": {
+          "Mother": "Mother",
+          "Father": "Father",
+          "Brother": "Brother",
+          "Sister": "Sister",
+          "Grandfather": "Grandfather",
+          "Grandmother": "Grandmother",
+          "Friend": "Friend",
+          "Uncle": "Uncle",
+          "Aunt": "Aunt",
+          "Police": "Police",
+          "Guardian": "Guardian",
+          "Brother in Law": "Brother in Law",
+          "Sister in Law": "Sister in Law",
+          "Son": "Son",
+          "Daughter": "Daughter",
+          "Work Colleague": "Work Colleague",
+          "Husband": "Husband"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select the relationship"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_relevance.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "caregiver_relationship",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "caregiver_relationship",
+        "type": "hidden",
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "all_clients_member_update_calculation.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "other_phone_number",
         "openmrs_entity_parent": "phone_number",
         "openmrs_entity": "concept",

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_calculation.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_calculation.yml
@@ -13,6 +13,13 @@ condition: "step2_sex == 'Female' && (step2_age_calculated >= 10 && step2_age_ca
 actions:
   - "calculation = 1"
 ---
+name: step2_caregiver_relationship
+description: caregiver relationship selected value
+priority: 1
+condition: "true"
+actions:
+  - "calculation = step2_caregiver_relationship_base != '' ? step2_caregiver_relationship_base : step2_caregiver_relationship_adult != '' ? step2_caregiver_relationship_adult : step2_caregiver_relationship_in_law != '' ? step2_caregiver_relationship_in_law : step2_caregiver_relationship_in_law_adult != '' ? step2_caregiver_relationship_in_law_adult : step2_caregiver_relationship_wife != '' ? step2_caregiver_relationship_wife : step2_caregiver_relationship_wife_adult != '' ? step2_caregiver_relationship_wife_adult : step2_caregiver_relationship_husband != '' ? step2_caregiver_relationship_husband : step2_caregiver_relationship_husband_adult != '' ? step2_caregiver_relationship_husband_adult : ''"
+---
 name: step2_surname
 description: set surname as the one added in step one
 priority: 1

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_relevance.yml
@@ -97,6 +97,62 @@ condition: "step2_has_primary_caregiver == 'Yes'"
 actions:
   - "isRelevant = true"
 ---
+name: step2_caregiver_relationship_base
+description: caregiver relationship with always available options only
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && !(step2_marital_status != '' && !step2_marital_status.equals('Single')) && !((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18))"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_adult
+description: caregiver relationship with adult-only options
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && !(step2_marital_status != '' && !step2_marital_status.equals('Single')) && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18))"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_in_law
+description: caregiver relationship with in-law options
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && (step2_marital_status != '' && !step2_marital_status.equals('Single')) && !((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && !(step2_sex == 'Male' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')) && !(step2_sex == 'Female' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed'))"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_in_law_adult
+description: caregiver relationship with in-law and adult-only options
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && (step2_marital_status != '' && !step2_marital_status.equals('Single')) && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && !(step2_sex == 'Male' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')) && !(step2_sex == 'Female' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed'))"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_wife
+description: caregiver relationship with wife option
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && step2_sex == 'Male' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && !((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_wife_adult
+description: caregiver relationship with wife and adult-only options
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && step2_sex == 'Male' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_husband
+description: caregiver relationship with husband option
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && step2_sex == 'Female' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && !((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step2_caregiver_relationship_husband_adult
+description: caregiver relationship with husband and adult-only options
+priority: 1
+condition: "step2_has_primary_caregiver == 'Yes' && step2_sex == 'Female' && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 15) || (step2_age != '' && step2_age >= 15)) && ((step2_dob != '' && helper.formatDate(step2_dob,'y') >= 18) || (step2_age != '' && step2_age >= 18)) && step2_marital_status != '' && !step2_marital_status.equals('Single') && !step2_marital_status.equals('Divorced') && !step2_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
 name: step2_specify_other_disabilities
 description: specify other disabilities
 priority: 1

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_calculation.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_calculation.yml
@@ -12,3 +12,10 @@ priority: 1
 condition: "step1_sex == 'Female' && (step1_age_calculated >= 10 && step1_age_calculated <= 49)"
 actions:
   - "calculation = 1"
+---
+name: step1_caregiver_relationship
+description: caregiver relationship selected value
+priority: 1
+condition: "true"
+actions:
+  - "calculation = step1_caregiver_relationship_base != '' ? step1_caregiver_relationship_base : step1_caregiver_relationship_adult != '' ? step1_caregiver_relationship_adult : step1_caregiver_relationship_in_law != '' ? step1_caregiver_relationship_in_law : step1_caregiver_relationship_in_law_adult != '' ? step1_caregiver_relationship_in_law_adult : step1_caregiver_relationship_wife != '' ? step1_caregiver_relationship_wife : step1_caregiver_relationship_wife_adult != '' ? step1_caregiver_relationship_wife_adult : step1_caregiver_relationship_husband != '' ? step1_caregiver_relationship_husband : step1_caregiver_relationship_husband_adult != '' ? step1_caregiver_relationship_husband_adult : ''"

--- a/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/all_clients_member_update_relevance.yml
@@ -97,6 +97,62 @@ condition: "step1_has_primary_caregiver == 'Yes'"
 actions:
   - "isRelevant = true"
 ---
+name: step1_caregiver_relationship_base
+description: caregiver relationship with always available options only
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && !(step1_marital_status != '' && !step1_marital_status.equals('Single')) && !((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18))"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_adult
+description: caregiver relationship with adult-only options
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && !(step1_marital_status != '' && !step1_marital_status.equals('Single')) && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18))"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_in_law
+description: caregiver relationship with in-law options
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && (step1_marital_status != '' && !step1_marital_status.equals('Single')) && !((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && !(step1_sex == 'Male' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')) && !(step1_sex == 'Female' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed'))"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_in_law_adult
+description: caregiver relationship with in-law and adult-only options
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && (step1_marital_status != '' && !step1_marital_status.equals('Single')) && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && !(step1_sex == 'Male' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')) && !(step1_sex == 'Female' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed'))"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_wife
+description: caregiver relationship with wife option
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && step1_sex == 'Male' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && !((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_wife_adult
+description: caregiver relationship with wife and adult-only options
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && step1_sex == 'Male' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_husband
+description: caregiver relationship with husband option
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && step1_sex == 'Female' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && !((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
+name: step1_caregiver_relationship_husband_adult
+description: caregiver relationship with husband and adult-only options
+priority: 1
+condition: "step1_has_primary_caregiver == 'Yes' && step1_sex == 'Female' && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 15) || (step1_age != '' && step1_age >= 15)) && ((step1_dob != '' && helper.formatDate(step1_dob,'y') >= 18) || (step1_age != '' && step1_age >= 18)) && step1_marital_status != '' && !step1_marital_status.equals('Single') && !step1_marital_status.equals('Divorced') && !step1_marital_status.equals('Widowed')"
+actions:
+  - "isRelevant = true"
+---
 name: step1_marital_status
 description: marital_status relevance
 priority: 1

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
@@ -953,6 +953,12 @@ public class ChwRepositoryFlv {
 
     private static void upgradeToVersion43(SQLiteDatabase db) {
         try {
+            db.execSQL("ALTER TABLE ec_family_member ADD COLUMN caregiver_relationship VARCHAR;");
+        } catch (Exception e) {
+            Timber.e(e, "upgradeToVersion43-add-caregiver-relationship");
+        }
+
+        try {
             DatabaseMigrationUtils.createAddedECTables(db,
                     new HashSet<>(Arrays.asList(Constants.TABLES.NCD_ENROLLMENT,
                             Constants.TABLES.DIABETES_HYPERTENSION_FOLLOWUP,


### PR DESCRIPTION
…pdate forms

Add `caregiver_relationship` field to track the client's relationship to their primary caregiver across registration and update forms (EN + SW).

📋 **Forms & UI**:
- Added multiple versions of the relationship spinner (base, adult, in-law, etc.) to `all_clients_registration_form.json` and `all_clients_update_registration_info_form.json`.
- Implemented logic to show specific relationship options based on the client's age, sex, and marital status.

⚙️ **Rules & Logic**:
- **Relevance**: New rules in `all_clients_member_relevance.yml` and `all_clients_member_update_relevance.yml` to toggle relationship spinners based on demographic criteria.
- **Calculations**: Added logic to consolidate the selected value from multiple spinners into a single `caregiver_relationship` hidden field.

🗄️ **Database & Infrastructure**:
- **Schema**: Updated `DATABASE_VERSION` to `43` and added `caregiver_relationship` column to `ec_family_member` table via `ChwRepositoryFlv`.
- **Mapping**: Added `caregiver_relationship` to `ec_client_fields.json` for event-to-column processing.