### PR TITLE
🌐 Add Swahili translation for NCD referral form

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/ncd_referral_form.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ncd_referral_form.json
@@ -1,0 +1,331 @@
+{
+  "form": "Fomu ya rufaa ya NCD",
+  "encounter_type": "Referral Registration",
+  "entity_id": "",
+  "relational_id": "",
+  "rules_file": "rule/general_neat_referral_form_rules.yml",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "today": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "encounter",
+      "openmrs_entity_id": "encounter_date"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": "",
+    "look_up": {
+      "entity_id": "",
+      "value": ""
+    }
+  },
+  "steps": [
+    {
+      "title": "Fomu ya rufaa ya NCD",
+      "fields": [
+        {
+          "name": "problem",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Sababu ya rufaa"
+          },
+          "meta_data": {
+            "openmrs_entity_parent": "",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "163182AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          "options": [
+            {
+              "name": "high_blood_pressure",
+              "text": "Shinikizo la juu la damu (BP ≥ 140/90 mmHg)",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "high_blood_pressure",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "elevated_blood_glucose",
+              "text": "Kiwango cha juu cha sukari kwenye damu (≥ 7.0 mmol/L)",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "elevated_blood_glucose",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "chest_pain",
+              "text": "Maumivu ya kifua au kubana kifua",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "chest_pain",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "difficulty_breathing",
+              "text": "Ugumu wa kupumua / kupumua kwa shida",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "difficulty_breathing",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "severe_headache_dizziness",
+              "text": "Maumivu makali ya kichwa au kizunguzungu",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "severe_headache_dizziness",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "blurred_vision",
+              "text": "Uoni hafifu au mabadiliko ya uoni",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "blurred_vision",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "numbness_tingling",
+              "text": "Ganzi au kuwashwa mikononi / miguuni (neuropathy)",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "numbness_tingling",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "non_healing_wounds",
+              "text": "Majeraha au vidonda visivyopona",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "non_healing_wounds",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "swelling_legs_feet",
+              "text": "Kuvimba kwa miguu au nyayo (uvimbe)",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "swelling_legs_feet",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "medication_side_effects",
+              "text": "Madhara ya dawa",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "medication_side_effects",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "missed_clinic_appointment",
+              "text": "Kukosa miadi ya kliniki — anahitaji ufuatiliaji kituoni",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "missed_clinic_appointment",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "medication_refill",
+              "text": "Kuongeza dawa / kuhuisha agizo la dawa",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "medication_refill",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "Other_symptom",
+              "text": "Nyingine",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "Other_symptom",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali bainisha sababu ya rufaa",
+          "dependent_calculations": [
+            "referral_date",
+            "referral_time",
+            "referral_type",
+            "referral_status"
+          ]
+        },
+        {
+          "name": "problem_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Dalili zingine",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "openmrs_entity_parent": "163182AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          "required_status": "true:Tafadhali bainisha dalili zingine",
+          "subjects": "problem:map"
+        },
+        {
+          "name": "service_before_referral",
+          "type": "multi_choice_checkbox",
+          "properties": {
+            "text": "Huduma iliyotolewa kabla ya rufaa."
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "164378AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "openmrs_entity_parent": ""
+          },
+          "options": [
+            {
+              "name": "antihypertensive_given",
+              "text": "Dawa ya kushusha shinikizo la damu imetolewa",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "antihypertensive_given",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "blood_glucose_lowering_given",
+              "text": "Dawa ya kushusha sukari kwenye damu imetolewa",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "blood_glucose_lowering_given",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "wound_care_given",
+              "text": "Huduma ya jeraha imetolewa",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "wound_care_given",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "client_counselled",
+              "text": "Mteja amepewa ushauri nasaha",
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "client_counselled",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "Other_treatment",
+              "text": "Matibabu mengine",
+              "meta_data": {
+                "openmrs_entity": "concept",
+                "openmrs_entity_id": "5622AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                "openmrs_entity_parent": ""
+              }
+            },
+            {
+              "name": "none",
+              "text": "Hakuna",
+              "is_exclusive": true,
+              "meta_data": {
+                "openmrs_entity": "",
+                "openmrs_entity_id": "",
+                "openmrs_entity_parent": ""
+              }
+            }
+          ],
+          "required_status": "yes:Tafadhali bainisha huduma iliyotolewa kabla ya rufaa"
+        },
+        {
+          "name": "service_before_referral_other",
+          "type": "text_input_edit_text",
+          "properties": {
+            "hint": "Matibabu mengine",
+            "type": "name"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "160632AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "openmrs_entity_parent": "164378AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+          },
+          "required_status": "true:Tafadhali bainisha matibabu mengine yaliyotolewa",
+          "subjects": "service_before_referral:map"
+        },
+        {
+          "name": "chw_referral_hf",
+          "type": "spinner",
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "chw_referral_hf",
+            "openmrs_entity_parent": ""
+          },
+          "properties": {
+            "text": "Chagua kituo cha rufaa",
+            "searchable": "Chagua kituo cha rufaa"
+          },
+          "options": [],
+          "required_status": "yes:Tafadhali bainisha kituo cha rufaa"
+        },
+        {
+          "name": "referral_appointment_date",
+          "type": "datetime_picker",
+          "properties": {
+            "hint": "Tafadhali chagua tarehe ya miadi",
+            "type": "date_picker",
+            "display_format": "dd/MM/yyyy",
+            "min_date": "today"
+          },
+          "meta_data": {
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "referral_appointment_date",
+            "openmrs_entity_parent": ""
+          },
+          "required_status": "true:Tafadhali bainisha tarehe ya miadi"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
The NCD profile overflow-menu referral workflow (issue referral for diabetes/hypertension cases) displayed in **English even when the app was set to Swahili**.

Root cause: the native-form library resolves locale-specific assets first (`json.form-sw/<form>.json`) and only falls back to the default `json.form/<form>.json` when the localized copy is missing. Every other referral form has a Swahili twin in `json.form-sw/`, but `ncd_referral_form.json` did not — so it silently fell back to English.

This PR adds the missing Swahili copy.

## Changes
- Add `opensrp-chw/src/nacp/assets/json.form-sw/ncd_referral_form.json`

## Translation safety
- Structure, field `name`s, `meta_data`, all `openmrs_entity_id`s, `subjects`, `dependent_calculations`, `encounter_type`, and `rules_file` are kept **byte-identical** to the English form.
- Only user-facing strings are translated (title, field labels, option text, hints, validation messages).
- Verified against the referral library: selected options persist their `openmrs_entity_id` as the coded obs value (translated text is stored only as a human-readable label), and the rules engine keys off option `name`. Both are identical across languages, so persisted observations and referral type/status/date logic are unaffected by locale.
