### PR TITLE
Add additional referral obs for diabetes/hypertension screening

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
@@ -761,6 +761,24 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
             String dbRiskScore = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "diabetes_risk_score_output");
             formData.put("diabetes_risk_score", createFormViewData(dbRiskScore,"Calculation",metaData("concept", "diabetes_risk_score", "")));
 
+            // Screening measurements (renamed to match server concepts)
+            String familyHistoryDiabetes = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "family_history_diabetes");
+            if (familyHistoryDiabetes != null && !familyHistoryDiabetes.isEmpty()) {
+                formData.put("family_history_of_dm", createFormViewData(familyHistoryDiabetes, null, metaData("concept", "family_history_of_dm", "")));
+            }
+            String waistCircumference = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "waist_circumference");
+            if (waistCircumference != null && !waistCircumference.isEmpty()) {
+                formData.put("waist_circumference", createFormViewData(waistCircumference, null, metaData("concept", "waist_circumference", "")));
+            }
+            String systolicBp = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "systolic_bp");
+            if (systolicBp != null && !systolicBp.isEmpty()) {
+                formData.put("systolic", createFormViewData(systolicBp, null, metaData("concept", "systolic", "")));
+            }
+            String diastolicBp = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "diastolic_bp");
+            if (diastolicBp != null && !diastolicBp.isEmpty()) {
+                formData.put("diastolic", createFormViewData(diastolicBp, null, metaData("concept", "diastolic", "")));
+            }
+
             // Appointment data
             String appointmentDate = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "referral_appointment_date");
             formData.put("referral_appointment_date", createFormViewData(String.valueOf(convertDateToLong(appointmentDate)),"Calculation",metaData("concept", "referral_appointment_date", "")));

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HpsMemberProfileActivity.java
@@ -759,7 +759,7 @@ public class HpsMemberProfileActivity extends CoreHpsProfileActivity implements 
 
             // Diabetes risk score
             String dbRiskScore = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "diabetes_risk_score_output");
-            formData.put("diabetes_risk_score", createFormViewData(dbRiskScore,"Calculation",null));
+            formData.put("diabetes_risk_score", createFormViewData(dbRiskScore,"Calculation",metaData("concept", "diabetes_risk_score", "")));
 
             // Appointment data
             String appointmentDate = org.smartregister.chw.util.JsonFormUtils.getValue(new JSONObject(jsonForm), "referral_appointment_date");

--- a/opensrp-chw/src/nacp/assets/ec_client_classification.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_classification.json
@@ -905,8 +905,7 @@
             "field": "eventType",
             "field_value": "Diabetes and Hypertension Screening Confirmation",
             "creates_case": [
-              "ec_diabetes_hypertension_confirmation",
-              "ec_close_referral"
+              "ec_diabetes_hypertension_confirmation"
             ]
           },
           {

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -6080,8 +6080,7 @@
           "column_name": "visit_date",
           "type": "Event",
           "json_mapping": {
-            "field": "obs.formSubmissionField",
-            "concept": "end"
+            "field": "eventDate"
           }
         },
         {
@@ -6089,14 +6088,6 @@
           "type": "Event",
           "json_mapping": {
             "field": "version"
-          }
-        },
-        {
-          "column_name": "referral_task",
-          "type": "Event",
-          "json_mapping": {
-            "field": "obs.formSubmissionField",
-            "concept": "referral_task"
           }
         },
         {


### PR DESCRIPTION
## Summary

Builds on `add-treatment-supporter` to enrich the diabetes/hypertension screening referral obs and clean up dead linkage on the confirmation table.

## Changes

- **Add screening measurements to the referral obs** — capture the screening measurements on the diabetes/hypertension referral event so they flow through to the referral payload (`HpsMemberProfileActivity`).
- **Add concept metadata to `diabetes_risk_score` referral obs** — ensure the risk-score obs carries proper concept metadata.
- **Remove dead referral linkage from the confirmation flow** — the `Diabetes and Hypertension Screening Confirmation` event no longer routes into `ec_close_referral`, and the unused `referral_task` column mapping is dropped from `ec_diabetes_hypertension_confirmation`. The confirmation event is auto-generated and never populated `referral_task`, and no consumer read it from that table. Remaining columns (`diabetes_result`, `hypertension_result`, `visit_date`, `last_interacted_with`) are unchanged and still consumed by `NcdDao` / `NcdCaseManagementDao`.

## Migration / compatibility

No DB version bump or new migration needed. The confirmation table is created in `upgradeToVersion43` via `createAddedECTables`, which builds the schema from `ec_client_fields.json`:
- Fresh installs get the lean schema (no `referral_task`).
- Existing installs keep the harmless, unread column (SQLite has no safe `DROP COLUMN`, and nothing references it).

## Testing

- Verified no code reads `referral_task` from `ec_diabetes_hypertension_confirmation`.
- Confirmed `ec_client_fields.json` remains valid JSON after the edit.