### PR TITLE
Update NCD alcohol abstinence guidance

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_lifestyle.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_lifestyle.json
@@ -193,7 +193,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "alcohol_intake_target_met",
         "type": "native_radio",
-        "label": "Je, mteja anaepuka pombe au anatumia kwa kiasi salama?",
+        "label": "Je, mteja anajiepusha kabisa na pombe?",
         "options": [
           {
             "key": "yes",
@@ -221,10 +221,10 @@
         "openmrs_entity": "",
         "openmrs_entity_id": "",
         "type": "toaster_notes",
-        "text": "<b>\"Kupunguza Pombe\"</b><br> <span>▪ <b>Lengo:</b> epuka pombe; ukiendelea kunywa, usizidi vinywaji 2 vyenye kiwango cha kawaida kwa siku kwa wanaume au kinywaji 1 kwa wanawake</span><br><span>▪ Pombe huongeza shinikizo la damu, hudhoofisha udhibiti wa kisukari, huharibu ini na moyo, na inaweza kuingiliana na dawa.</span><br><br><i><font color=\"#0061A4\"> Bonyeza ⓘ kusoma zaidi</font></i>",
+        "text": "<b>\"Kuacha Pombe Kabisa\"</b><br> <span>▪ <b>Lengo:</b> usinywe pombe yoyote</span><br><span>▪ Pombe huongeza shinikizo la damu, hudhoofisha udhibiti wa kisukari, huharibu ini na moyo, na inaweza kuingiliana na dawa.</span><br><br><i><font color=\"#0061A4\"> Bonyeza ⓘ kusoma zaidi</font></i>",
         "toaster_type": "info",
-        "toaster_info_title": "Kupunguza Matumizi ya Pombe",
-        "toaster_info_text": "Nini cha kufanya: Epuka pombe au punguza matumizi yake yawe ndani ya kiwango salama ili kulinda moyo, shinikizo la damu, na udhibiti wa sukari ya damu\n\nKwa nini: Pombe huongeza shinikizo la damu, inaweza kushusha sukari ya damu kwa kiwango cha hatari (hasa ukitumia dawa za kisukari), huharibu ini na moyo, huongeza kalori zisizo na faida, na huongeza hatari ya kiharusi na saratani. Shirika la Afya Duniani (WHO) linashauri kuwa kidogo ni bora, na hakuna kabisa ni bora zaidi.\n\nLini: Hakuna kiwango salama cha kila siku; ukinywa mara chache, usizidi vinywaji 2 kwa siku kwa wanaume au kinywaji 1 kwa wanawake, na uwe na siku kadhaa kwa wiki bila pombe\n\nWapi: Nyumbani na kwenye matukio ya kijamii. Jiandae kukataa kwa heshima ikiwa unashinikizwa kunywa.\n\nNamna: Jiwekee kikomo binafsi (au lengo la kutokunywa kabisa), chagua maji au vinywaji visivyo na pombe, usinywe ukiwa na njaa (hasa ukitumia dawa za kisukari), na omba msaada kama kuachisha kunakuwa kugumu",
+        "toaster_info_title": "Kuacha Pombe Kabisa",
+        "toaster_info_text": "Nini cha kufanya: Acha kabisa kutumia pombe ili kulinda moyo, shinikizo la damu, na udhibiti wa sukari ya damu\n\nKwa nini: Pombe huongeza shinikizo la damu, inaweza kushusha sukari ya damu kwa kiwango cha hatari (hasa ukitumia dawa za kisukari), huharibu ini na moyo, huongeza kalori zisizo na faida, na huongeza hatari ya kiharusi na saratani. Kutotumia pombe kabisa ndiyo njia salama zaidi.\n\nLini: Wakati wote; usinywe pombe yoyote\n\nWapi: Nyumbani na kwenye matukio ya kijamii. Jiandae kukataa kwa heshima ikiwa unashinikizwa kunywa.\n\nNamna: Chagua maji au vinywaji visivyo na kilevi, epuka mazingira yanayoweza kukushawishi kunywa, jiandae kukataa kwa heshima, na omba msaada ikiwa kuacha pombe ni vigumu",
         "relevance": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-chw/src/nacp/assets/json.form/ncd_followup_lifestyle.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ncd_followup_lifestyle.json
@@ -193,7 +193,7 @@
         "openmrs_entity": "concept",
         "openmrs_entity_id": "alcohol_intake_target_met",
         "type": "native_radio",
-        "label": "Is the client avoiding alcohol or drinking within safe limits?",
+        "label": "Is the client completely abstaining from alcohol?",
         "options": [
           {
             "key": "yes",
@@ -221,10 +221,10 @@
         "openmrs_entity": "",
         "openmrs_entity_id": "",
         "type": "toaster_notes",
-        "text": "<b>\"Reducing Alcohol Intake\"</b><br> <span>▪ <b>Target:</b> avoid alcohol; if drinking, no more than 2 standard drinks per day for men or 1 for women</span><br><span>▪ Alcohol raises blood pressure, worsens diabetes control, damages the liver and heart, and can interact with medicines.</span><br><br><i><font color=\"#0061A4\"> Tap ⓘ for the full counselling guide</font></i>",
+        "text": "<b>\"Complete Abstinence from Alcohol\"</b><br> <span>▪ <b>Target:</b> do not drink any alcohol</span><br><span>▪ Alcohol raises blood pressure, worsens diabetes control, damages the liver and heart, and can interact with medicines.</span><br><br><i><font color=\"#0061A4\"> Tap ⓘ for the full counselling guide</font></i>",
         "toaster_type": "info",
-        "toaster_info_title": "Reducing Alcohol Intake",
-        "toaster_info_text": "What to do: Avoid alcohol or keep intake within safe limits to protect heart, blood pressure, and blood sugar control\n\nWhy: Alcohol raises blood pressure, can cause low blood sugar (especially with diabetes medicines), damages the liver and heart, adds empty calories, and increases the risk of stroke and cancer. WHO advises that less is better, and none is best.\n\nWhen: There is no safe daily amount; if drinking occasionally, keep it to no more than 2 standard drinks per day for men or 1 for women, and have several alcohol-free days each week\n\nWhere: At home and at social events. Be aware of pressure to drink and prepare polite refusals.\n\nHow: Set a personal limit (or aim for none), choose water or unsweetened drinks, do not drink on an empty stomach (especially if on diabetes medicines), and seek help if cutting down is difficult",
+        "toaster_info_title": "Complete Abstinence from Alcohol",
+        "toaster_info_text": "What to do: Completely abstain from alcohol to protect the heart, blood pressure, and blood sugar control\n\nWhy: Alcohol raises blood pressure, can cause low blood sugar (especially with diabetes medicines), damages the liver and heart, adds empty calories, and increases the risk of stroke and cancer. Not drinking alcohol is the safest choice.\n\nWhen: At all times; do not drink any alcohol\n\nWhere: At home and at social events. Be aware of pressure to drink and prepare polite refusals.\n\nHow: Choose water or unsweetened drinks, avoid situations that may trigger drinking, prepare polite refusals, and seek help if stopping alcohol use is difficult",
         "relevance": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/NcdFollowupLifestyleConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/NcdFollowupLifestyleConfigTest.java
@@ -1,0 +1,88 @@
+package org.smartregister.chw.resources;
+
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class NcdFollowupLifestyleConfigTest {
+
+    private static final String ENGLISH_FORM_PATH =
+            "src/nacp/assets/json.form/ncd_followup_lifestyle.json";
+    private static final String SWAHILI_FORM_PATH =
+            "src/nacp/assets/json.form-sw/ncd_followup_lifestyle.json";
+
+    @Test
+    public void alcoholGuidanceShouldRecommendCompleteAbstinenceInEnglish() throws Exception {
+        JSONObject form = readForm(ENGLISH_FORM_PATH);
+        JSONObject target = findField(form, "alcohol_intake_target_met");
+        JSONObject prompt = findField(form, "alcohol_prompt");
+
+        Assert.assertEquals(
+                "Is the client completely abstaining from alcohol?",
+                target.getString(JsonFormConstants.LABEL)
+        );
+        Assert.assertTrue(prompt.getString(JsonFormConstants.TEXT).contains("do not drink any alcohol"));
+        Assert.assertEquals(
+                "Complete Abstinence from Alcohol",
+                prompt.getString("toaster_info_title")
+        );
+        Assert.assertTrue(
+                prompt.getString("toaster_info_text").contains("Completely abstain from alcohol")
+        );
+        assertDoesNotContainSafeLimitGuidance(prompt, "safe limits", "standard drinks");
+    }
+
+    @Test
+    public void alcoholGuidanceShouldRecommendCompleteAbstinenceInSwahili() throws Exception {
+        JSONObject form = readForm(SWAHILI_FORM_PATH);
+        JSONObject target = findField(form, "alcohol_intake_target_met");
+        JSONObject prompt = findField(form, "alcohol_prompt");
+
+        Assert.assertEquals(
+                "Je, mteja anajiepusha kabisa na pombe?",
+                target.getString(JsonFormConstants.LABEL)
+        );
+        Assert.assertTrue(prompt.getString(JsonFormConstants.TEXT).contains("usinywe pombe yoyote"));
+        Assert.assertEquals("Kuacha Pombe Kabisa", prompt.getString("toaster_info_title"));
+        Assert.assertTrue(
+                prompt.getString("toaster_info_text").contains("Acha kabisa kutumia pombe")
+        );
+        assertDoesNotContainSafeLimitGuidance(prompt, "kiasi salama", "vinywaji 2");
+    }
+
+    private void assertDoesNotContainSafeLimitGuidance(
+            JSONObject prompt,
+            String safeLimitPhrase,
+            String drinkingLimitPhrase
+    ) throws Exception {
+        String guidance = prompt.getString(JsonFormConstants.TEXT)
+                + " "
+                + prompt.getString("toaster_info_text");
+        Assert.assertFalse(guidance.contains(safeLimitPhrase));
+        Assert.assertFalse(guidance.contains(drinkingLimitPhrase));
+    }
+
+    private JSONObject readForm(String path) throws Exception {
+        byte[] contents = Files.readAllBytes(Paths.get(path));
+        return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private JSONObject findField(JSONObject form, String key) throws Exception {
+        JSONArray fields = form.getJSONObject("step1").getJSONArray(JsonFormConstants.FIELDS);
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.optJSONObject(i);
+            if (field != null && key.equals(field.optString(JsonFormConstants.KEY))) {
+                return field;
+            }
+        }
+        Assert.fail("Missing field " + key);
+        return null;
+    }
+}


### PR DESCRIPTION
CLoses #962 
## Summary

- Updated NCD follow-up alcohol counseling guidance to explicitly recommend complete abstinence from alcohol.
- Removed “safe limits” and drink-count guidance from English and Swahili lifestyle follow-up forms.
- Added regression tests to ensure both locales continue to recommend complete abstinence.

## Testing

- Validated both updated JSON forms.
- Ran focused NACP unit test:

```bash
./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.NcdFollowupLifestyleConfigTest
```

Result: `BUILD SUCCESSFUL`