### PR TITLE
Feature/ncd followup status mortality workflow

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
@@ -25,9 +25,7 @@ public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisi
     public static final String STATUS_ACTIVE = "currently_in_service";
     public static final String STATUS_INACTIVE = "not_in_service";
 
-    public static final String REASON_MOVED = "moved_to_another_location";
     public static final String REASON_DECEASED = "deceased";
-    public static final String REASON_LOST_TO_FOLLOW_UP = "lost_to_follow_up";
     public static final String REASON_OTHER = "other";
 
     private static final String STEP_ONE = "step1";

--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
@@ -17,16 +17,12 @@ import timber.log.Timber;
 
 public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisitActionHelper {
 
-    public static final String KEY_STATUS = "client_follow_up_status";
-    public static final String KEY_REASON = "reason_for_not_receiving_service";
-    public static final String KEY_OTHER_REASON = "other_reason_for_not_receiving_service";
+    public static final String KEY_STATUS = "client_status";
     public static final String KEY_DATE_OF_DEATH = "date_of_death";
 
-    public static final String STATUS_ACTIVE = "currently_in_service";
-    public static final String STATUS_INACTIVE = "not_in_service";
-
-    public static final String REASON_DECEASED = "deceased";
-    public static final String REASON_OTHER = "other";
+    public static final String STATUS_CONTINUING = "continuing";
+    public static final String STATUS_DEAD = "dead";
+    public static final String STATUS_TRANSFERRED = "transferred";
 
     private static final String STEP_ONE = "step1";
 
@@ -73,11 +69,14 @@ public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisi
     @Override
     public String evaluateSubTitle() {
         String status = getStatus();
-        if (STATUS_ACTIVE.equals(status)) {
-            return getString(R.string.ncd_followup_status_active, "Currently in service");
+        if (STATUS_CONTINUING.equals(status)) {
+            return getString(R.string.ncd_followup_status_continuing, "Continuing with Services");
         }
-        if (STATUS_INACTIVE.equals(status)) {
-            return getString(R.string.ncd_followup_status_inactive, "Not in service");
+        if (STATUS_DEAD.equals(status)) {
+            return getString(R.string.ncd_followup_status_dead, "Dead");
+        }
+        if (STATUS_TRANSFERRED.equals(status)) {
+            return getString(R.string.ncd_followup_status_transferred, "Transferred");
         }
         return getString(R.string.ncd_followup_status_pending, "Not yet completed");
     }
@@ -101,36 +100,23 @@ public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisi
         return extractValue(jsonPayload, KEY_STATUS);
     }
 
-    public String getReason() {
-        return extractValue(jsonPayload, KEY_REASON);
-    }
-
     public boolean isActive() {
-        return STATUS_ACTIVE.equals(getStatus());
+        return STATUS_CONTINUING.equals(getStatus());
     }
 
     public boolean isDeceased() {
-        return STATUS_INACTIVE.equals(getStatus()) && REASON_DECEASED.equals(getReason());
+        return STATUS_DEAD.equals(getStatus());
     }
 
     private boolean isComplete() {
         String status = getStatus();
-        if (STATUS_ACTIVE.equals(status)) {
+        if (STATUS_CONTINUING.equals(status) || STATUS_TRANSFERRED.equals(status)) {
             return true;
         }
-        if (!STATUS_INACTIVE.equals(status)) {
-            return false;
-        }
-
-        String reason = getReason();
-        if (StringUtils.isBlank(reason)) {
-            return false;
-        }
-        if (REASON_DECEASED.equals(reason)) {
+        if (STATUS_DEAD.equals(status)) {
             return StringUtils.isNotBlank(extractValue(jsonPayload, KEY_DATE_OF_DEATH));
         }
-        return !REASON_OTHER.equals(reason)
-                || StringUtils.isNotBlank(extractValue(jsonPayload, KEY_OTHER_REASON));
+        return false;
     }
 
     private String fetchStoredPayload() {
@@ -186,15 +172,7 @@ public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisi
             }
 
             String status = findValue(fields, KEY_STATUS);
-            String reason = findValue(fields, KEY_REASON);
-            if (STATUS_ACTIVE.equals(status)) {
-                setValue(fields, KEY_REASON, "");
-                setValue(fields, KEY_OTHER_REASON, "");
-                setValue(fields, KEY_DATE_OF_DEATH, "");
-            } else if (STATUS_INACTIVE.equals(status) && !REASON_OTHER.equals(reason)) {
-                setValue(fields, KEY_OTHER_REASON, "");
-            }
-            if (STATUS_INACTIVE.equals(status) && !REASON_DECEASED.equals(reason)) {
+            if (!STATUS_DEAD.equals(status)) {
                 setValue(fields, KEY_DATE_OF_DEATH, "");
             }
             return form.toString();

--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelper.java
@@ -1,0 +1,232 @@
+package org.smartregister.chw.actionhelper;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.smartregister.chw.R;
+import org.smartregister.chw.ncd.domain.VisitDetail;
+import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
+
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+public class NcdFollowUpStatusActionHelper implements BaseNcdVisitAction.NcdVisitActionHelper {
+
+    public static final String KEY_STATUS = "client_follow_up_status";
+    public static final String KEY_REASON = "reason_for_not_receiving_service";
+    public static final String KEY_OTHER_REASON = "other_reason_for_not_receiving_service";
+    public static final String KEY_DATE_OF_DEATH = "date_of_death";
+
+    public static final String STATUS_ACTIVE = "currently_in_service";
+    public static final String STATUS_INACTIVE = "not_in_service";
+
+    public static final String REASON_MOVED = "moved_to_another_location";
+    public static final String REASON_DECEASED = "deceased";
+    public static final String REASON_LOST_TO_FOLLOW_UP = "lost_to_follow_up";
+    public static final String REASON_OTHER = "other";
+
+    private static final String STEP_ONE = "step1";
+
+    private Context context;
+    private Map<String, List<VisitDetail>> details;
+    private String jsonPayload;
+
+    @Override
+    public void onJsonFormLoaded(String json, Context context, Map<String, List<VisitDetail>> details) {
+        this.context = context;
+        this.details = details;
+        if (TextUtils.isEmpty(jsonPayload)) {
+            jsonPayload = fetchStoredPayload();
+        }
+    }
+
+    @Override
+    public String getPreProcessed() {
+        return jsonPayload;
+    }
+
+    @Override
+    public void onPayloadReceived(String payload) {
+        jsonPayload = payload;
+    }
+
+    @Override
+    public BaseNcdVisitAction.ScheduleStatus getPreProcessedStatus() {
+        return isComplete()
+                ? BaseNcdVisitAction.ScheduleStatus.DUE
+                : BaseNcdVisitAction.ScheduleStatus.OVERDUE;
+    }
+
+    @Override
+    public String getPreProcessedSubTitle() {
+        return evaluateSubTitle();
+    }
+
+    @Override
+    public String postProcess(String payload) {
+        return payload;
+    }
+
+    @Override
+    public String evaluateSubTitle() {
+        String status = getStatus();
+        if (STATUS_ACTIVE.equals(status)) {
+            return getString(R.string.ncd_followup_status_active, "Currently in service");
+        }
+        if (STATUS_INACTIVE.equals(status)) {
+            return getString(R.string.ncd_followup_status_inactive, "Not in service");
+        }
+        return getString(R.string.ncd_followup_status_pending, "Not yet completed");
+    }
+
+    @Override
+    public BaseNcdVisitAction.Status evaluateStatusOnPayload() {
+        return isComplete()
+                ? BaseNcdVisitAction.Status.COMPLETED
+                : BaseNcdVisitAction.Status.PENDING;
+    }
+
+    @Override
+    public void onPayloadReceived(BaseNcdVisitAction action) {
+        jsonPayload = action.getJsonPayload();
+        action.setSubTitle(evaluateSubTitle());
+        action.setScheduleStatus(getPreProcessedStatus());
+        action.setActionStatus(evaluateStatusOnPayload());
+    }
+
+    public String getStatus() {
+        return extractValue(jsonPayload, KEY_STATUS);
+    }
+
+    public String getReason() {
+        return extractValue(jsonPayload, KEY_REASON);
+    }
+
+    public boolean isActive() {
+        return STATUS_ACTIVE.equals(getStatus());
+    }
+
+    public boolean isDeceased() {
+        return STATUS_INACTIVE.equals(getStatus()) && REASON_DECEASED.equals(getReason());
+    }
+
+    private boolean isComplete() {
+        String status = getStatus();
+        if (STATUS_ACTIVE.equals(status)) {
+            return true;
+        }
+        if (!STATUS_INACTIVE.equals(status)) {
+            return false;
+        }
+
+        String reason = getReason();
+        if (StringUtils.isBlank(reason)) {
+            return false;
+        }
+        if (REASON_DECEASED.equals(reason)) {
+            return StringUtils.isNotBlank(extractValue(jsonPayload, KEY_DATE_OF_DEATH));
+        }
+        return !REASON_OTHER.equals(reason)
+                || StringUtils.isNotBlank(extractValue(jsonPayload, KEY_OTHER_REASON));
+    }
+
+    private String fetchStoredPayload() {
+        if (details == null) {
+            return null;
+        }
+        List<VisitDetail> storedDetails = details.get(KEY_STATUS);
+        if (storedDetails == null) {
+            return null;
+        }
+        for (int i = storedDetails.size() - 1; i >= 0; i--) {
+            VisitDetail detail = storedDetails.get(i);
+            if (detail != null && StringUtils.isNotBlank(detail.getJsonDetails())) {
+                return detail.getJsonDetails();
+            }
+        }
+        return null;
+    }
+
+    public static String extractValue(String payload, String key) {
+        if (StringUtils.isBlank(payload)) {
+            return null;
+        }
+        try {
+            JSONObject form = new JSONObject(payload);
+            JSONObject step = form.optJSONObject(STEP_ONE);
+            JSONArray fields = step != null ? step.optJSONArray("fields") : null;
+            if (fields == null) {
+                return null;
+            }
+            for (int i = 0; i < fields.length(); i++) {
+                JSONObject field = fields.optJSONObject(i);
+                if (field != null && key.equals(field.optString("key"))) {
+                    return field.optString("value", null);
+                }
+            }
+        } catch (Exception e) {
+            Timber.e(e, "Unable to parse NCD follow-up status payload");
+        }
+        return null;
+    }
+
+    public static String clearIrrelevantValues(String payload) {
+        if (StringUtils.isBlank(payload)) {
+            return payload;
+        }
+        try {
+            JSONObject form = new JSONObject(payload);
+            JSONObject step = form.optJSONObject(STEP_ONE);
+            JSONArray fields = step != null ? step.optJSONArray("fields") : null;
+            if (fields == null) {
+                return payload;
+            }
+
+            String status = findValue(fields, KEY_STATUS);
+            String reason = findValue(fields, KEY_REASON);
+            if (STATUS_ACTIVE.equals(status)) {
+                setValue(fields, KEY_REASON, "");
+                setValue(fields, KEY_OTHER_REASON, "");
+                setValue(fields, KEY_DATE_OF_DEATH, "");
+            } else if (STATUS_INACTIVE.equals(status) && !REASON_OTHER.equals(reason)) {
+                setValue(fields, KEY_OTHER_REASON, "");
+            }
+            if (STATUS_INACTIVE.equals(status) && !REASON_DECEASED.equals(reason)) {
+                setValue(fields, KEY_DATE_OF_DEATH, "");
+            }
+            return form.toString();
+        } catch (Exception e) {
+            Timber.e(e, "Unable to sanitize NCD follow-up status payload");
+            return payload;
+        }
+    }
+
+    private static String findValue(JSONArray fields, String key) {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field != null && key.equals(field.optString("key"))) {
+                return field.optString("value", null);
+            }
+        }
+        return null;
+    }
+
+    private static void setValue(JSONArray fields, String key, String value) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field != null && key.equals(field.optString("key"))) {
+                field.put("value", value);
+                return;
+            }
+        }
+    }
+
+    private String getString(int resourceId, String fallback) {
+        return context != null ? context.getString(resourceId) : fallback;
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -3,16 +3,36 @@ package org.smartregister.chw.activity;
 import android.app.Activity;
 import android.content.Intent;
 
+import androidx.annotation.NonNull;
+
+import org.smartregister.chw.actionhelper.NcdFollowUpStatusActionHelper;
 import org.smartregister.chw.custom_views.NcdReferralPromptDialog;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor.PendingNcdReferral;
+import org.smartregister.chw.dao.NcdCaseManagementDao;
+import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
 import org.smartregister.chw.ncd.util.Constants;
+import org.smartregister.chw.ncd.util.AppExecutors;
+import org.smartregister.chw.ncd.util.NcdUtil;
 import org.smartregister.chw.presenter.NcdCaseManagementVisitPresenter;
+import org.smartregister.chw.util.MarkClientAsDeceasedHelper;
 import org.smartregister.chw.util.NcdReferralTaskHelper;
+
+import com.vijay.jsonwizard.utils.FormUtils;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import timber.log.Timber;
 
 public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
+
+    private final LinkedHashMap<String, BaseNcdVisitAction> completeActionList = new LinkedHashMap<>();
+    private final AppExecutors appExecutors = new AppExecutors();
+    private String pendingMortalityResult;
 
     public static void startMe(Activity activity, String baseEntityId, Boolean isEditMode) {
         Intent intent = new Intent(activity, NcdCaseManagementVisitActivity.class);
@@ -27,6 +47,57 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
         presenter = new NcdCaseManagementVisitPresenter(memberObject, this);
     }
 
+    @Override
+    public void initializeActions(@NonNull LinkedHashMap<String, BaseNcdVisitAction> actions) {
+        completeActionList.clear();
+        completeActionList.putAll(actions);
+        super.initializeActions(actions);
+        applyFollowUpStatusGate();
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == org.smartregister.family.util.JsonFormUtils.REQUEST_CODE_GET_JSON
+                && resultCode == RESULT_OK) {
+            applyFollowUpStatusGate();
+        }
+    }
+
+    private void applyFollowUpStatusGate() {
+        BaseNcdVisitAction statusAction = findStatusAction(completeActionList);
+        if (statusAction == null || actionList == null) {
+            return;
+        }
+
+        String status = NcdFollowUpStatusActionHelper.extractValue(
+                statusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_STATUS);
+
+        actionList.clear();
+        if (NcdFollowUpStatusActionHelper.STATUS_ACTIVE.equals(status)) {
+            actionList.putAll(completeActionList);
+        } else {
+            actionList.put(statusAction.getTitle(), statusAction);
+        }
+
+        if (mAdapter != null) {
+            mAdapter.notifyDataSetChanged();
+        }
+        redrawVisitUI();
+    }
+
+    private BaseNcdVisitAction findStatusAction(Map<String, BaseNcdVisitAction> actions) {
+        if (actions == null) {
+            return null;
+        }
+        for (BaseNcdVisitAction action : actions.values()) {
+            if (org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_STATUS.equals(action.getFormName())) {
+                return action;
+            }
+        }
+        return null;
+    }
+
     /**
      * After the visit is submitted, check whether the interactor staged a pending referral.
      * If so, prompt the CHW to confirm before any Referral Registration event / task is
@@ -34,6 +105,12 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
      */
     @Override
     public void submittedAndClose(String results) {
+        if (isSubmittedAsDeceased()) {
+            pendingMortalityResult = results;
+            createMortalityRecords(results);
+            return;
+        }
+
         PendingNcdReferral pending = readPendingReferral();
         if (pending == null) {
             super.submittedAndClose(results);
@@ -62,11 +139,80 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
         }));
     }
 
+    @Override
+    public void submitVisit() {
+        if (pendingMortalityResult != null) {
+            createMortalityRecords(pendingMortalityResult);
+            return;
+        }
+        super.submitVisit();
+    }
+
+    private boolean isSubmittedAsDeceased() {
+        NcdCaseManagementInteractor interactor = getCaseManagementInteractor();
+        return interactor != null
+                && NcdFollowUpStatusActionHelper.STATUS_INACTIVE.equals(
+                interactor.getLastSubmittedFollowUpStatus())
+                && NcdFollowUpStatusActionHelper.REASON_DECEASED.equals(
+                interactor.getLastSubmittedInactiveReason());
+    }
+
+    private void createMortalityRecords(String results) {
+        displayProgressBar(true);
+        if (tvSubmit != null) {
+            tvSubmit.setEnabled(false);
+        }
+
+        NcdCaseManagementInteractor interactor = getCaseManagementInteractor();
+        String dateOfDeath = interactor != null ? interactor.getLastSubmittedDateOfDeath() : null;
+        appExecutors.diskIO().execute(() -> {
+            try {
+                MarkClientAsDeceasedHelper.markAsDeceased(
+                        NcdCaseManagementVisitActivity.this, memberObject, dateOfDeath);
+                closeDeceasedNcdCase();
+                NcdCaseManagementDao.cancelOpenTasks(memberObject.getBaseEntityId());
+                NcdCaseManagementDao.voidOpenReferrals(memberObject.getBaseEntityId());
+
+                appExecutors.mainThread().execute(() -> {
+                    pendingMortalityResult = null;
+                    NcdCaseManagementVisitActivity.super.submittedAndClose(results);
+                });
+            } catch (Exception e) {
+                Timber.e(e, "Unable to create mortality records for NCD client");
+                appExecutors.mainThread().execute(() -> {
+                    displayProgressBar(false);
+                    if (tvSubmit != null) {
+                        tvSubmit.setEnabled(true);
+                    }
+                    displayToast(getString(org.smartregister.chw.R.string.ncd_death_registration_save_failed));
+                });
+            }
+        });
+    }
+
+    private void closeDeceasedNcdCase() throws Exception {
+        JSONObject form = (new FormUtils()).getFormJsonFromRepositoryOrAssets(
+                this, org.smartregister.chw.util.Constants.JsonForm.NCD_CASE_MANAGEMENT_CLOSE);
+        if (form == null) {
+            throw new IllegalStateException("Unable to load NCD case management close form");
+        }
+        form.put(org.smartregister.family.util.JsonFormUtils.ENTITY_ID,
+                memberObject.getBaseEntityId());
+        JSONArray fields = form.getJSONObject(org.smartregister.family.util.JsonFormUtils.STEP1)
+                .getJSONArray(org.smartregister.family.util.JsonFormUtils.FIELDS);
+        org.smartregister.chw.core.utils.FormUtils.updateFormField(
+                fields, "close_reason", NcdFollowUpStatusActionHelper.REASON_DECEASED);
+        NcdUtil.saveFormEvent(form.toString());
+    }
+
     private PendingNcdReferral readPendingReferral() {
-        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) return null;
-        NcdCaseManagementInteractor interactor =
-                ((NcdCaseManagementVisitPresenter) presenter).getCaseManagementInteractor();
+        NcdCaseManagementInteractor interactor = getCaseManagementInteractor();
         return interactor != null ? interactor.getPendingReferral() : null;
+    }
+
+    private NcdCaseManagementInteractor getCaseManagementInteractor() {
+        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) return null;
+        return ((NcdCaseManagementVisitPresenter) presenter).getCaseManagementInteractor();
     }
 
     private void clearPendingReferral() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -167,11 +167,16 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
         String dateOfDeath = interactor != null ? interactor.getLastSubmittedDateOfDeath() : null;
         appExecutors.diskIO().execute(() -> {
             try {
-                MarkClientAsDeceasedHelper.markAsDeceased(
-                        NcdCaseManagementVisitActivity.this, memberObject, dateOfDeath);
-                closeDeceasedNcdCase();
-                NcdCaseManagementDao.cancelOpenTasks(memberObject.getBaseEntityId());
-                NcdCaseManagementDao.voidOpenReferrals(memberObject.getBaseEntityId());
+                String baseEntityId = memberObject.getBaseEntityId();
+                if (!NcdCaseManagementDao.hasMortalityRecord(baseEntityId)) {
+                    MarkClientAsDeceasedHelper.markAsDeceased(
+                            NcdCaseManagementVisitActivity.this, memberObject, dateOfDeath);
+                }
+                if (!NcdCaseManagementDao.isNcdCaseClosed(baseEntityId)) {
+                    closeDeceasedNcdCase();
+                }
+                NcdCaseManagementDao.cancelOpenTasks(baseEntityId);
+                NcdCaseManagementDao.voidOpenReferrals(baseEntityId);
 
                 appExecutors.mainThread().execute(() -> {
                     pendingMortalityResult = null;

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -30,6 +30,8 @@ import timber.log.Timber;
 
 public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
 
+    private static final String CLOSE_REASON_DECEASED = "deceased";
+
     private final LinkedHashMap<String, BaseNcdVisitAction> completeActionList = new LinkedHashMap<>();
     private final AppExecutors appExecutors = new AppExecutors();
     private String pendingMortalityResult;
@@ -74,7 +76,7 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
                 statusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_STATUS);
 
         actionList.clear();
-        if (NcdFollowUpStatusActionHelper.STATUS_ACTIVE.equals(status)) {
+        if (NcdFollowUpStatusActionHelper.STATUS_CONTINUING.equals(status)) {
             actionList.putAll(completeActionList);
         } else {
             actionList.put(statusAction.getTitle(), statusAction);
@@ -151,10 +153,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
     private boolean isSubmittedAsDeceased() {
         NcdCaseManagementInteractor interactor = getCaseManagementInteractor();
         return interactor != null
-                && NcdFollowUpStatusActionHelper.STATUS_INACTIVE.equals(
-                interactor.getLastSubmittedFollowUpStatus())
-                && NcdFollowUpStatusActionHelper.REASON_DECEASED.equals(
-                interactor.getLastSubmittedInactiveReason());
+                && NcdFollowUpStatusActionHelper.STATUS_DEAD.equals(
+                interactor.getLastSubmittedFollowUpStatus());
     }
 
     private void createMortalityRecords(String results) {
@@ -201,7 +201,7 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
         JSONArray fields = form.getJSONObject(org.smartregister.family.util.JsonFormUtils.STEP1)
                 .getJSONArray(org.smartregister.family.util.JsonFormUtils.FIELDS);
         org.smartregister.chw.core.utils.FormUtils.updateFormField(
-                fields, "close_reason", NcdFollowUpStatusActionHelper.REASON_DECEASED);
+                fields, "close_reason", CLOSE_REASON_DECEASED);
         NcdUtil.saveFormEvent(form.toString());
     }
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/NcdCaseManagementDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/NcdCaseManagementDao.java
@@ -281,17 +281,12 @@ public class NcdCaseManagementDao extends AbstractDao {
             return false;
         }
 
-        String sql = String.format(Locale.US,
-                "SELECT COUNT(*) as cnt FROM task " +
-                        "WHERE for_entity = '%s' " +
-                        "AND focus IN ('NCD Danger Signs', 'NCD Clinical Concern') " +
-                        "AND status IN ('READY', 'IN_PROGRESS') " +
-                        "LIMIT 1",
-                baseEntityId);
-
-        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
-        List<Integer> results = readData(sql, dataMap);
-        return (results != null && !results.isEmpty() && results.get(0) > 0);
+        String sql = "SELECT COUNT(*) as cnt FROM task " +
+                "WHERE for_entity = ? " +
+                "AND focus IN ('NCD Danger Signs', 'NCD Clinical Concern') " +
+                "AND status IN ('READY', 'IN_PROGRESS') " +
+                "LIMIT 1";
+        return hasCount(sql, baseEntityId);
     }
 
     public static boolean hasDeathRegisterRecord(String baseEntityId) {
@@ -299,16 +294,11 @@ public class NcdCaseManagementDao extends AbstractDao {
             return false;
         }
 
-        String sql = String.format(Locale.US,
-                "SELECT COUNT(*) as cnt FROM ec_hps_death_register " +
-                        "WHERE base_entity_id = '%s' " +
-                        "AND IFNULL(dod, '') <> '' " +
-                        "LIMIT 1",
-                baseEntityId);
-
-        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
-        List<Integer> results = readData(sql, dataMap);
-        return (results != null && !results.isEmpty() && results.get(0) > 0);
+        String sql = "SELECT COUNT(*) as cnt FROM ec_hps_death_register " +
+                "WHERE base_entity_id = ? " +
+                "AND IFNULL(dod, '') <> '' " +
+                "LIMIT 1";
+        return hasCount(sql, baseEntityId);
     }
 
     public static boolean hasRemoveMemberEvent(String baseEntityId) {
@@ -316,16 +306,11 @@ public class NcdCaseManagementDao extends AbstractDao {
             return false;
         }
 
-        String sql = String.format(Locale.US,
-                "SELECT COUNT(*) as cnt FROM event " +
-                        "WHERE baseEntityId = '%s' COLLATE NOCASE " +
-                        "AND eventType = '%s' COLLATE NOCASE " +
-                        "LIMIT 1",
-                baseEntityId, CoreConstants.EventType.REMOVE_MEMBER);
-
-        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
-        List<Integer> results = readData(sql, dataMap);
-        return (results != null && !results.isEmpty() && results.get(0) > 0);
+        String sql = "SELECT COUNT(*) as cnt FROM event " +
+                "WHERE baseEntityId = ? COLLATE NOCASE " +
+                "AND eventType = ? COLLATE NOCASE " +
+                "LIMIT 1";
+        return hasCount(sql, baseEntityId, CoreConstants.EventType.REMOVE_MEMBER);
     }
 
     public static boolean hasMortalityRecord(String baseEntityId) {
@@ -337,16 +322,24 @@ public class NcdCaseManagementDao extends AbstractDao {
             return false;
         }
 
-        String sql = String.format(Locale.US,
-                "SELECT COUNT(*) as cnt FROM ec_ncd_register " +
-                        "WHERE base_entity_id = '%s' " +
-                        "AND IFNULL(is_closed, 0) = 1 " +
-                        "LIMIT 1",
-                baseEntityId);
+        String sql = "SELECT COUNT(*) as cnt FROM ec_ncd_register " +
+                "WHERE base_entity_id = ? " +
+                "AND IFNULL(is_closed, 0) = 1 " +
+                "LIMIT 1";
+        return hasCount(sql, baseEntityId);
+    }
 
-        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
-        List<Integer> results = readData(sql, dataMap);
-        return (results != null && !results.isEmpty() && results.get(0) > 0);
+    private static boolean hasCount(String sql, String... selectionArgs) {
+        List<Map<String, Object>> results = readData(sql, selectionArgs);
+        if (results == null || results.isEmpty()) {
+            return false;
+        }
+
+        Object count = results.get(0).get("cnt");
+        if (count instanceof Number) {
+            return ((Number) count).intValue() > 0;
+        }
+        return count != null && Integer.parseInt(count.toString()) > 0;
     }
 
     /**

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/NcdCaseManagementDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/NcdCaseManagementDao.java
@@ -1,6 +1,7 @@
 package org.smartregister.chw.dao;
 
 import org.apache.commons.lang3.StringUtils;
+import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.util.Constants;
 import org.smartregister.dao.AbstractDao;
 
@@ -285,6 +286,61 @@ public class NcdCaseManagementDao extends AbstractDao {
                         "WHERE for_entity = '%s' " +
                         "AND focus IN ('NCD Danger Signs', 'NCD Clinical Concern') " +
                         "AND status IN ('READY', 'IN_PROGRESS') " +
+                        "LIMIT 1",
+                baseEntityId);
+
+        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
+        List<Integer> results = readData(sql, dataMap);
+        return (results != null && !results.isEmpty() && results.get(0) > 0);
+    }
+
+    public static boolean hasDeathRegisterRecord(String baseEntityId) {
+        if (StringUtils.isBlank(baseEntityId)) {
+            return false;
+        }
+
+        String sql = String.format(Locale.US,
+                "SELECT COUNT(*) as cnt FROM ec_hps_death_register " +
+                        "WHERE base_entity_id = '%s' " +
+                        "AND IFNULL(dod, '') <> '' " +
+                        "LIMIT 1",
+                baseEntityId);
+
+        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
+        List<Integer> results = readData(sql, dataMap);
+        return (results != null && !results.isEmpty() && results.get(0) > 0);
+    }
+
+    public static boolean hasRemoveMemberEvent(String baseEntityId) {
+        if (StringUtils.isBlank(baseEntityId)) {
+            return false;
+        }
+
+        String sql = String.format(Locale.US,
+                "SELECT COUNT(*) as cnt FROM event " +
+                        "WHERE baseEntityId = '%s' COLLATE NOCASE " +
+                        "AND eventType = '%s' COLLATE NOCASE " +
+                        "LIMIT 1",
+                baseEntityId, CoreConstants.EventType.REMOVE_MEMBER);
+
+        DataMap<Integer> dataMap = cursor -> getCursorIntValue(cursor, "cnt");
+        List<Integer> results = readData(sql, dataMap);
+        return (results != null && !results.isEmpty() && results.get(0) > 0);
+    }
+
+    public static boolean hasMortalityRecord(String baseEntityId) {
+        return hasRemoveMemberEvent(baseEntityId) || hasDeathRegisterRecord(baseEntityId);
+    }
+
+    public static boolean isNcdCaseClosed(String baseEntityId) {
+        if (StringUtils.isBlank(baseEntityId)) {
+            return false;
+        }
+
+        String sql = String.format(Locale.US,
+                "SELECT COUNT(*) as cnt FROM ec_ncd_register " +
+                        "WHERE base_entity_id = '%s' " +
+                        "AND IFNULL(is_closed, 0) = 1 " +
                         "LIMIT 1",
                 baseEntityId);
 

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
@@ -41,10 +41,17 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
     private static final String KEY_IS_SIDE_EFFECTS_ALERT = "is_side_effects_alert";
     private static final String KEY_IS_MISSED_CLINIC_ALERT = "is_missed_clinic_alert";
     private static final String KEY_ALERT_STATUS = "alert_status";
-
     public static final String ALERT_RED = "red";
     public static final String ALERT_YELLOW = "yellow";
     public static final String ALERT_NONE = "none";
+    private PendingNcdReferral pendingReferral = null;
+    private String lastSubmittedFollowUpStatus;
+    private String lastSubmittedDateOfDeath;
+    private String lastComputedAlertStatus = ALERT_NONE;
+    private boolean lastHasSideEffects = false;
+    private boolean lastHasMissedClinic = false;
+    private String lastVitalsAlertReason = null;
+    private final List<String> lastReferralReasons = new ArrayList<>();
 
     public NcdCaseManagementInteractor() {
         super(Constants.EncounterType.NCD_MONTHLY_FOLLOWUP);
@@ -169,17 +176,6 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
     public void clearPendingReferral() {
         pendingReferral = null;
     }
-
-    private PendingNcdReferral pendingReferral = null;
-
-    private String lastSubmittedFollowUpStatus;
-    private String lastSubmittedDateOfDeath;
-
-    private String lastComputedAlertStatus = ALERT_NONE;
-    private boolean lastHasSideEffects = false;
-    private boolean lastHasMissedClinic = false;
-    private String lastVitalsAlertReason = null;
-    private final List<String> lastReferralReasons = new ArrayList<>();
 
     public String getLastSubmittedFollowUpStatus() {
         return lastSubmittedFollowUpStatus;

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
@@ -140,9 +140,6 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
         lastSubmittedFollowUpStatus = followUpStatusAction == null ? null
                 : NcdFollowUpStatusActionHelper.extractValue(
                         followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_STATUS);
-        lastSubmittedInactiveReason = followUpStatusAction == null ? null
-                : NcdFollowUpStatusActionHelper.extractValue(
-                        followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_REASON);
         lastSubmittedDateOfDeath = followUpStatusAction == null ? null
                 : NcdFollowUpStatusActionHelper.extractValue(
                         followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH);
@@ -176,7 +173,6 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
     private PendingNcdReferral pendingReferral = null;
 
     private String lastSubmittedFollowUpStatus;
-    private String lastSubmittedInactiveReason;
     private String lastSubmittedDateOfDeath;
 
     private String lastComputedAlertStatus = ALERT_NONE;
@@ -187,10 +183,6 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
 
     public String getLastSubmittedFollowUpStatus() {
         return lastSubmittedFollowUpStatus;
-    }
-
-    public String getLastSubmittedInactiveReason() {
-        return lastSubmittedInactiveReason;
     }
 
     public String getLastSubmittedDateOfDeath() {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
@@ -4,6 +4,7 @@ import static org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_CLINICA
 import static org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_DANGER_SIGNS;
 import static org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_LIFESTYLE;
 import static org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_PSYCHOSOCIAL;
+import static org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_STATUS;
 import static org.smartregister.chw.util.Constants.JsonForm.NCD_VITALS_FORM;
 
 import androidx.annotation.NonNull;
@@ -14,6 +15,7 @@ import org.json.JSONObject;
 import org.smartregister.chw.R;
 import org.smartregister.chw.actionhelper.NcdClinicalAdherenceActionHelper;
 import org.smartregister.chw.actionhelper.NcdDangerSignsActionHelper;
+import org.smartregister.chw.actionhelper.NcdFollowUpStatusActionHelper;
 import org.smartregister.chw.actionhelper.NcdLifestyleActionHelper;
 import org.smartregister.chw.actionhelper.NcdPsychosocialActionHelper;
 import org.smartregister.chw.actionhelper.NcdVitalsActionHelper;
@@ -66,6 +68,11 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
             try {
                 boolean unresolvedRed = checkUnresolvedRedAlert();
 
+                BaseNcdVisitAction followUpStatus = buildAction(
+                        context.getString(R.string.ncd_followup_action_status),
+                        NCD_FOLLOWUP_STATUS,
+                        new NcdFollowUpStatusActionHelper());
+
                 NcdDangerSignsActionHelper dangerSignsHelper = new NcdDangerSignsActionHelper();
                 if (unresolvedRed) {
                     dangerSignsHelper.setUnresolvedRedAlert(true);
@@ -96,6 +103,7 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
                         NCD_FOLLOWUP_PSYCHOSOCIAL,
                         new NcdPsychosocialActionHelper());
 
+                actionMap.put(context.getString(R.string.ncd_followup_action_status), followUpStatus);
                 actionMap.put(context.getString(R.string.ncd_followup_action_vitals), vitals);
                 actionMap.put(context.getString(R.string.ncd_followup_action_clinical_adherence), clinicalAdherence);
                 actionMap.put(context.getString(R.string.ncd_followup_action_danger_signs), dangerSigns);
@@ -124,6 +132,22 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
     protected String submitVisit(boolean editMode, String memberID,
                                  Map<String, BaseNcdVisitAction> map,
                                  String parentEventType) throws Exception {
+        BaseNcdVisitAction followUpStatusAction = findActionByFormName(map, NCD_FOLLOWUP_STATUS);
+        if (followUpStatusAction != null) {
+            followUpStatusAction.setJsonPayload(
+                    NcdFollowUpStatusActionHelper.clearIrrelevantValues(
+                            followUpStatusAction.getJsonPayload()));
+        }
+        lastSubmittedFollowUpStatus = followUpStatusAction == null ? null
+                : NcdFollowUpStatusActionHelper.extractValue(
+                        followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_STATUS);
+        lastSubmittedInactiveReason = followUpStatusAction == null ? null
+                : NcdFollowUpStatusActionHelper.extractValue(
+                        followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_REASON);
+        lastSubmittedDateOfDeath = followUpStatusAction == null ? null
+                : NcdFollowUpStatusActionHelper.extractValue(
+                        followUpStatusAction.getJsonPayload(), NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH);
+
         // Compute alert status and stage pending referral before forms are combined into one event
         computeAndInjectAlertStatus(map);
 
@@ -152,11 +176,27 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
 
     private PendingNcdReferral pendingReferral = null;
 
+    private String lastSubmittedFollowUpStatus;
+    private String lastSubmittedInactiveReason;
+    private String lastSubmittedDateOfDeath;
+
     private String lastComputedAlertStatus = ALERT_NONE;
     private boolean lastHasSideEffects = false;
     private boolean lastHasMissedClinic = false;
     private String lastVitalsAlertReason = null;
     private final List<String> lastReferralReasons = new ArrayList<>();
+
+    public String getLastSubmittedFollowUpStatus() {
+        return lastSubmittedFollowUpStatus;
+    }
+
+    public String getLastSubmittedInactiveReason() {
+        return lastSubmittedInactiveReason;
+    }
+
+    public String getLastSubmittedDateOfDeath() {
+        return lastSubmittedDateOfDeath;
+    }
 
     private void computeAndInjectAlertStatus(Map<String, BaseNcdVisitAction> map) {
         BaseNcdVisitAction dangerSignsAction = findActionByFormName(map, NCD_FOLLOWUP_DANGER_SIGNS);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/NcdCaseManagementInteractor.java
@@ -122,7 +122,6 @@ public class NcdCaseManagementInteractor extends BaseNcdVisitInteractor {
     /**
      * Computes alert status from action payloads and injects it before the combined event is saved.
      * With COMBINED processing mode, all fields land in one event/row.
-     *
      * Phase 2: referral creation is no longer invoked inline. Instead, when the visit raises a
      * non-NONE alert, a {@link PendingNcdReferral} is staged on this interactor and the
      * VisitActivity reads it after submission to prompt the CHW for confirmation. Only the

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -158,6 +158,7 @@ public class Constants extends CoreConstants {
         public static final String DIABETES_FOLLOWUP_FORM = "diabetes_hypertension_followup_form";
         public static final String NCD_VITALS_FORM = "record_diabetes_hypertension_vital_form";
         public static final String NCD_CLIENT_EDUCATION_FORM = "ncd_client_education_form";
+        public static final String NCD_FOLLOWUP_STATUS = "ncd_followup_status";
         public static final String NCD_FOLLOWUP_CLINICAL_ADHERENCE = "ncd_followup_clinical_adherence";
         public static final String NCD_FOLLOWUP_DANGER_SIGNS = "ncd_followup_danger_signs";
         public static final String NCD_FOLLOWUP_LIFESTYLE = "ncd_followup_lifestyle";

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/MarkClientAsDeceasedHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/MarkClientAsDeceasedHelper.java
@@ -1,0 +1,128 @@
+package org.smartregister.chw.util;
+
+import android.content.Context;
+
+import com.vijay.jsonwizard.utils.FormUtils;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.joda.time.format.ISODateTimeFormat;
+import org.smartregister.AllConstants;
+import org.smartregister.chw.core.utils.CoreConstants;
+import org.smartregister.chw.dao.PersonDao;
+import org.smartregister.chw.ncd.domain.MemberObject;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public final class MarkClientAsDeceasedHelper {
+
+    private static final String REMOVE_REASON_DEATH = "Death";
+    private static final String DATE_FORMAT_DISPLAY = "dd-MM-yyyy";
+    private static final String DATE_FORMAT_ISO = "yyyy-MM-dd";
+
+    private MarkClientAsDeceasedHelper() {
+    }
+
+    public static void markAsDeceased(Context context, MemberObject memberObject,
+                                      String dateOfDeath) throws Exception {
+        if (memberObject == null || StringUtils.isBlank(memberObject.getBaseEntityId())) {
+            throw new IllegalArgumentException("NCD client is required");
+        }
+
+        String normalizedDateOfDeath = normalizeDateOfDeath(dateOfDeath);
+        String normalizedDateOfBirth = normalizeDateOfBirth(
+                PersonDao.getDob(memberObject.getBaseEntityId()));
+        JSONObject form = (new FormUtils()).getFormJsonFromRepositoryOrAssets(
+                context, CoreConstants.JSON_FORM.FAMILY_DETAILS_REMOVE_MEMBER);
+        if (form == null) {
+            throw new IllegalStateException("Unable to load Mark as Deceased form");
+        }
+
+        org.smartregister.chw.anc.util.JsonFormUtils.getRegistrationForm(
+                form,
+                memberObject.getBaseEntityId(),
+                org.smartregister.Context.getInstance().allSharedPreferences()
+                        .getPreference(AllConstants.CURRENT_LOCATION_ID));
+        populateForm(form, memberObject, normalizedDateOfBirth, normalizedDateOfDeath);
+
+        String eventType = Utils.removeUser(
+                null,
+                form,
+                Utils.context().allSharedPreferences().fetchRegisteredANM());
+        if (!CoreConstants.EventType.REMOVE_MEMBER.equalsIgnoreCase(eventType)) {
+            throw new IllegalStateException("Mark as Deceased did not create Remove Family Member event");
+        }
+    }
+
+    static void populateForm(JSONObject form, MemberObject memberObject,
+                             String normalizedDateOfBirth,
+                             String normalizedDateOfDeath) throws Exception {
+        JSONArray fields = form.getJSONObject(org.smartregister.family.util.JsonFormUtils.STEP1)
+                .getJSONArray(org.smartregister.family.util.JsonFormUtils.FIELDS);
+
+        updateField(fields, "first_name", memberObject.getFirstName());
+        updateField(fields, "middle_name", memberObject.getMiddleName());
+        updateField(fields, "last_name", memberObject.getLastName());
+        updateField(fields, "sex", memberObject.getGender());
+        updateField(fields, "dob", normalizedDateOfBirth);
+        updateField(fields, "remove_reason", REMOVE_REASON_DEATH);
+        updateField(fields, "date_died", normalizedDateOfDeath);
+        updateField(fields, "dod", normalizedDateOfDeath);
+    }
+
+    static String normalizeDateOfDeath(String dateOfDeath) throws ParseException {
+        return normalizeDate(dateOfDeath, "Date of death is required",
+                "Unsupported date of death: ");
+    }
+
+    static String normalizeDateOfBirth(String dateOfBirth) throws ParseException {
+        return normalizeDate(dateOfBirth, "Client date of birth is missing",
+                "Unsupported client date of birth: ");
+    }
+
+    private static String normalizeDate(String value, String missingMessage,
+                                        String unsupportedMessage) throws ParseException {
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException(missingMessage);
+        }
+
+        Date parsedDate = parseStrictly(value, DATE_FORMAT_DISPLAY);
+        if (parsedDate == null) {
+            parsedDate = parseStrictly(value, DATE_FORMAT_ISO);
+        }
+        if (parsedDate != null) {
+            return new SimpleDateFormat(DATE_FORMAT_DISPLAY, Locale.ENGLISH).format(parsedDate);
+        }
+
+        if (!value.matches("^\\d{4}-\\d{2}-\\d{2}T.+$")) {
+            throw new ParseException(unsupportedMessage + value, 0);
+        }
+
+        try {
+            return ISODateTimeFormat.dateOptionalTimeParser()
+                    .withOffsetParsed()
+                    .parseDateTime(value)
+                    .toString(DATE_FORMAT_DISPLAY, Locale.ENGLISH);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(unsupportedMessage + value, 0);
+        }
+    }
+
+    private static Date parseStrictly(String value, String pattern) {
+        SimpleDateFormat format = new SimpleDateFormat(pattern, Locale.ENGLISH);
+        format.setLenient(false);
+        ParsePosition position = new ParsePosition(0);
+        Date parsedDate = format.parse(value, position);
+        return parsedDate != null && position.getIndex() == value.length() ? parsedDate : null;
+    }
+
+    private static void updateField(JSONArray fields, String key, String value) {
+        org.smartregister.chw.core.utils.FormUtils.updateFormField(fields, key,
+                StringUtils.defaultString(value));
+    }
+}

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -725,10 +725,11 @@
 
     <!-- NCD Case Management Follow-Up -->
     <string name="ncd_case_management_visit_title">Ufuatiliaji wa Kila Mwezi wa NCD</string>
-    <string name="ncd_followup_action_status">Hali ya Ufuatiliaji</string>
+    <string name="ncd_followup_action_status">Hali ya Mteja</string>
     <string name="ncd_followup_status_pending">Bado haijakamilika</string>
-    <string name="ncd_followup_status_active">Anaendelea na huduma</string>
-    <string name="ncd_followup_status_inactive">Hapokei huduma</string>
+    <string name="ncd_followup_status_continuing">Anaendelea na Huduma</string>
+    <string name="ncd_followup_status_dead">Amefariki</string>
+    <string name="ncd_followup_status_transferred">Amehamishwa</string>
     <string name="ncd_death_registration_save_failed">Imeshindikana kuunda kumbukumbu ya kifo. Bonyeza hifadhi ili kujaribu tena.</string>
     <string name="ncd_followup_action_clinical_adherence">Ufuatiliaji wa Dawa na Kliniki</string>
     <string name="ncd_followup_action_danger_signs">Dalili za Hatari</string>

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -725,6 +725,11 @@
 
     <!-- NCD Case Management Follow-Up -->
     <string name="ncd_case_management_visit_title">Ufuatiliaji wa Kila Mwezi wa NCD</string>
+    <string name="ncd_followup_action_status">Hali ya Ufuatiliaji</string>
+    <string name="ncd_followup_status_pending">Bado haijakamilika</string>
+    <string name="ncd_followup_status_active">Anaendelea na huduma</string>
+    <string name="ncd_followup_status_inactive">Hapokei huduma</string>
+    <string name="ncd_death_registration_save_failed">Imeshindikana kuunda kumbukumbu ya kifo. Bonyeza hifadhi ili kujaribu tena.</string>
     <string name="ncd_followup_action_clinical_adherence">Ufuatiliaji wa Dawa na Kliniki</string>
     <string name="ncd_followup_action_danger_signs">Dalili za Hatari</string>
     <string name="ncd_followup_action_lifestyle">Mtindo wa Maisha</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -697,10 +697,11 @@
 
     <!-- NCD Case Management Follow-Up -->
     <string name="ncd_case_management_visit_title">NCD Monthly Follow-Up</string>
-    <string name="ncd_followup_action_status">Follow-Up Status</string>
+    <string name="ncd_followup_action_status">Client Status</string>
     <string name="ncd_followup_status_pending">Not yet completed</string>
-    <string name="ncd_followup_status_active">Currently in service</string>
-    <string name="ncd_followup_status_inactive">Not in service</string>
+    <string name="ncd_followup_status_continuing">Continuing with Services</string>
+    <string name="ncd_followup_status_dead">Dead</string>
+    <string name="ncd_followup_status_transferred">Transferred</string>
     <string name="ncd_death_registration_save_failed">Unable to create the mortality record. Tap submit to try again.</string>
     <string name="ncd_followup_action_clinical_adherence">Clinical Adherence</string>
     <string name="ncd_followup_action_danger_signs">Danger Signs</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -697,6 +697,11 @@
 
     <!-- NCD Case Management Follow-Up -->
     <string name="ncd_case_management_visit_title">NCD Monthly Follow-Up</string>
+    <string name="ncd_followup_action_status">Follow-Up Status</string>
+    <string name="ncd_followup_status_pending">Not yet completed</string>
+    <string name="ncd_followup_status_active">Currently in service</string>
+    <string name="ncd_followup_status_inactive">Not in service</string>
+    <string name="ncd_death_registration_save_failed">Unable to create the mortality record. Tap submit to try again.</string>
     <string name="ncd_followup_action_clinical_adherence">Clinical Adherence</string>
     <string name="ncd_followup_action_danger_signs">Danger Signs</string>
     <string name="ncd_followup_action_lifestyle">Lifestyle Modifications</string>

--- a/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_status.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_status.json
@@ -1,0 +1,169 @@
+{
+  "count": "1",
+  "encounter_type": "NCD Monthly Follow-Up",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "step1": {
+    "title": "Hali ya Ufuatiliaji",
+    "fields": [
+      {
+        "key": "client_follow_up_status",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "client_follow_up_status",
+        "openmrs_data_type": "select one",
+        "type": "native_radio",
+        "label": "Chagua hali ya mpokea huduma",
+        "options": [
+          {
+            "key": "currently_in_service",
+            "text": "Anaendelea na huduma",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "currently_in_service"
+          },
+          {
+            "key": "not_in_service",
+            "text": "Hapokei huduma",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "not_in_service"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua hali ya ufuatiliaji ya mpokea huduma"
+        }
+      },
+      {
+        "key": "reason_for_not_receiving_service",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "reason_for_not_receiving_service",
+        "openmrs_data_type": "select one",
+        "type": "native_radio",
+        "label": "Sababu ya kutokupokea huduma",
+        "options": [
+          {
+            "key": "moved_to_another_location",
+            "text": "Amehama kwenda eneo jingine",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "moved_to_another_location"
+          },
+          {
+            "key": "deceased",
+            "text": "Amefariki",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "deceased"
+          },
+          {
+            "key": "lost_to_follow_up",
+            "text": "Amepotea",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "lost_to_follow_up"
+          },
+          {
+            "key": "other",
+            "text": "Nyingine (Taja)",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "other"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua sababu ya kutokupokea huduma"
+        },
+        "relevance": {
+          "step1:client_follow_up_status": {
+            "type": "string",
+            "ex": "equalTo(., \"not_in_service\")"
+          }
+        }
+      },
+      {
+        "key": "other_reason_for_not_receiving_service",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "other_reason_for_not_receiving_service",
+        "type": "edit_text",
+        "hint": "Taja sababu nyingine",
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali taja sababu nyingine"
+        },
+        "relevance": {
+          "step1:reason_for_not_receiving_service": {
+            "type": "string",
+            "ex": "equalTo(., \"other\")"
+          }
+        }
+      },
+      {
+        "key": "date_of_death",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "date_of_death",
+        "type": "date_picker",
+        "hint": "Tarehe ya kifo",
+        "max_date": "today",
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua tarehe ya kifo"
+        },
+        "relevance": {
+          "step1:reason_for_not_receiving_service": {
+            "type": "string",
+            "ex": "equalTo(., \"deceased\")"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_status.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_status.json
@@ -1,19 +1,19 @@
 {
   "count": "1",
-  "encounter_type": "NCD Monthly Follow-Up",
+  "encounter_type": "client_status",
   "entity_id": "",
   "metadata": {
     "start": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "start",
-      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "start"
     },
     "end": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "end",
-      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "end"
     },
     "today": {
       "openmrs_entity_parent": "",
@@ -24,125 +24,65 @@
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "deviceid",
-      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "deviceid"
     },
     "subscriberid": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "subscriberid",
-      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "subscriberid"
     },
     "simserial": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "simserial",
-      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "simserial"
     },
     "phonenumber": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "phonenumber",
-      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "phonenumber"
     },
     "encounter_location": ""
   },
   "step1": {
-    "title": "Hali ya Ufuatiliaji",
+    "title": "Hali ya Mteja",
+    "display_back_button": "true",
     "fields": [
       {
-        "key": "client_follow_up_status",
+        "key": "client_status",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "client_follow_up_status",
-        "openmrs_data_type": "select one",
+        "openmrs_entity_id": "client_status",
         "type": "native_radio",
-        "label": "Chagua hali ya mpokea huduma",
+        "label": "Hali ya Mteja",
         "options": [
           {
-            "key": "currently_in_service",
-            "text": "Anaendelea na huduma",
+            "key": "continuing",
+            "text": "Anaendelea na Huduma",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "currently_in_service"
+            "openmrs_entity_id": "continuing"
           },
           {
-            "key": "not_in_service",
-            "text": "Hapokei huduma",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "not_in_service"
-          }
-        ],
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali chagua hali ya ufuatiliaji ya mpokea huduma"
-        }
-      },
-      {
-        "key": "reason_for_not_receiving_service",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "reason_for_not_receiving_service",
-        "openmrs_data_type": "select one",
-        "type": "native_radio",
-        "label": "Sababu ya kutokupokea huduma",
-        "options": [
-          {
-            "key": "moved_to_another_location",
-            "text": "Amehama kwenda eneo jingine",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "moved_to_another_location"
-          },
-          {
-            "key": "deceased",
+            "key": "dead",
             "text": "Amefariki",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "deceased"
+            "openmrs_entity_id": "dead"
           },
           {
-            "key": "lost_to_follow_up",
-            "text": "Amepotea",
+            "key": "transferred",
+            "text": "Amehamishwa",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "lost_to_follow_up"
-          },
-          {
-            "key": "other",
-            "text": "Nyingine (Taja)",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "other"
+            "openmrs_entity_id": "transferred"
           }
         ],
         "v_required": {
-          "value": "true",
-          "err": "Tafadhali chagua sababu ya kutokupokea huduma"
-        },
-        "relevance": {
-          "step1:client_follow_up_status": {
-            "type": "string",
-            "ex": "equalTo(., \"not_in_service\")"
-          }
-        }
-      },
-      {
-        "key": "other_reason_for_not_receiving_service",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "other_reason_for_not_receiving_service",
-        "type": "edit_text",
-        "hint": "Taja sababu nyingine",
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali taja sababu nyingine"
-        },
-        "relevance": {
-          "step1:reason_for_not_receiving_service": {
-            "type": "string",
-            "ex": "equalTo(., \"other\")"
-          }
+          "value": true,
+          "err": "Tafadhali chagua hali ya mteja"
         }
       },
       {
@@ -154,13 +94,13 @@
         "hint": "Tarehe ya kifo",
         "max_date": "today",
         "v_required": {
-          "value": "true",
+          "value": true,
           "err": "Tafadhali chagua tarehe ya kifo"
         },
         "relevance": {
-          "step1:reason_for_not_receiving_service": {
+          "step1:client_status": {
             "type": "string",
-            "ex": "equalTo(., \"deceased\")"
+            "ex": "equalTo(., \"dead\")"
           }
         }
       }

--- a/opensrp-chw/src/nacp/assets/json.form/ncd_followup_status.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ncd_followup_status.json
@@ -1,19 +1,19 @@
 {
   "count": "1",
-  "encounter_type": "NCD Monthly Follow-Up",
+  "encounter_type": "client_status",
   "entity_id": "",
   "metadata": {
     "start": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "start",
-      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "start"
     },
     "end": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "end",
-      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "end"
     },
     "today": {
       "openmrs_entity_parent": "",
@@ -24,125 +24,65 @@
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "deviceid",
-      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "deviceid"
     },
     "subscriberid": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "subscriberid",
-      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "subscriberid"
     },
     "simserial": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "simserial",
-      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "simserial"
     },
     "phonenumber": {
       "openmrs_entity_parent": "",
       "openmrs_entity": "concept",
       "openmrs_data_type": "phonenumber",
-      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+      "openmrs_entity_id": "phonenumber"
     },
     "encounter_location": ""
   },
   "step1": {
-    "title": "Follow-Up Status",
+    "title": "Client Status",
+    "display_back_button": "true",
     "fields": [
       {
-        "key": "client_follow_up_status",
+        "key": "client_status",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "client_follow_up_status",
-        "openmrs_data_type": "select one",
+        "openmrs_entity_id": "client_status",
         "type": "native_radio",
-        "label": "Client Follow-Up Status",
+        "label": "Client Status",
         "options": [
           {
-            "key": "currently_in_service",
-            "text": "Currently in service",
+            "key": "continuing",
+            "text": "Continuing with Services",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "currently_in_service"
+            "openmrs_entity_id": "continuing"
           },
           {
-            "key": "not_in_service",
-            "text": "Not in service",
+            "key": "dead",
+            "text": "Dead",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
-            "openmrs_entity_id": "not_in_service"
+            "openmrs_entity_id": "dead"
+          },
+          {
+            "key": "transferred",
+            "text": "Transferred",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "transferred"
           }
         ],
         "v_required": {
-          "value": "true",
-          "err": "Please select the client's follow-up status"
-        }
-      },
-      {
-        "key": "reason_for_not_receiving_service",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "reason_for_not_receiving_service",
-        "openmrs_data_type": "select one",
-        "type": "native_radio",
-        "label": "Reason for Not Receiving Service",
-        "options": [
-          {
-            "key": "moved_to_another_location",
-            "text": "Moved to another location",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "moved_to_another_location"
-          },
-          {
-            "key": "deceased",
-            "text": "Deceased",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "deceased"
-          },
-          {
-            "key": "lost_to_follow_up",
-            "text": "Lost to follow-up",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "lost_to_follow_up"
-          },
-          {
-            "key": "other",
-            "text": "Other (Specify)",
-            "openmrs_entity_parent": "",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "other"
-          }
-        ],
-        "v_required": {
-          "value": "true",
-          "err": "Please select the reason for not receiving service"
-        },
-        "relevance": {
-          "step1:client_follow_up_status": {
-            "type": "string",
-            "ex": "equalTo(., \"not_in_service\")"
-          }
-        }
-      },
-      {
-        "key": "other_reason_for_not_receiving_service",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "other_reason_for_not_receiving_service",
-        "type": "edit_text",
-        "hint": "Specify the other reason",
-        "v_required": {
-          "value": "true",
-          "err": "Please specify the other reason"
-        },
-        "relevance": {
-          "step1:reason_for_not_receiving_service": {
-            "type": "string",
-            "ex": "equalTo(., \"other\")"
-          }
+          "value": true,
+          "err": "Please select the client status"
         }
       },
       {
@@ -154,13 +94,13 @@
         "hint": "Date of death",
         "max_date": "today",
         "v_required": {
-          "value": "true",
+          "value": true,
           "err": "Please select the date of death"
         },
         "relevance": {
-          "step1:reason_for_not_receiving_service": {
+          "step1:client_status": {
             "type": "string",
-            "ex": "equalTo(., \"deceased\")"
+            "ex": "equalTo(., \"dead\")"
           }
         }
       }

--- a/opensrp-chw/src/nacp/assets/json.form/ncd_followup_status.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ncd_followup_status.json
@@ -1,0 +1,169 @@
+{
+  "count": "1",
+  "encounter_type": "NCD Monthly Follow-Up",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "step1": {
+    "title": "Follow-Up Status",
+    "fields": [
+      {
+        "key": "client_follow_up_status",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "client_follow_up_status",
+        "openmrs_data_type": "select one",
+        "type": "native_radio",
+        "label": "Client Follow-Up Status",
+        "options": [
+          {
+            "key": "currently_in_service",
+            "text": "Currently in service",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "currently_in_service"
+          },
+          {
+            "key": "not_in_service",
+            "text": "Not in service",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "not_in_service"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Please select the client's follow-up status"
+        }
+      },
+      {
+        "key": "reason_for_not_receiving_service",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "reason_for_not_receiving_service",
+        "openmrs_data_type": "select one",
+        "type": "native_radio",
+        "label": "Reason for Not Receiving Service",
+        "options": [
+          {
+            "key": "moved_to_another_location",
+            "text": "Moved to another location",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "moved_to_another_location"
+          },
+          {
+            "key": "deceased",
+            "text": "Deceased",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "deceased"
+          },
+          {
+            "key": "lost_to_follow_up",
+            "text": "Lost to follow-up",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "lost_to_follow_up"
+          },
+          {
+            "key": "other",
+            "text": "Other (Specify)",
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "other"
+          }
+        ],
+        "v_required": {
+          "value": "true",
+          "err": "Please select the reason for not receiving service"
+        },
+        "relevance": {
+          "step1:client_follow_up_status": {
+            "type": "string",
+            "ex": "equalTo(., \"not_in_service\")"
+          }
+        }
+      },
+      {
+        "key": "other_reason_for_not_receiving_service",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "other_reason_for_not_receiving_service",
+        "type": "edit_text",
+        "hint": "Specify the other reason",
+        "v_required": {
+          "value": "true",
+          "err": "Please specify the other reason"
+        },
+        "relevance": {
+          "step1:reason_for_not_receiving_service": {
+            "type": "string",
+            "ex": "equalTo(., \"other\")"
+          }
+        }
+      },
+      {
+        "key": "date_of_death",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "date_of_death",
+        "type": "date_picker",
+        "hint": "Date of death",
+        "max_date": "today",
+        "v_required": {
+          "value": "true",
+          "err": "Please select the date of death"
+        },
+        "relevance": {
+          "step1:reason_for_not_receiving_service": {
+            "type": "string",
+            "ex": "equalTo(., \"deceased\")"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelperTest.java
@@ -10,9 +10,9 @@ import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
 public class NcdFollowUpStatusActionHelperTest {
 
     @Test
-    public void activeStatusIsComplete() {
+    public void continuingStatusIsComplete() {
         NcdFollowUpStatusActionHelper helper = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_ACTIVE, null, null);
+                NcdFollowUpStatusActionHelper.STATUS_CONTINUING, null);
 
         assertEquals(BaseNcdVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
         assertTrue(helper.isActive());
@@ -20,50 +20,31 @@ public class NcdFollowUpStatusActionHelperTest {
     }
 
     @Test
-    public void inactiveStatusRequiresReason() {
+    public void transferredStatusIsComplete() {
         NcdFollowUpStatusActionHelper helper = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_INACTIVE, null, null);
+                NcdFollowUpStatusActionHelper.STATUS_TRANSFERRED, null);
 
-        assertEquals(BaseNcdVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+        assertEquals(BaseNcdVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
+        assertFalse(helper.isActive());
+        assertFalse(helper.isDeceased());
     }
 
     @Test
-    public void otherReasonRequiresSpecification() {
-        NcdFollowUpStatusActionHelper missingSpecification = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
-                NcdFollowUpStatusActionHelper.REASON_OTHER,
-                null);
-        NcdFollowUpStatusActionHelper complete = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
-                NcdFollowUpStatusActionHelper.REASON_OTHER,
-                "Receiving care elsewhere");
-
-        assertEquals(BaseNcdVisitAction.Status.PENDING,
-                missingSpecification.evaluateStatusOnPayload());
-        assertEquals(BaseNcdVisitAction.Status.COMPLETED,
-                complete.evaluateStatusOnPayload());
-    }
-
-    @Test
-    public void deceasedReasonIsDetected() {
+    public void deadStatusIsDetectedWhenDateIsPresent() {
         NcdFollowUpStatusActionHelper helper = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
-                NcdFollowUpStatusActionHelper.REASON_DECEASED,
-                null,
-                "2026-06-01");
+                NcdFollowUpStatusActionHelper.STATUS_DEAD, "2026-06-01");
 
         assertEquals(BaseNcdVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
         assertTrue(helper.isDeceased());
     }
 
     @Test
-    public void deceasedReasonRequiresDateOfDeath() {
+    public void deadStatusRequiresDateOfDeath() {
         NcdFollowUpStatusActionHelper helper = helperWith(
-                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
-                NcdFollowUpStatusActionHelper.REASON_DECEASED,
-                null);
+                NcdFollowUpStatusActionHelper.STATUS_DEAD, null);
 
         assertEquals(BaseNcdVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+        assertTrue(helper.isDeceased());
     }
 
     @Test
@@ -76,42 +57,36 @@ public class NcdFollowUpStatusActionHelperTest {
     }
 
     @Test
-    public void activeStatusClearsInactiveReasonValues() {
+    public void nonDeadStatusClearsStaleDateOfDeath() {
         String payload = "{\"step1\":{\"fields\":["
                 + field(NcdFollowUpStatusActionHelper.KEY_STATUS,
-                NcdFollowUpStatusActionHelper.STATUS_ACTIVE) + ","
-                + field(NcdFollowUpStatusActionHelper.KEY_REASON,
-                NcdFollowUpStatusActionHelper.REASON_OTHER) + ","
-                + field(NcdFollowUpStatusActionHelper.KEY_OTHER_REASON, "Old reason") + ","
+                NcdFollowUpStatusActionHelper.STATUS_TRANSFERRED) + ","
                 + field(NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH, "2026-06-01")
                 + "]}}";
 
         String sanitized = NcdFollowUpStatusActionHelper.clearIrrelevantValues(payload);
 
         assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
-                sanitized, NcdFollowUpStatusActionHelper.KEY_REASON));
-        assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
-                sanitized, NcdFollowUpStatusActionHelper.KEY_OTHER_REASON));
-        assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
                 sanitized, NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH));
     }
 
-    private NcdFollowUpStatusActionHelper helperWith(String status, String reason,
-                                                       String otherReason) {
-        return helperWith(status, reason, otherReason, null);
+    @Test
+    public void deadStatusPreservesDateOfDeath() {
+        String payload = "{\"step1\":{\"fields\":["
+                + field(NcdFollowUpStatusActionHelper.KEY_STATUS,
+                NcdFollowUpStatusActionHelper.STATUS_DEAD) + ","
+                + field(NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH, "2026-06-01")
+                + "]}}";
+
+        String sanitized = NcdFollowUpStatusActionHelper.clearIrrelevantValues(payload);
+
+        assertEquals("2026-06-01", NcdFollowUpStatusActionHelper.extractValue(
+                sanitized, NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH));
     }
 
-    private NcdFollowUpStatusActionHelper helperWith(String status, String reason,
-                                                       String otherReason, String dateOfDeath) {
+    private NcdFollowUpStatusActionHelper helperWith(String status, String dateOfDeath) {
         StringBuilder fields = new StringBuilder();
         fields.append(field(NcdFollowUpStatusActionHelper.KEY_STATUS, status));
-        if (reason != null) {
-            fields.append(',').append(field(NcdFollowUpStatusActionHelper.KEY_REASON, reason));
-        }
-        if (otherReason != null) {
-            fields.append(',').append(field(
-                    NcdFollowUpStatusActionHelper.KEY_OTHER_REASON, otherReason));
-        }
         if (dateOfDeath != null) {
             fields.append(',').append(field(
                     NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH, dateOfDeath));

--- a/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/NcdFollowUpStatusActionHelperTest.java
@@ -1,0 +1,128 @@
+package org.smartregister.chw.actionhelper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
+
+public class NcdFollowUpStatusActionHelperTest {
+
+    @Test
+    public void activeStatusIsComplete() {
+        NcdFollowUpStatusActionHelper helper = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_ACTIVE, null, null);
+
+        assertEquals(BaseNcdVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
+        assertTrue(helper.isActive());
+        assertFalse(helper.isDeceased());
+    }
+
+    @Test
+    public void inactiveStatusRequiresReason() {
+        NcdFollowUpStatusActionHelper helper = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_INACTIVE, null, null);
+
+        assertEquals(BaseNcdVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+    }
+
+    @Test
+    public void otherReasonRequiresSpecification() {
+        NcdFollowUpStatusActionHelper missingSpecification = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
+                NcdFollowUpStatusActionHelper.REASON_OTHER,
+                null);
+        NcdFollowUpStatusActionHelper complete = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
+                NcdFollowUpStatusActionHelper.REASON_OTHER,
+                "Receiving care elsewhere");
+
+        assertEquals(BaseNcdVisitAction.Status.PENDING,
+                missingSpecification.evaluateStatusOnPayload());
+        assertEquals(BaseNcdVisitAction.Status.COMPLETED,
+                complete.evaluateStatusOnPayload());
+    }
+
+    @Test
+    public void deceasedReasonIsDetected() {
+        NcdFollowUpStatusActionHelper helper = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
+                NcdFollowUpStatusActionHelper.REASON_DECEASED,
+                null,
+                "2026-06-01");
+
+        assertEquals(BaseNcdVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
+        assertTrue(helper.isDeceased());
+    }
+
+    @Test
+    public void deceasedReasonRequiresDateOfDeath() {
+        NcdFollowUpStatusActionHelper helper = helperWith(
+                NcdFollowUpStatusActionHelper.STATUS_INACTIVE,
+                NcdFollowUpStatusActionHelper.REASON_DECEASED,
+                null);
+
+        assertEquals(BaseNcdVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+    }
+
+    @Test
+    public void emptyPayloadRemainsPending() {
+        NcdFollowUpStatusActionHelper helper = new NcdFollowUpStatusActionHelper();
+
+        assertEquals(BaseNcdVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+        assertFalse(helper.isActive());
+        assertFalse(helper.isDeceased());
+    }
+
+    @Test
+    public void activeStatusClearsInactiveReasonValues() {
+        String payload = "{\"step1\":{\"fields\":["
+                + field(NcdFollowUpStatusActionHelper.KEY_STATUS,
+                NcdFollowUpStatusActionHelper.STATUS_ACTIVE) + ","
+                + field(NcdFollowUpStatusActionHelper.KEY_REASON,
+                NcdFollowUpStatusActionHelper.REASON_OTHER) + ","
+                + field(NcdFollowUpStatusActionHelper.KEY_OTHER_REASON, "Old reason") + ","
+                + field(NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH, "2026-06-01")
+                + "]}}";
+
+        String sanitized = NcdFollowUpStatusActionHelper.clearIrrelevantValues(payload);
+
+        assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
+                sanitized, NcdFollowUpStatusActionHelper.KEY_REASON));
+        assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
+                sanitized, NcdFollowUpStatusActionHelper.KEY_OTHER_REASON));
+        assertEquals("", NcdFollowUpStatusActionHelper.extractValue(
+                sanitized, NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH));
+    }
+
+    private NcdFollowUpStatusActionHelper helperWith(String status, String reason,
+                                                       String otherReason) {
+        return helperWith(status, reason, otherReason, null);
+    }
+
+    private NcdFollowUpStatusActionHelper helperWith(String status, String reason,
+                                                       String otherReason, String dateOfDeath) {
+        StringBuilder fields = new StringBuilder();
+        fields.append(field(NcdFollowUpStatusActionHelper.KEY_STATUS, status));
+        if (reason != null) {
+            fields.append(',').append(field(NcdFollowUpStatusActionHelper.KEY_REASON, reason));
+        }
+        if (otherReason != null) {
+            fields.append(',').append(field(
+                    NcdFollowUpStatusActionHelper.KEY_OTHER_REASON, otherReason));
+        }
+        if (dateOfDeath != null) {
+            fields.append(',').append(field(
+                    NcdFollowUpStatusActionHelper.KEY_DATE_OF_DEATH, dateOfDeath));
+        }
+
+        NcdFollowUpStatusActionHelper helper = new NcdFollowUpStatusActionHelper();
+        helper.onPayloadReceived("{\"step1\":{\"fields\":[" + fields + "]}}");
+        return helper;
+    }
+
+    private String field(String key, String value) {
+        return "{\"key\":\"" + key + "\",\"value\":\"" + value + "\"}";
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/dao/NcdCaseManagementDaoTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/dao/NcdCaseManagementDaoTest.java
@@ -1,0 +1,78 @@
+package org.smartregister.chw.dao;
+
+import net.zetetic.database.MatrixCursor;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.smartregister.dao.AbstractDao;
+import org.smartregister.repository.Repository;
+
+public class NcdCaseManagementDaoTest extends AbstractDao {
+
+    @Mock
+    private Repository repository;
+
+    @Mock
+    private SQLiteDatabase database;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        setRepository(repository);
+        Mockito.doReturn(database).when(repository).getReadableDatabase();
+    }
+
+    @Test
+    public void hasDeathRegisterRecordReturnsTrueWhenRowExists() {
+        Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(NcdCaseManagementDao.hasDeathRegisterRecord("base-entity-id"));
+    }
+
+    @Test
+    public void hasDeathRegisterRecordReturnsFalseWhenRowDoesNotExist() {
+        Mockito.doReturn(countCursor(0)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertFalse(NcdCaseManagementDao.hasDeathRegisterRecord("base-entity-id"));
+    }
+
+    @Test
+    public void hasRemoveMemberEventReturnsTrueWhenEventExists() {
+        Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(NcdCaseManagementDao.hasRemoveMemberEvent("base-entity-id"));
+    }
+
+    @Test
+    public void hasMortalityRecordShortCircuitsWhenRemoveMemberEventExists() {
+        Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(NcdCaseManagementDao.hasMortalityRecord("base-entity-id"));
+        Mockito.verify(database, Mockito.times(1)).rawQuery(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    public void isNcdCaseClosedReturnsTrueWhenCaseIsClosed() {
+        Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(NcdCaseManagementDao.isNcdCaseClosed("base-entity-id"));
+    }
+
+    @Test
+    public void isNcdCaseClosedReturnsFalseWhenCaseIsOpen() {
+        Mockito.doReturn(countCursor(0)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertFalse(NcdCaseManagementDao.isNcdCaseClosed("base-entity-id"));
+    }
+
+    private MatrixCursor countCursor(int count) {
+        MatrixCursor cursor = new MatrixCursor(new String[]{"cnt"});
+        cursor.addRow(new Object[]{count});
+        return cursor;
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/dao/NcdCaseManagementDaoTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/dao/NcdCaseManagementDaoTest.java
@@ -6,9 +6,11 @@ import net.zetetic.database.sqlcipher.SQLiteDatabase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.dao.AbstractDao;
 import org.smartregister.repository.Repository;
 
@@ -28,10 +30,19 @@ public class NcdCaseManagementDaoTest extends AbstractDao {
     }
 
     @Test
+    public void hasOpenReferralUsesSelectionArgs() {
+        Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
+
+        Assert.assertTrue(NcdCaseManagementDao.hasOpenReferral("base'entity-id"));
+        verifyRawQueryUsesArgs("base'entity-id");
+    }
+
+    @Test
     public void hasDeathRegisterRecordReturnsTrueWhenRowExists() {
         Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
 
-        Assert.assertTrue(NcdCaseManagementDao.hasDeathRegisterRecord("base-entity-id"));
+        Assert.assertTrue(NcdCaseManagementDao.hasDeathRegisterRecord("base'entity-id"));
+        verifyRawQueryUsesArgs("base'entity-id");
     }
 
     @Test
@@ -45,22 +56,25 @@ public class NcdCaseManagementDaoTest extends AbstractDao {
     public void hasRemoveMemberEventReturnsTrueWhenEventExists() {
         Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
 
-        Assert.assertTrue(NcdCaseManagementDao.hasRemoveMemberEvent("base-entity-id"));
+        Assert.assertTrue(NcdCaseManagementDao.hasRemoveMemberEvent("base'entity-id"));
+        verifyRawQueryUsesArgs("base'entity-id", CoreConstants.EventType.REMOVE_MEMBER);
     }
 
     @Test
     public void hasMortalityRecordShortCircuitsWhenRemoveMemberEventExists() {
         Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
 
-        Assert.assertTrue(NcdCaseManagementDao.hasMortalityRecord("base-entity-id"));
+        Assert.assertTrue(NcdCaseManagementDao.hasMortalityRecord("base'entity-id"));
         Mockito.verify(database, Mockito.times(1)).rawQuery(Mockito.any(), Mockito.any());
+        verifyRawQueryUsesArgs("base'entity-id", CoreConstants.EventType.REMOVE_MEMBER);
     }
 
     @Test
     public void isNcdCaseClosedReturnsTrueWhenCaseIsClosed() {
         Mockito.doReturn(countCursor(1)).when(database).rawQuery(Mockito.any(), Mockito.any());
 
-        Assert.assertTrue(NcdCaseManagementDao.isNcdCaseClosed("base-entity-id"));
+        Assert.assertTrue(NcdCaseManagementDao.isNcdCaseClosed("base'entity-id"));
+        verifyRawQueryUsesArgs("base'entity-id");
     }
 
     @Test
@@ -74,5 +88,17 @@ public class NcdCaseManagementDaoTest extends AbstractDao {
         MatrixCursor cursor = new MatrixCursor(new String[]{"cnt"});
         cursor.addRow(new Object[]{count});
         return cursor;
+    }
+
+    private void verifyRawQueryUsesArgs(String... expectedArgs) {
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String[]> argsCaptor = ArgumentCaptor.forClass(String[].class);
+        Mockito.verify(database, Mockito.atLeastOnce()).rawQuery(sqlCaptor.capture(), argsCaptor.capture());
+
+        String sql = sqlCaptor.getAllValues().get(sqlCaptor.getAllValues().size() - 1);
+        Assert.assertTrue(sql.contains("?"));
+        Assert.assertFalse(sql.contains("base'entity-id"));
+        Assert.assertArrayEquals(expectedArgs,
+                argsCaptor.getAllValues().get(argsCaptor.getAllValues().size() - 1));
     }
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/MarkClientAsDeceasedHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/MarkClientAsDeceasedHelperTest.java
@@ -1,0 +1,92 @@
+package org.smartregister.chw.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.smartregister.chw.ncd.domain.MemberObject;
+
+public class MarkClientAsDeceasedHelperTest {
+
+    @Test
+    public void normalizesIsoDateForRemoveMemberProcessor() throws Exception {
+        assertEquals("10-06-2026",
+                MarkClientAsDeceasedHelper.normalizeDateOfDeath("2026-06-10"));
+    }
+
+    @Test
+    public void preservesDisplayFormattedDate() throws Exception {
+        assertEquals("10-06-2026",
+                MarkClientAsDeceasedHelper.normalizeDateOfDeath("10-06-2026"));
+    }
+
+    @Test
+    public void normalizesFamilyMemberDateOfBirth() throws Exception {
+        assertEquals("14-02-1985",
+                MarkClientAsDeceasedHelper.normalizeDateOfBirth("1985-02-14"));
+    }
+
+    @Test
+    public void normalizesFamilyMemberIsoTimestampDateOfBirth() throws Exception {
+        assertEquals("20-06-1994", MarkClientAsDeceasedHelper.normalizeDateOfBirth(
+                "1994-06-20T03:00:00.000+03:00"));
+    }
+
+    @Test(expected = java.text.ParseException.class)
+    public void rejectsNumericAgeAsDateOfBirth() throws Exception {
+        MarkClientAsDeceasedHelper.normalizeDateOfBirth("41");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingDateOfBirth() throws Exception {
+        MarkClientAsDeceasedHelper.normalizeDateOfBirth("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingDate() throws Exception {
+        MarkClientAsDeceasedHelper.normalizeDateOfDeath("");
+    }
+
+    @Test
+    public void populatesRemoveMemberWorkflowFields() throws Exception {
+        JSONObject form = new JSONObject("{\"step1\":{\"fields\":["
+                + field("first_name") + "," + field("middle_name") + ","
+                + field("last_name") + "," + field("sex") + ","
+                + field("dob") + "," + field("remove_reason") + ","
+                + field("date_died") + "," + field("dod") + "]}}");
+        MemberObject member = new MemberObject();
+        member.setFirstName("Asha");
+        member.setMiddleName("Juma");
+        member.setLastName("Moshi");
+        member.setDob("41");
+        member.setGender("Female");
+
+        MarkClientAsDeceasedHelper.populateForm(
+                form, member, "14-02-1985", "10-06-2026");
+
+        JSONArray fields = form.getJSONObject("step1").getJSONArray("fields");
+        assertEquals("Asha", value(fields, "first_name"));
+        assertEquals("Juma", value(fields, "middle_name"));
+        assertEquals("Moshi", value(fields, "last_name"));
+        assertEquals("Female", value(fields, "sex"));
+        assertEquals("14-02-1985", value(fields, "dob"));
+        assertEquals("Death", value(fields, "remove_reason"));
+        assertEquals("10-06-2026", value(fields, "date_died"));
+        assertEquals("10-06-2026", value(fields, "dod"));
+    }
+
+    private String field(String key) {
+        return "{\"key\":\"" + key + "\",\"value\":\"\"}";
+    }
+
+    private String value(JSONArray fields, String key) {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field != null && key.equals(field.optString("key"))) {
+                return field.optString("value");
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
closes #961 
✨ feat(ncd): add follow-up status and mortality registration
Add a "Follow-Up Status" action to NCD Monthly visits to track service continuity and automate the "Mark as Deceased" workflow for inactive clients.

⚙️ Follow-up Status:
  - Add `ncd_followup_status` form (EN + SW) to track if a client is "In service" or "Not in service"
  - Implement `NcdFollowUpStatusActionHelper` to handle form logic, sub-titles, and data sanitization
  - Add "gatekeeper" logic in `NcdCaseManagementVisitActivity`: if a client is marked "Not in service", all other visit actions are hidden

⚰️ Mortality Workflow:
  - Add `MarkClientAsDeceasedHelper` to automate the removal of deceased members using family member removal logic
  - Trigger mortality record creation, NCD case closure, and task/referral cancellation when "Deceased" is selected as the reason for inactivity
  - Add automated date normalization for death and birth dates to ensure compatibility with event processors

🧪 Testing:
  - Add unit tests for `MarkClientAsDeceasedHelper` (date parsing and form population)
  - Add unit tests for `NcdFollowUpStatusActionHelper` (status evaluation and payload sanitization)