### PR TITLE
Wire Mama Kinara household enrollment flow

### DIFF
--- a/opensrp-chw/src/main/assets/ec_client_fields.json
+++ b/opensrp-chw/src/main/assets/ec_client_fields.json
@@ -797,6 +797,63 @@
           }
         }
       ]
+    },
+    {
+      "name": "ec_mothermentor_household_enrolment",
+      "columns": [
+        {
+          "column_name": "base_entity_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "baseEntityId"
+          }
+        },
+        {
+          "column_name": "household_id",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "household_id"
+          }
+        },
+        {
+          "column_name": "consent",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "consent"
+          }
+        },
+        {
+          "column_name": "enrollment_date",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "enrollment_date"
+          }
+        },
+        {
+          "column_name": "event_date",
+          "type": "Event",
+          "json_mapping": {
+            "field": "eventDate"
+          }
+        },
+        {
+          "column_name": "entity_type",
+          "type": "Event",
+          "json_mapping": {
+            "field": "entityType"
+          }
+        },
+        {
+          "column_name": "last_interacted_with",
+          "type": "Event",
+          "json_mapping": {
+            "field": "version"
+          }
+        }
+      ]
     }
   ]
 }

--- a/opensrp-chw/src/main/assets/json.form-sw/mama_kinara_household_enrolment.json
+++ b/opensrp-chw/src/main/assets/json.form-sw/mama_kinara_household_enrolment.json
@@ -1,0 +1,107 @@
+{
+  "count": "1",
+  "encounter_type": "mama_kinara_household_enrolment",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "global": {},
+  "step1": {
+    "title": "Usajili kwenye huduma za Mama Kinara",
+    "fields": [
+      {
+        "key": "household_id",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "household_id",
+        "type": "hidden"
+      },
+      {
+        "key": "enrollment_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "enrollment_date",
+        "type": "hidden"
+      },
+      {
+        "key": "consent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "consent",
+        "type": "native_radio",
+        "label": "Je, kaya inakubali kuandikishwa kwenye huduma za Mama Kinara?",
+        "label_text_size": "18px",
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali jibu swali"
+        },
+        "options": [
+          {
+            "key": "ndiyo",
+            "text": "Ndiyo",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "ndiyo"
+          },
+          {
+            "key": "hapana",
+            "text": "Hapana",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hapana"
+          }
+        ]
+      },
+      {
+        "key": "consent_advice",
+        "type": "toaster_notes",
+        "text": "Kaya haitaunganishwa kwenye huduma za Mama Kinara. Endelea kuhamasisha kaya kuhusu umuhimu wa huduma hizi.",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "consent_advice",
+        "toaster_type": "warning",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "mama_kinara_household_enrolment_relevance.yml"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/main/assets/json.form/mama_kinara_household_enrolment.json
+++ b/opensrp-chw/src/main/assets/json.form/mama_kinara_household_enrolment.json
@@ -1,0 +1,107 @@
+{
+  "count": "1",
+  "encounter_type": "mama_kinara_household_enrolment",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "global": {},
+  "step1": {
+    "title": "Enrolment in Mama Kinara services",
+    "fields": [
+      {
+        "key": "household_id",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "household_id",
+        "type": "hidden"
+      },
+      {
+        "key": "enrollment_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "enrollment_date",
+        "type": "hidden"
+      },
+      {
+        "key": "consent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "consent",
+        "type": "native_radio",
+        "label": "Does the household agree to enrol in Mama Kinara services?",
+        "label_text_size": "18px",
+        "v_required": {
+          "value": "true",
+          "err": "Please answer the question"
+        },
+        "options": [
+          {
+            "key": "ndiyo",
+            "text": "Yes",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "ndiyo"
+          },
+          {
+            "key": "hapana",
+            "text": "No",
+            "openmrs_entity": "concept",
+            "openmrs_entity_id": "hapana"
+          }
+        ]
+      },
+      {
+        "key": "consent_advice",
+        "type": "toaster_notes",
+        "text": "The household will not be linked to Mama Kinara services. Continue raising awareness with the household about the importance of these services.",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "consent_advice",
+        "toaster_type": "warning",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "mama_kinara_household_enrolment_relevance.yml"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/main/assets/rule/mama_kinara_household_enrolment_relevance.yml
+++ b/opensrp-chw/src/main/assets/rule/mama_kinara_household_enrolment_relevance.yml
@@ -1,0 +1,7 @@
+---
+name: step1_consent_advice
+description: show no-consent advisory
+priority: 1
+condition: "step1_consent.contains('hapana')"
+actions:
+  - "isRelevant = true"

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/FamilyProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/FamilyProfileActivity.java
@@ -4,11 +4,14 @@ import static org.smartregister.chw.core.utils.Utils.passToolbarTitle;
 
 import android.app.Activity;
 import android.content.Context;
+import android.database.Cursor;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 import androidx.viewpager.widget.ViewPager;
@@ -46,6 +49,9 @@ import org.smartregister.view.fragment.BaseRegisterFragment;
 
 import java.util.HashMap;
 import java.util.Objects;
+
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import timber.log.Timber;
 
 public class FamilyProfileActivity extends CoreFamilyProfileActivity {
     private BaseFamilyProfileDueFragment profileDueFragment;
@@ -201,6 +207,15 @@ public class FamilyProfileActivity extends CoreFamilyProfileActivity {
     }
 
     @Override
+    protected void startMotherMentorHouseholdEnrollment(String baseEntityId) {
+        if (isHouseholdEnrolledForMotherMentor(baseEntityId)) {
+            Toast.makeText(this, R.string.mama_kinara_household_already_enrolled, Toast.LENGTH_SHORT).show();
+            return;
+        }
+        MotherMentorRegisterActivity.startHouseholdEnrollment(FamilyProfileActivity.this, baseEntityId);
+    }
+
+    @Override
     protected HashMap<String, String> getAncFamilyHeadNameAndPhone(String baseEntityId) {
         return getFamilyProfilePresenter().getAncFamilyHeadNameAndPhone(baseEntityId);
     }
@@ -275,6 +290,32 @@ public class FamilyProfileActivity extends CoreFamilyProfileActivity {
         if (ChwApplication.getApplicationFlavor().hasHps()) {
             menu.findItem(R.id.action_hps_enrollment).setVisible(!HpsDao.isHouseholdRegisteredForHps(familyBaseEntityId));
         }
+        MenuItem motherMentorHouseholdEnrollment = menu.findItem(R.id.action_mother_mentor_household_enrollment);
+        if (motherMentorHouseholdEnrollment != null) {
+            motherMentorHouseholdEnrollment.setVisible(
+                    ChwApplication.getApplicationFlavor().hasMotherMentor()
+                            && !isHouseholdEnrolledForMotherMentor(familyBaseEntityId));
+        }
         return true;
+    }
+
+    private boolean isHouseholdEnrolledForMotherMentor(String householdBaseEntityId) {
+        Cursor cursor = null;
+        try {
+            SQLiteDatabase db = ChwApplication.getInstance().getRepository().getReadableDatabase();
+            cursor = db.rawQuery(
+                    "SELECT count(base_entity_id) FROM ec_mothermentor_household_enrolment WHERE base_entity_id = ? AND is_closed = 0 AND consent = ?",
+                    new String[]{householdBaseEntityId, "ndiyo"});
+            if (cursor != null && cursor.moveToFirst()) {
+                return cursor.getInt(0) > 0;
+            }
+        } catch (Exception e) {
+            Timber.w(e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return false;
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/MotherMentorRegisterActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/MotherMentorRegisterActivity.java
@@ -37,6 +37,10 @@ import org.smartregister.family.util.Utils;
 import org.smartregister.helper.BottomNavigationHelper;
 import org.smartregister.view.fragment.BaseRegisterFragment;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
 import timber.log.Timber;
 
 public class MotherMentorRegisterActivity extends CoreMotherMentorRegisterActivity {
@@ -44,10 +48,16 @@ public class MotherMentorRegisterActivity extends CoreMotherMentorRegisterActivi
     private static final String EVENT_MOTHER_MENTOR_ENROLL_PARTNER = "Mother Mentor Enroll Partner";
     private static final String EVENT_MOTHER_MENTOR_ENROLL_CHILD_EID = "Mother Mentor Enroll Child Eid";
     private static final String EVENT_MOTHER_MENTOR_MOBILIZATION = "MotherMentor Mobilization Session";
+    private static final String EVENT_MAMA_KINARA_HOUSEHOLD_ENROLMENT = "mama_kinara_household_enrolment";
     private static final String TABLE_MOTHERMENTOR_ENROLL_IIT = "ec_mothermentor_enroll_it";
     private static final String TABLE_MOTHERMENTOR_ENROLL_PARTNER = "ec_mothermentor_enroll_partner";
     private static final String TABLE_MOTHERMENTOR_ENROLL_CHILD_EID = "ec_mothermentor_enroll_child_eid";
     private static final String TABLE_MOTHERMENTOR_MOBILIZATION = "ec_mothermentor_mobilization";
+    private static final String TABLE_MAMA_KINARA_HOUSEHOLD_ENROLMENT = "ec_mothermentor_household_enrolment";
+    private static final String FIELD_HOUSEHOLD_ID = "household_id";
+    private static final String FIELD_ENROLLMENT_DATE = "enrollment_date";
+    private static final String FIELD_CONSENT = "consent";
+    private static final String CONSENT_YES = "ndiyo";
     private static final String FIELD_SH_TAREHE = "sh_tarehe";
     private static final String FIELD_SH_AINA = "sh_aina";
     private static final String FIELD_SH_AINA_OTHER = "sh_aina_other";
@@ -74,6 +84,14 @@ public class MotherMentorRegisterActivity extends CoreMotherMentorRegisterActivi
         intent.putExtra(org.smartregister.chw.kvp.util.Constants.ACTIVITY_PAYLOAD.GENDER, gender);
         intent.putExtra(org.smartregister.chw.kvp.util.Constants.ACTIVITY_PAYLOAD.AGE, age);
         intent.putExtra(org.smartregister.chw.mothermentor.util.Constants.ACTIVITY_PAYLOAD.MOTHER_MENTOR_FORM_NAME, formName);
+        activity.startActivity(intent);
+    }
+
+    public static void startHouseholdEnrollment(Activity activity, String householdBaseEntityId) {
+        Intent intent = new Intent(activity, MotherMentorRegisterActivity.class);
+        intent.putExtra(org.smartregister.chw.mothermentor.util.Constants.ACTIVITY_PAYLOAD.BASE_ENTITY_ID, householdBaseEntityId);
+        intent.putExtra(org.smartregister.chw.mothermentor.util.Constants.ACTIVITY_PAYLOAD.FAMILY_BASE_ENTITY_ID, householdBaseEntityId);
+        intent.putExtra(org.smartregister.chw.mothermentor.util.Constants.ACTIVITY_PAYLOAD.MOTHER_MENTOR_FORM_NAME, EVENT_MAMA_KINARA_HOUSEHOLD_ENROLMENT);
         activity.startActivity(intent);
     }
 
@@ -203,6 +221,17 @@ public class MotherMentorRegisterActivity extends CoreMotherMentorRegisterActivi
             try {
                 String jsonString = data.getStringExtra(Constants.JSON_FORM_EXTRA.JSON);
                 JSONObject form = new JSONObject(jsonString);
+                if (EVENT_MAMA_KINARA_HOUSEHOLD_ENROLMENT.equals(form.optString(Constants.ENCOUNTER_TYPE))) {
+                    boolean hasConsent = saveHouseholdEnrollment(form);
+                    displayToast(getString(hasConsent
+                            ? R.string.mama_kinara_household_enrolled
+                            : R.string.mama_kinara_household_no_consent));
+                    startClientProcessing();
+                    if (!hasConsent) {
+                        finish();
+                    }
+                    return;
+                }
                 String tableName = getMotherMentorSecondaryEnrollmentTable(form.optString(Constants.ENCOUNTER_TYPE));
                 if (tableName != null) {
                     saveMotherMentorSecondaryEnrollment(form, tableName);
@@ -220,6 +249,49 @@ public class MotherMentorRegisterActivity extends CoreMotherMentorRegisterActivi
 
     private boolean isJsonFormRequest(int requestCode) {
         return requestCode == Constants.REQUEST_CODE_GET_JSON || requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON;
+    }
+
+    private boolean saveHouseholdEnrollment(JSONObject form) throws Exception {
+        String today = new SimpleDateFormat("yyyy-MM-dd", Locale.US).format(new Date());
+        JSONArray fields = org.smartregister.chw.mothermentor.util.MotherMentorJsonFormUtils.fields(form, Constants.STEP_ONE);
+        String consent = getFieldValue(fields, FIELD_CONSENT);
+        setFieldValue(fields, FIELD_HOUSEHOLD_ID, BASE_ENTITY_ID);
+        setFieldValue(fields, FIELD_ENROLLMENT_DATE, today);
+        form.put(org.smartregister.util.JsonFormUtils.ENTITY_ID, BASE_ENTITY_ID);
+
+        org.smartregister.repository.AllSharedPreferences allSharedPreferences =
+                org.smartregister.chw.mothermentor.MotherMentorLibrary.getInstance().context().allSharedPreferences();
+        Event event = org.smartregister.chw.mothermentor.util.JsonFormUtils.processJsonForm(
+                allSharedPreferences,
+                form.toString(),
+                TABLE_MAMA_KINARA_HOUSEHOLD_ENROLMENT);
+        org.smartregister.chw.mothermentor.util.MotherMentorUtil.processEvent(allSharedPreferences, event);
+        return CONSENT_YES.equals(consent);
+    }
+
+    private String getFieldValue(JSONArray fields, String key) throws JSONException {
+        JSONObject field = getField(fields, key);
+        return field == null ? "" : field.optString(org.smartregister.util.JsonFormUtils.VALUE);
+    }
+
+    private void setFieldValue(JSONArray fields, String key, String value) throws JSONException {
+        JSONObject field = getField(fields, key);
+        if (field != null) {
+            field.put(org.smartregister.util.JsonFormUtils.VALUE, value);
+        }
+    }
+
+    private JSONObject getField(JSONArray fields, String key) throws JSONException {
+        if (fields == null) {
+            return null;
+        }
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (key.equals(field.optString("key"))) {
+                return field;
+            }
+        }
+        return null;
     }
 
     private String getMotherMentorSecondaryEnrollmentTable(String encounterType) {

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -3,6 +3,9 @@
     <string name="logo">Nembo</string>
 
     <string name="title_family_detail">Taarifa za kaya</string>
+    <string name="mama_kinara_household_already_enrolled">Kaya hii tayari imeunganishwa kwenye Mama Kinara</string>
+    <string name="mama_kinara_household_enrolled">Kaya imeunganishwa kwenye huduma za Mama Kinara</string>
+    <string name="mama_kinara_household_no_consent">Kaya haijaunganishwa - haijatoa kibali</string>
     <string name="not_done">Haujafanyika</string>
     <string name="done" tools:ignore="ExtraTranslation">Hifadhi</string>
     <string name="subtask_not_done" tools:ignore="ExtraTranslation">Haujafanyika</string>

--- a/opensrp-chw/src/main/res/values/ids.xml
+++ b/opensrp-chw/src/main/res/values/ids.xml
@@ -9,4 +9,5 @@
     <item name="referral_type_form_name" type="id" />
     <item name="action_view_households" type="id" />
     <item name="action_mother_mentor_registration" type="id" />
+    <item name="action_mother_mentor_household_enrollment" type="id" />
 </resources>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
 
     <string name="title_family_detail">Family Detail</string>
     <string name="mother_mentor_registration">Mother Mentor Registration</string>
+    <string name="mama_kinara_household_already_enrolled">This household is already linked to Mama Kinara</string>
+    <string name="mama_kinara_household_enrolled">Household linked to Mama Kinara services</string>
+    <string name="mama_kinara_household_no_consent">Household not linked - consent not given</string>
     <string name="not_done">Not done</string>
     <string name="not_provided">Not provided</string>
 


### PR DESCRIPTION
## Summary
- Shows the Mama Kinara household enrollment action from family profile when Mother Mentor is enabled and the household is not enrolled
- Launches the household consent form, saves consent/household_id/enrollment_date to ec_mothermentor_household_enrolment, and handles no-consent/enrolled toasts
- Adds app-side form assets, rule file, ec_fields mapping, strings, and the menu id bridge needed until the core artifact is republished

Closes Digital-Square-Tanzania/opensrp-client-chw#947.

## Validation
- jq empty on the new form JSON and ec_client_fields.json
- git diff --check

Note: :opensrp-chw:compileNacpDebugJavaWithJavac is blocked by the current NACP dependency graph missing org.smartregister.chw.mothermentor.* classes across existing app files, before isolating this change.