### PR TITLE
fix(ncd): remove medication questions from screening

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdAutoConfirmationHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdAutoConfirmationHelper.java
@@ -23,7 +23,8 @@ public final class NcdAutoConfirmationHelper {
 
     public static final String SCREENING_EVENT_TYPE = "Diabetes and Hypertension Screening";
     private static final String CONFIRMATION_EVENT_TYPE = "Diabetes and Hypertension Screening Confirmation";
-    private static final String FIELD_DIAGNOSED = "diagnosed_diabetes";
+    private static final String FIELD_DIAGNOSED_DIABETES = "diagnosed_diabetes";
+    private static final String FIELD_DIAGNOSED_HYPERTENSION = "diagnosed_hypertension";
     private static final String FIELD_MEDICINES_DIABETES = "medicines_diabetes";
     private static final String FIELD_MEDICINES_HYPERTENSION = "medicines_hypertension";
     private static final String DIABETES_RESULT_FIELD = "diabetes_result";
@@ -50,9 +51,8 @@ public final class NcdAutoConfirmationHelper {
                 return;
             }
 
-            boolean diabetesPositive = isAffirmative(extractValue(screeningEvent, FIELD_DIAGNOSED))
-                    || isAffirmative(extractValue(screeningEvent, FIELD_MEDICINES_DIABETES));
-            boolean hypertensionPositive = isAffirmative(extractValue(screeningEvent, FIELD_MEDICINES_HYPERTENSION));
+            boolean diabetesPositive = isDiabetesPositive(screeningEvent);
+            boolean hypertensionPositive = isHypertensionPositive(screeningEvent);
 
             if (!diabetesPositive && !hypertensionPositive) {
                 return;
@@ -70,6 +70,16 @@ public final class NcdAutoConfirmationHelper {
         } catch (Exception e) {
             Timber.e(e, "Error auto-confirming diabetes/hypertension results");
         }
+    }
+
+    static boolean isDiabetesPositive(org.smartregister.domain.Event screeningEvent) {
+        return isAffirmative(extractValue(screeningEvent, FIELD_DIAGNOSED_DIABETES))
+                || isAffirmative(extractValue(screeningEvent, FIELD_MEDICINES_DIABETES));
+    }
+
+    static boolean isHypertensionPositive(org.smartregister.domain.Event screeningEvent) {
+        return isAffirmative(extractValue(screeningEvent, FIELD_DIAGNOSED_HYPERTENSION))
+                || isAffirmative(extractValue(screeningEvent, FIELD_MEDICINES_HYPERTENSION));
     }
 
     private static void queueConfirmationEvent(String baseEntityId, Map<String, String> details,

--- a/opensrp-chw/src/nacp/assets/json.form-sw/diabetes_hypertension_screening_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/diabetes_hypertension_screening_form.json
@@ -197,30 +197,6 @@
         }
       },
       {
-        "key": "medicines_diabetes",
-        "type": "spinner",
-        "hint": "Je, unatumia dawa za kisukari?",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "medicines_diabetes",
-        "values": ["Ndio", "Hapana"],
-        "keys": ["Yes", "No"],
-        "openmrs_choice_ids": {
-          "Yes": "Yes",
-          "No": "No"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Tafadhali chagua moja"
-        },
-        "relevance": {
-          "step2:diagnosed_diabetes": {
-            "type": "string",
-            "ex": "equalTo(., \"No\")"
-          }
-        }
-      },
-      {
         "key": "screened_diabetes_12m",
         "type": "spinner",
         "hint": "Je, umewahi kupimwa kisukari katika kipindi cha miezi 12 iliyopita?",
@@ -238,7 +214,7 @@
           "err": "Tafadhali chagua moja"
         },
         "relevance": {
-          "step2:medicines_diabetes": {
+          "step2:diagnosed_diabetes": {
             "type": "string",
             "ex": "equalTo(., \"No\")"
           }
@@ -269,30 +245,6 @@
         }
       },
       {
-        "key": "medicines_hypertension",
-        "type": "spinner",
-        "hint": "Je, unatumia dawa za shinikizo la damu?",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "medicines_hypertension",
-        "values": ["Ndio", "Hapana"],
-        "keys": ["Yes", "No"],
-        "openmrs_choice_ids": {
-          "Yes": "Yes",
-          "No": "No"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Tafadhali chagua moja"
-        },
-        "relevance": {
-          "step2:diagnosed_hypertension": {
-            "type": "string",
-            "ex": "equalTo(., \"No\")"
-          }
-        }
-      },
-      {
         "key": "screened_hypertension_last12m",
         "type": "spinner",
         "hint": "Je, umewahi kupimwa shinikizo la damu katika kipindi cha miezi 12 iliyopita?",
@@ -310,7 +262,7 @@
           "err": "Tafadhali chagua moja"
         },
         "relevance": {
-          "step2:medicines_hypertension": {
+          "step2:diagnosed_hypertension": {
             "type": "string",
             "ex": "equalTo(., \"No\")"
           }
@@ -570,7 +522,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "",
         "type": "toaster_notes",
-        "text": "Kwa mujibu wa taarifa ulizotoa, tayari unapokea huduma  na umeshafanyiwa uchunguzi wa kisukari na shinikizo la damu hivi karibuni. Hivyo basi, hauhitaji kufanyiwa uchunguzi mwingine kwa sasa. Tafadhali endelea kuhudhuria kliniki na kufuata ushauri wa mtoa huduma wako wa afya. Ni muhimu kuzingatia matumizi sahihi ya dawa ulizopewa na kudumisha mtindo mzuri wa maisha kama kufanya mazoezi mara kwa mara na kula chakula chenye lishe bora.",
+        "text": "Kwa mujibu wa taarifa ulizotoa, tayari umegunduliwa, umefanyiwa uchunguzi hivi karibuni, au umejiandikisha katika huduma za kawaida za kisukari au shinikizo la damu. Hivyo basi, huhitaji kufanyiwa uchunguzi mwingine kwa sasa. Tafadhali endelea na ukaguzi wa afya wa mara kwa mara na ufuate ushauri wa mtoa huduma wako wa afya.",
         "text_color": "#000000",
         "toaster_type": "info",
         "calculation": {
@@ -580,23 +532,6 @@
             }
           }
         },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "diabetes_hypertension_screening_relevance.yml"
-            }
-          }
-        }
-      },
-      {
-        "key": "prescreening_client_has_condition_toaster_not_using_meds",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "",
-        "type": "toaster_notes",
-        "text": "Umetaja kuwa kwa sasa hutumii dawa za kisukari au shinikizo la damu. Ni muhimu kufika kituo cha afya kilicho karibu nawe kwa ushauri wa kitabibu na matibabu iwapo itahitajika. Huhitaji kufanyiwa uchunguzi mpya kwa sasa, lakini unashauriwa kuendelea na ukaguzi wa afya wa mara kwa mara kama utakavyoelekezwa na mtoa huduma wako wa afya.",
-        "text_color": "#000000",
-        "toaster_type": "info",
         "relevance": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-chw/src/nacp/assets/json.form/diabetes_hypertension_screening_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form/diabetes_hypertension_screening_form.json
@@ -197,30 +197,6 @@
         }
       },
       {
-        "key": "medicines_diabetes",
-        "type": "spinner",
-        "hint": "Are you taking medicines for diabetes?",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "medicines_diabetes",
-        "keys": ["Yes", "No"],
-        "values": ["Yes", "No"],
-        "openmrs_choice_ids": {
-          "Yes": "Yes",
-          "No": "No"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Please select whether you agree with the screening"
-        },
-        "relevance": {
-          "step2:diagnosed_diabetes": {
-            "type": "string",
-            "ex": "equalTo(., \"No\")"
-          }
-        }
-      },
-      {
         "key": "screened_diabetes_12m",
         "type": "spinner",
         "hint": "Have you been screened for diabetes in the last 12 months?",
@@ -238,7 +214,7 @@
           "err": "Please select whether you agree with the screening"
         },
         "relevance": {
-          "step2:medicines_diabetes": {
+          "step2:diagnosed_diabetes": {
             "type": "string",
             "ex": "equalTo(., \"No\")"
           }
@@ -269,30 +245,6 @@
         }
       },
       {
-        "key": "medicines_hypertension",
-        "type": "spinner",
-        "hint": "Are you taking medicines for hypertension?",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "medicines_hypertension",
-        "keys": ["Yes", "No"],
-        "values": ["Yes", "No"],
-        "openmrs_choice_ids": {
-          "Yes": "Yes",
-          "No": "No"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Please select whether you agree with the screening"
-        },
-        "relevance": {
-          "step2:diagnosed_hypertension": {
-            "type": "string",
-            "ex": "equalTo(., \"No\")"
-          }
-        }
-      },
-      {
         "key": "screened_hypertension_last12m",
         "type": "spinner",
         "hint": "Have you been screened for hypertension in the last 12 months?",
@@ -310,7 +262,7 @@
           "err": "Please select whether you agree with the screening"
         },
         "relevance": {
-          "step2:medicines_hypertension": {
+          "step2:diagnosed_hypertension": {
             "type": "string",
             "ex": "equalTo(., \"No\")"
           }
@@ -570,7 +522,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "",
         "type": "toaster_notes",
-        "text": "According to the information you have provided, you are already receiving care or have been recently screened for diabetes and hypertension. Therefore, you are not eligible for another screening today. Please continue with your routine clinic visits and follow your healthcare provider’s advice. Please ensure you take your medicines as prescribed and maintain a healthy lifestyle, such as staying physically active and eating a balanced diet.",
+        "text": "According to the information you have provided, you have already been diagnosed, recently screened, or enrolled in routine care for diabetes or hypertension. Therefore, you are not eligible for another screening today. Please continue with regular check-ups and follow your healthcare provider’s advice.",
         "text_color": "#000000",
         "toaster_type": "info",
         "calculation": {
@@ -580,23 +532,6 @@
             }
           }
         },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "diabetes_hypertension_screening_relevance.yml"
-            }
-          }
-        }
-      },
-      {
-        "key": "prescreening_client_has_condition_toaster_not_using_meds",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "",
-        "type": "toaster_notes",
-        "text": "You mentioned that you are not currently taking medicines for diabetes or hypertension. It is important to follow up at your nearest health facility for medical advice and possible treatment. You are not eligible for a new screening today, but you should continue with regular check-ups as advised by your healthcare provider",
-        "text_color": "#000000",
-        "toaster_type": "info",
         "relevance": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-chw/src/nacp/assets/rule/diabetes_hypertension_screening_relevance.yml
+++ b/opensrp-chw/src/nacp/assets/rule/diabetes_hypertension_screening_relevance.yml
@@ -11,10 +11,8 @@ description: Family history diabetes relevance based on the pre-screening questi
 priority: 1
 condition: "(step1_agree_with_screening_procedure == 'Yes' || step1_agree_with_screening_procedure == 'Ndio') &&
             (step2_diagnosed_diabetes == 'No' || step2_diagnosed_diabetes == '') && 
-            (step2_medicines_diabetes == 'No' || step2_medicines_diabetes == '') && 
             (step2_screened_diabetes_12m == 'No' || step2_screened_diabetes_12m == '') &&
             (step2_diagnosed_hypertension == 'No' || step2_diagnosed_hypertension == '') && 
-            (step2_medicines_hypertension == 'No' || step2_medicines_hypertension == '') && 
             (step2_screened_hypertension_last12m == 'No' || step2_screened_hypertension_last12m == '') &&
             (step2_routine_clinic_visits == 'No' || step2_routine_clinic_visits == '')"
 actions:
@@ -25,10 +23,8 @@ description: WC relevance based on the pre-screening questions
 priority: 1
 condition: "(step1_agree_with_screening_procedure == 'Yes' || step1_agree_with_screening_procedure == '') &&
             (step2_diagnosed_diabetes == 'No' || step2_diagnosed_diabetes == '') && 
-            (step2_medicines_diabetes == 'No'  || step2_medicines_diabetes == '') && 
             (step2_screened_diabetes_12m == 'No' || step2_screened_diabetes_12m == '') && 
             (step2_diagnosed_hypertension == 'No' || step2_diagnosed_hypertension == '') &&
-            (step2_medicines_hypertension == 'No'  || step2_medicines_hypertension == '')&& 
             (step2_screened_hypertension_last12m == 'No' || step2_screened_hypertension_last12m == '') &&
             (step2_routine_clinic_visits == 'No' || step2_routine_clinic_visits == '')"
 actions:
@@ -39,10 +35,8 @@ description: SBP relevance based on the pre-screening questions
 priority: 1
 condition: "(step1_agree_with_screening_procedure == 'Yes' || step1_agree_with_screening_procedure == '') &&
             (step2_diagnosed_diabetes == 'No' || step2_diagnosed_diabetes == '') && 
-            (step2_medicines_diabetes == 'No' || step2_medicines_diabetes == '') && 
             (step2_screened_diabetes_12m == 'No' || step2_screened_diabetes_12m == '') && 
             (step2_diagnosed_hypertension == 'No' || step2_diagnosed_hypertension == '') &&
-            (step2_medicines_hypertension == 'No' || step2_medicines_hypertension == '') && 
             (step2_screened_hypertension_last12m == 'No' || step2_screened_hypertension_last12m == '') &&
             (step2_routine_clinic_visits == 'No' || step2_routine_clinic_visits == '')"
 actions:
@@ -53,10 +47,8 @@ description: DBP relevance based on the pre-screening questions
 priority: 1
 condition: "(step1_agree_with_screening_procedure == 'Yes' || step1_agree_with_screening_procedure == '') &&
             (step2_diagnosed_diabetes == 'No' || step2_diagnosed_diabetes == '') && 
-            (step2_medicines_diabetes == 'No' || step2_medicines_diabetes == '') && 
             (step2_screened_diabetes_12m == 'No' || step2_screened_diabetes_12m == '') && 
             (step2_diagnosed_hypertension == 'No' || step2_diagnosed_hypertension == '') &&
-            (step2_medicines_hypertension == 'No' || step2_medicines_hypertension == '') && 
             (step2_screened_hypertension_last12m == 'No' || step2_screened_hypertension_last12m == '') &&
             (step2_routine_clinic_visits == 'No' || step2_routine_clinic_visits == '')"
 actions:
@@ -139,28 +131,21 @@ condition: "(step3_systolic_bp != '' && step3_systolic_bp < 140 &&
             step3_diastolic_bp != '' && step3_diastolic_bp < 90 && 
             step4_diabetes_risk_score_output < 0.09175944) || 
             (step1_agree_with_screening_procedure == 'No' || step1_agree_with_screening_procedure == 'Hapana') ||
-            (step2_diagnosed_diabetes == 'Yes' || step2_medicines_diabetes == 'Yes' || 
-            step2_screened_diabetes_12m == 'Yes' || step2_diagnosed_hypertension == 'Yes' || step2_medicines_hypertension == 'Yes' || 
-            step2_screened_hypertension_last12m == 'Yes' || step2_routine_clinic_visits == 'Yes')"
+            (step2_diagnosed_diabetes == 'Yes' || step2_diagnosed_diabetes == 'Ndio' ||
+            step2_screened_diabetes_12m == 'Yes' || step2_screened_diabetes_12m == 'Ndio' ||
+            step2_diagnosed_hypertension == 'Yes' || step2_diagnosed_hypertension == 'Ndio' ||
+            step2_screened_hypertension_last12m == 'Yes' || step2_screened_hypertension_last12m == 'Ndio' ||
+            step2_routine_clinic_visits == 'Yes' || step2_routine_clinic_visits == 'Ndio')"
 actions:
   - "isRelevant = true"
 ---
 name: step4_prescreening_client_has_condition_toaster
 description: Prescreening client has condition toaster
 priority: 1
-condition: "step2_medicines_diabetes == 'Yes' || step2_medicines_diabetes == 'Ndio' ||
-            step2_medicines_hypertension == 'Yes' || step2_medicines_hypertension == 'Ndio'"
-actions:
-  - "isRelevant = true"
----
-name: step4_prescreening_client_has_condition_toaster_not_using_meds
-description: Prescreening client has condition toaster but not using meds
-priority: 1
 condition: "(step2_diagnosed_diabetes == 'Yes' || step2_diagnosed_diabetes == 'Ndio' ||
             step2_screened_diabetes_12m == 'Yes' || step2_screened_diabetes_12m == 'Ndio' ||
+            step2_diagnosed_hypertension == 'Yes' || step2_diagnosed_hypertension == 'Ndio' ||
             step2_screened_hypertension_last12m == 'Yes' || step2_screened_hypertension_last12m == 'Ndio' ||
-            step2_routine_clinic_visits == 'Yes' || step2_routine_clinic_visits == 'Ndio' || step2_diagnosed_hypertension == 'Yes') &&
-            (step2_medicines_diabetes != 'Yes' && step2_medicines_diabetes != 'Ndio' &&
-            step2_medicines_hypertension != 'Yes' && step2_medicines_hypertension != 'Ndio')"
+            step2_routine_clinic_visits == 'Yes' || step2_routine_clinic_visits == 'Ndio')"
 actions:
   - "isRelevant = true"

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/NcdInitialScreeningConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/NcdInitialScreeningConfigTest.java
@@ -1,0 +1,86 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class NcdInitialScreeningConfigTest {
+
+    private static final String ENGLISH_FORM =
+            "src/nacp/assets/json.form/diabetes_hypertension_screening_form.json";
+    private static final String SWAHILI_FORM =
+            "src/nacp/assets/json.form-sw/diabetes_hypertension_screening_form.json";
+    private static final String RELEVANCE_RULES =
+            "src/nacp/assets/rule/diabetes_hypertension_screening_relevance.yml";
+
+    @Test
+    public void screeningFormsShouldExcludeCurrentMedicationQuestionsAndKeepFlowConnected() throws Exception {
+        assertFormUpdated(ENGLISH_FORM);
+        assertFormUpdated(SWAHILI_FORM);
+    }
+
+    @Test
+    public void screeningRulesShouldNotDependOnRemovedMedicationAnswers() throws Exception {
+        String rules = readText(RELEVANCE_RULES);
+
+        Assert.assertFalse(rules.contains("step2_medicines_diabetes"));
+        Assert.assertFalse(rules.contains("step2_medicines_hypertension"));
+        Assert.assertFalse(rules.contains("prescreening_client_has_condition_toaster_not_using_meds"));
+    }
+
+    private static void assertFormUpdated(String path) throws Exception {
+        JSONObject form = new JSONObject(readText(path));
+        JSONArray fields = form.getJSONObject("step2").getJSONArray("fields");
+
+        Assert.assertNull(findField(fields, "medicines_diabetes"));
+        Assert.assertNull(findField(fields, "medicines_hypertension"));
+        assertRelevantAfter(fields, "screened_diabetes_12m", "diagnosed_diabetes");
+        assertRelevantAfter(fields, "screened_hypertension_last12m", "diagnosed_hypertension");
+
+        JSONArray resultFields = form.getJSONObject("step4").getJSONArray("fields");
+        Assert.assertNotNull(findField(resultFields, "prescreening_client_has_condition_toaster"));
+        Assert.assertNull(findField(resultFields,
+                "prescreening_client_has_condition_toaster_not_using_meds"));
+    }
+
+    private static void assertRelevantAfter(JSONArray fields, String fieldKey, String dependencyKey)
+            throws Exception {
+        JSONObject field = findField(fields, fieldKey);
+        Assert.assertNotNull(field);
+        Assert.assertTrue(field.getJSONObject("relevance").has("step2:" + dependencyKey));
+    }
+
+    private static JSONObject findField(JSONArray fields, String key) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (key.equals(field.optString("key"))) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdAutoConfirmationHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdAutoConfirmationHelperTest.java
@@ -1,0 +1,50 @@
+package org.smartregister.chw.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.domain.Event;
+import org.smartregister.util.JsonFormUtils;
+
+public class NcdAutoConfirmationHelperTest {
+
+    @Test
+    public void diagnosedConditionsShouldTriggerAutoConfirmation() {
+        Event event = eventWithAnswers("diagnosed_diabetes", "Yes",
+                "diagnosed_hypertension", "Ndio");
+
+        Assert.assertTrue(NcdAutoConfirmationHelper.isDiabetesPositive(event));
+        Assert.assertTrue(NcdAutoConfirmationHelper.isHypertensionPositive(event));
+    }
+
+    @Test
+    public void legacyMedicationAnswersShouldStillTriggerAutoConfirmation() {
+        Event event = eventWithAnswers("medicines_diabetes", "Yes",
+                "medicines_hypertension", "Yes");
+
+        Assert.assertTrue(NcdAutoConfirmationHelper.isDiabetesPositive(event));
+        Assert.assertTrue(NcdAutoConfirmationHelper.isHypertensionPositive(event));
+    }
+
+    @Test
+    public void negativeDiagnosisShouldNotTriggerAutoConfirmation() {
+        Event event = eventWithAnswers("diagnosed_diabetes", "No",
+                "diagnosed_hypertension", "Hapana");
+
+        Assert.assertFalse(NcdAutoConfirmationHelper.isDiabetesPositive(event));
+        Assert.assertFalse(NcdAutoConfirmationHelper.isHypertensionPositive(event));
+    }
+
+    private static Event eventWithAnswers(String firstField, String firstValue,
+                                          String secondField, String secondValue) {
+        String json = "{\"obs\":["
+                + observation(firstField, firstValue) + ","
+                + observation(secondField, secondValue) + "]}";
+        return JsonFormUtils.gson.fromJson(json, Event.class);
+    }
+
+    private static String observation(String field, String value) {
+        return "{\"formSubmissionField\":\"" + field
+                + "\",\"humanReadableValues\":[\"" + value
+                + "\"],\"values\":[\"" + value + "\"]}";
+    }
+}


### PR DESCRIPTION
Closes #957 
## Summary

Removes questions about current diabetes and hypertension medication use from the initial NCD screening assessment.

## Changes

- Removed medication-use questions from English and Swahili forms.
- Reconnected the remaining screening question flow.
- Updated eligibility, save, and messaging rules.
- Updated auto-confirmation to use reported diagnoses.
- Retained support for legacy medication-based events.
- Added regression tests for forms, rules, and auto-confirmation.

## Testing

- Focused NACP unit tests passed.
- English and Swahili JSON forms validated successfully.