### PR TITLE
Update NCD side effects follow-up form flow

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_clinical_adherence.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_clinical_adherence.json
@@ -124,6 +124,47 @@
         }
       },
       {
+        "key": "no_adherence_reason",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "no_adherence_reason",
+        "type": "spinner",
+        "hint": "Ni sababu gani ya kutotumia dawa?",
+        "values": [
+          "Alisahau",
+          "Alijisikia vizuri",
+          "Dawa Ziliisha Zahanati",
+          "Gharama ya Usafiri",
+          "Sababu Nyingine"
+        ],
+        "keys": [
+          "forgot",
+          "felt_better",
+          "stock_out",
+          "transport_cost",
+          "other"
+        ],
+        "openmrs_choice_ids": {
+          "forgot": "forgot",
+          "felt_better": "felt_better",
+          "side_effects": "side_effects",
+          "stock_out": "stock_out",
+          "transport_cost": "transport_cost",
+          "other": "other"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Tafadhali chagua sababu"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "ncd_followup_clinical_adherence_relevance.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "medication_side_effects",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -149,49 +190,6 @@
         "v_required": {
           "value": "true",
           "err": "Tafadhali jibu swali hili"
-        }
-      },
-      {
-        "key": "no_adherence_reason",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "no_adherence_reason",
-        "type": "spinner",
-        "hint": "Ni sababu gani ya kutotumia dawa?",
-        "values": [
-          "Alisahau",
-          "Alijisikia vizuri",
-          "Maudhi ya Dawa",
-          "Dawa Ziliisha Zahanati",
-          "Gharama ya Usafiri",
-          "Sababu Nyingine"
-        ],
-        "keys": [
-          "forgot",
-          "felt_better",
-          "side_effects",
-          "stock_out",
-          "transport_cost",
-          "other"
-        ],
-        "openmrs_choice_ids": {
-          "forgot": "forgot",
-          "felt_better": "felt_better",
-          "side_effects": "side_effects",
-          "stock_out": "stock_out",
-          "transport_cost": "transport_cost",
-          "other": "other"
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali chagua sababu"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "ncd_followup_clinical_adherence_relevance.yml"
-            }
-          }
         }
       },
       {

--- a/opensrp-chw/src/nacp/assets/json.form/ncd_followup_clinical_adherence.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ncd_followup_clinical_adherence.json
@@ -124,6 +124,47 @@
         }
       },
       {
+        "key": "no_adherence_reason",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "no_adherence_reason",
+        "type": "spinner",
+        "hint": "What was the reason for not using medication?",
+        "values": [
+          "Forgot",
+          "Felt Better",
+          "Facility Stock-out",
+          "Transport Cost",
+          "Other"
+        ],
+        "keys": [
+          "forgot",
+          "felt_better",
+          "stock_out",
+          "transport_cost",
+          "other"
+        ],
+        "openmrs_choice_ids": {
+          "forgot": "forgot",
+          "felt_better": "felt_better",
+          "side_effects": "side_effects",
+          "stock_out": "stock_out",
+          "transport_cost": "transport_cost",
+          "other": "other"
+        },
+        "v_required": {
+          "value": "true",
+          "err": "Please select a reason"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "ncd_followup_clinical_adherence_relevance.yml"
+            }
+          }
+        }
+      },
+      {
         "key": "medication_side_effects",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -149,49 +190,6 @@
         "v_required": {
           "value": "true",
           "err": "Please answer this question"
-        }
-      },
-      {
-        "key": "no_adherence_reason",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "no_adherence_reason",
-        "type": "spinner",
-        "hint": "What was the reason for not using medication?",
-        "values": [
-          "Forgot",
-          "Felt Better",
-          "Side Effects",
-          "Facility Stock-out",
-          "Transport Cost",
-          "Other"
-        ],
-        "keys": [
-          "forgot",
-          "felt_better",
-          "side_effects",
-          "stock_out",
-          "transport_cost",
-          "other"
-        ],
-        "openmrs_choice_ids": {
-          "forgot": "forgot",
-          "felt_better": "felt_better",
-          "side_effects": "side_effects",
-          "stock_out": "stock_out",
-          "transport_cost": "transport_cost",
-          "other": "other"
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Please select a reason"
-        },
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "ncd_followup_clinical_adherence_relevance.yml"
-            }
-          }
         }
       },
       {


### PR DESCRIPTION
**Title**
Update NCD side-effects follow-up form flow

**Description**
This PR refines the NCD Monthly Follow-Up clinical adherence form so medication side effects are captured through the standalone mandatory side-effects question, rather than as a non-adherence reason.

**Changes**
- Removed “Side Effects” from the `no_adherence_reason` options in English and Swahili forms.
- Kept `medication_side_effects` as the dedicated required side-effect inquiry.
- Positioned the side-effects question after the conditional non-adherence reason field in both form assets.

**Testing**
- `jq empty opensrp-chw/src/nacp/assets/json.form/ncd_followup_clinical_adherence.json`
- `jq empty opensrp-chw/src/nacp/assets/json.form-sw/ncd_followup_clinical_adherence.json`