### PR TITLE
Auto NCD referral: capture emergency case, treatment supporter & facility selection

### DIFF
--- a/docs/specs/ncd-auto-referral-facility-selection.md
+++ b/docs/specs/ncd-auto-referral-facility-selection.md
@@ -1,55 +1,68 @@
-# SPEC — Facility selection on auto-generated NCD referrals
+# SPEC - Facility selection on auto-generated NCD referrals
 
 **Branch:** `feat/ncd-auto-referral-emergency-supporter` (follows the emergency/supporter work)
-**Approach:** Extend the post-visit confirmation prompt (same dialog as the emergency/supporter feature)
-**Status:** Draft / not started
+**Approach:** Extend the post-visit confirmation prompt (same dialog as the emergency/supporter
+feature) **Status:** Draft / not started
 
 ---
 
 ## 1. Background
 
-The manual NCD referral (profile floating menu → `ncd_referral_form.json`) makes the CHW pick the
-**referral facility** via the `chw_referral_hf` spinner. That selection drives two things downstream:
+The manual NCD referral (profile floating menu to `ncd_referral_form.json`) makes the CHW pick the
+**referral facility** via the `chw_referral_hf` spinner. That selection drives two things
+downstream:
 
 - the **`chw_referral_hf` obs** on the Referral Registration event, and
 - the **task `groupId`** (and is also surfaced in the referral register / details views).
 
 Facility options are loaded at runtime from
-`org.smartregister.chw.referral.util.LocationUtils.INSTANCE.getFacilitiesKeyAndName()`, which returns a
-`Map<facilityLocationId, facilityName>`. In the spinner the option **key is the facility location id**
-and the text is the display name.
+`org.smartregister.chw.referral.util.LocationUtils.INSTANCE.getFacilitiesKeyAndName()`, which
+returns a `Map<facilityLocationId, facilityName>`. In the spinner the option **key is the facility
+location id** and the text is the display name.
 
-The **auto** referral path (post follow-up visit → `NcdReferralPromptDialog` → `NcdReferralTaskHelper`)
-builds the event programmatically and has **no facility picker**. It hardcodes the CHW's own locality:
+The **auto** referral path (post follow-up visit to `NcdReferralPromptDialog` to
+`NcdReferralTaskHelper`) builds the event programmatically and has **no facility picker**. It
+hardcodes the CHW's own locality:
 
-| Field | Auto path today | Should be |
-|---|---|---|
-| `chw_referral_hf` obs (`DBConstants.Key.REFERRAL_HF`) value | `sharedPreferences.fetchDefaultLocalityId(providerId)` | selected facility location id |
-| task `groupId` | `sharedPreferences.fetchUserLocalityId(...)` | selected facility location id |
-| task `location` | `fetchUserLocalityId(...)` | (decision — see §8) |
-| event `locationId` | `fetchDefaultLocalityId(...)` | (decision — see §8) |
+- `chw_referral_hf` obs (`DBConstants.Key.REFERRAL_HF`) value:
+  - Today: `sharedPreferences.fetchDefaultLocalityId(providerId)`
+  - Should be: selected facility location id
+- Task `groupId`:
+  - Today: `sharedPreferences.fetchUserLocalityId(...)`
+  - Should be: selected facility location id
+- Task `location`:
+  - Today: `fetchUserLocalityId(...)`
+  - Should stay as noted in section 8
+- Event `locationId`:
+  - Today: `fetchDefaultLocalityId(...)`
+  - Should stay as noted in section 8
 
-`DBConstants.Key.REFERRAL_HF` already resolves to the string `"chw_referral_hf"`, so the obs field code
-is correct — only its **value** is wrong (and there is no UI to choose it).
+`DBConstants.Key.REFERRAL_HF` already resolves to the string `"chw_referral_hf"`, so the obs field
+code is correct; only its **value** is wrong (and there is no UI to choose it).
 
 ---
 
 ## 2. Goal
 
-Let the CHW choose the referral facility on the post-visit prompt, and use that facility's location id
-as the `chw_referral_hf` obs value and the task `groupId`, matching the manual referral behaviour.
+Let the CHW choose the referral facility on the post-visit prompt, and use that facility's location
+id as the `chw_referral_hf` obs value and the task `groupId`, matching the manual referral
+behaviour.
 
 ---
 
 ## 3. Scope
 
 ### In scope
-- A required facility spinner on `NcdReferralPromptDialog`, populated from `getFacilitiesKeyAndName()`.
-- Carrying the selected facility (id + name) through `NcdReferralInputs` into `NcdReferralTaskHelper`.
+
+- A required facility spinner on `NcdReferralPromptDialog`, populated from
+  `getFacilitiesKeyAndName()`.
+- Carrying the selected facility (id + name) through `NcdReferralInputs` into
+  `NcdReferralTaskHelper`.
 - Using the facility id for the `chw_referral_hf` obs value and the task `groupId`.
 - Loading facilities off the main thread (DB read), alongside the existing caregiver fetch.
 
 ### Out of scope
+
 - The manual referral form path (already complete).
 - Changing how facilities are sourced / the location hierarchy.
 - A searchable/hierarchical facility picker (a flat spinner mirrors the form's spinner).
@@ -59,7 +72,9 @@ as the `chw_referral_hf` obs value and the task `groupId`, matching the manual r
 ## 4. Design
 
 ### 4.1 Dialog
+
 Add a **facility** section to `dialog_ncd_referral_prompt.xml` (above the Skip/Create buttons):
+
 - label `@string/ncd_referral_prompt_facility_label`,
 - `Spinner ncd_referral_facility` whose first entry is a non-selectable placeholder
   (`@string/ncd_referral_prompt_facility_hint`, e.g. "Choose referral facility"), followed by the
@@ -68,26 +83,30 @@ Add a **facility** section to `dialog_ncd_referral_prompt.xml` (above the Skip/C
 The dialog keeps a parallel `List<String>` of facility ids (index-aligned with the spinner) so the
 selected position resolves back to an id.
 
-Facility is **required** (the manual form marks `chw_referral_hf` required): the Create button must not
-proceed until a real facility is chosen. Implement by validating on the positive click and showing a
-toast / keeping the dialog open when nothing is selected (override the positive button's click listener
-so the dialog isn't auto-dismissed on invalid input).
+Facility is **required** (the manual form marks `chw_referral_hf` required): the Create button must
+not proceed until a real facility is chosen. Implement by validating on the positive click and
+showing a toast / keeping the dialog open when nothing is selected (override the positive button's
+click listener so the dialog isn't auto-dismissed on invalid input).
 
 ### 4.2 Data loading (off main thread)
+
 `NcdCaseManagementVisitActivity.submittedAndClose` already resolves the caregiver on
 `appExecutors.diskIO()`. Resolve the facility map there too
-(`LocationUtils.INSTANCE.getFacilitiesKeyAndName()`), then pass it into `NcdReferralPromptDialog.show(...)`
-so the spinner is built on the UI thread from in-memory data.
+(`LocationUtils.INSTANCE.getFacilitiesKeyAndName()`), then pass it into
+`NcdReferralPromptDialog.show(...)` so the spinner is built on the UI thread from in-memory data.
 
 ### 4.3 Inputs
-Extend `NcdReferralInputs` with `referralFacilityId` and `referralFacilityName` (immutable, nullable).
-Update the existing constructor or add a fuller one; the dialog populates both from the selection.
+
+Extend `NcdReferralInputs` with `referralFacilityId` and `referralFacilityName` (immutable,
+nullable). Update the existing constructor or add a fuller one; the dialog populates both from the
+selection.
 
 ### 4.4 Event + task (NcdReferralTaskHelper)
-- `buildAndPersistReferralEvent`: set the existing `REFERRAL_HF` (`chw_referral_hf`) obs **value** to
-  `inputs.referralFacilityId` when present (fallback to `locationId` to preserve current behaviour when
-  inputs/facility are null). Attach the facility name as `humanReadableValues` so register/detail views
-  can show it without a second lookup.
+
+- `buildAndPersistReferralEvent`: set the existing `REFERRAL_HF` (`chw_referral_hf`) obs **value**
+  to `inputs.referralFacilityId` when present (fallback to `locationId` to preserve current
+  behaviour when inputs/facility are null). Attach the facility name as `humanReadableValues` so
+  register/detail views can show it without a second lookup.
 - `createTask`: set `groupId` to `inputs.referralFacilityId` when present (fallback to
   `fetchUserLocalityId(...)`).
 - Keep the null-safe overload contract from the emergency/supporter work: when `inputs` is null the
@@ -97,15 +116,18 @@ Update the existing constructor or add a fuller one; the dialog populates both f
 
 ## 5. Files touched
 
-| File | Change |
-|---|---|
-| `custom_views/NcdReferralPromptDialog.java` | Facility spinner + id list, required-facility validation, pass facility into inputs |
-| `res/layout/dialog_ncd_referral_prompt.xml` | Facility label + spinner |
-| `activity/NcdCaseManagementVisitActivity.java` | Load facility map off-main-thread; pass into dialog |
-| `model/NcdReferralInputs.java` | Add `referralFacilityId` / `referralFacilityName` |
-| `util/NcdReferralTaskHelper.java` | Use facility id for `chw_referral_hf` obs value + task `groupId` |
-| `res/values/strings.xml`, `res/values-sw/strings.xml` | Facility label + hint + "select a facility" validation message |
-| `test/.../NcdReferralTaskHelperTest` | Cover HF value + groupId from facility, and null/fallback |
+- `custom_views/NcdReferralPromptDialog.java`: facility spinner and id list,
+  required-facility validation, and pass facility into inputs.
+- `res/layout/dialog_ncd_referral_prompt.xml`: facility label and spinner.
+- `activity/NcdCaseManagementVisitActivity.java`: load the facility map off the main thread and pass
+  it into the dialog.
+- `model/NcdReferralInputs.java`: add `referralFacilityId` and `referralFacilityName`.
+- `util/NcdReferralTaskHelper.java`: use the facility id for the `chw_referral_hf` obs value and
+  task `groupId`.
+- `res/values/strings.xml` and `res/values-sw/strings.xml`: facility label, hint, and validation
+  message.
+- `test/.../NcdReferralTaskHelperTest`: cover HF value and groupId from facility, plus
+  null/fallback.
 
 ---
 
@@ -113,8 +135,8 @@ Update the existing constructor or add a fuller one; the dialog populates both f
 
 1. The post-visit prompt shows a facility spinner populated from `getFacilitiesKeyAndName()`.
 2. Create is blocked until a facility is chosen (with a clear message); Skip is unaffected.
-3. On confirm, the event's `chw_referral_hf` obs value is the selected facility's location id (with the
-   facility name as humanReadableValue).
+3. On confirm, the event's `chw_referral_hf` obs value is the selected facility's location id (with
+   the facility name as humanReadableValue).
 4. The created task's `groupId` is the selected facility's location id.
 5. The facility map is read off the main thread.
 6. With `inputs` null (legacy callers), behaviour is unchanged (CHW locality fallback).
@@ -124,18 +146,19 @@ Update the existing constructor or add a fuller one; the dialog populates both f
 
 ## 7. Test plan
 
-- Unit: `NcdReferralTaskHelper` obs value + (where testable) groupId derive from `referralFacilityId`;
-  fallback to locality when null. (Task creation hits repositories/prefs, so groupId may be asserted via
-  a thin seam or left to the obs-level assertion — decide during implementation.)
+- Unit: `NcdReferralTaskHelper` obs value + (where testable) groupId derive from
+  `referralFacilityId`; fallback to locality when null. (Task creation hits repositories/prefs, so
+  groupId may be asserted via a thin seam or left to the obs-level assertion; decide during
+  implementation.)
 - Unit: `NcdReferralInputs` getters for the new fields.
 
 ---
 
 ## 8. Decisions (resolved)
 
-- **Facility is required** — Create is blocked until a facility is chosen (mirrors the form's
+- **Facility is required** - Create is blocked until a facility is chosen (mirrors the form's
   `chw_referral_hf` required_status).
-- **No default selection** — the spinner opens on a non-selectable "Choose referral facility"
+- **No default selection** - the spinner opens on a non-selectable "Choose referral facility"
   placeholder, forcing an explicit choice.
 - **Only `chw_referral_hf` obs + task `groupId`** take the selected facility id. `event.locationId`
   and `task.location` stay as the CHW's locality (current behaviour).

--- a/docs/specs/ncd-auto-referral-facility-selection.md
+++ b/docs/specs/ncd-auto-referral-facility-selection.md
@@ -1,28 +1,33 @@
+<!-- markdownlint-disable MD043 -->
+
 # SPEC - Facility selection on auto-generated NCD referrals
 
-**Branch:** `feat/ncd-auto-referral-emergency-supporter` (follows the emergency/supporter work)
-**Approach:** Extend the post-visit confirmation prompt (same dialog as the emergency/supporter
-feature) **Status:** Draft / not started
+**Branch:** `feat/ncd-auto-referral-emergency-supporter` (follows the
+emergency/supporter work) **Approach:** Extend the post-visit confirmation
+prompt (same dialog as the emergency/supporter feature) **Status:** Draft / not
+started
 
 ---
 
 ## 1. Background
 
-The manual NCD referral (profile floating menu to `ncd_referral_form.json`) makes the CHW pick the
-**referral facility** via the `chw_referral_hf` spinner. That selection drives two things
-downstream:
+The manual NCD referral (profile floating menu to `ncd_referral_form.json`)
+makes the CHW pick the **referral facility** via the `chw_referral_hf` spinner.
+That selection drives two things downstream:
 
 - the **`chw_referral_hf` obs** on the Referral Registration event, and
-- the **task `groupId`** (and is also surfaced in the referral register / details views).
+- the **task `groupId`** (and is also surfaced in the referral register /
+  details views).
 
 Facility options are loaded at runtime from
-`org.smartregister.chw.referral.util.LocationUtils.INSTANCE.getFacilitiesKeyAndName()`, which
-returns a `Map<facilityLocationId, facilityName>`. In the spinner the option **key is the facility
-location id** and the text is the display name.
+`LocationUtils.INSTANCE.getFacilitiesKeyAndName()` in
+`org.smartregister.chw.referral.util`. It returns a
+`Map<facilityLocationId, facilityName>`. In the spinner the option **key is the
+facility location id** and the text is the display name.
 
 The **auto** referral path (post follow-up visit to `NcdReferralPromptDialog` to
-`NcdReferralTaskHelper`) builds the event programmatically and has **no facility picker**. It
-hardcodes the CHW's own locality:
+`NcdReferralTaskHelper`) builds the event programmatically and has **no facility
+picker**. It hardcodes the CHW's own locality:
 
 - `chw_referral_hf` obs (`DBConstants.Key.REFERRAL_HF`) value:
   - Today: `sharedPreferences.fetchDefaultLocalityId(providerId)`
@@ -37,16 +42,17 @@ hardcodes the CHW's own locality:
   - Today: `fetchDefaultLocalityId(...)`
   - Should stay as noted in section 8
 
-`DBConstants.Key.REFERRAL_HF` already resolves to the string `"chw_referral_hf"`, so the obs field
-code is correct; only its **value** is wrong (and there is no UI to choose it).
+`DBConstants.Key.REFERRAL_HF` already resolves to the string
+`"chw_referral_hf"`, so the obs field code is correct; only its **value** is
+wrong (and there is no UI to choose it).
 
 ---
 
 ## 2. Goal
 
-Let the CHW choose the referral facility on the post-visit prompt, and use that facility's location
-id as the `chw_referral_hf` obs value and the task `groupId`, matching the manual referral
-behaviour.
+Let the CHW choose the referral facility on the post-visit prompt, and use that
+facility's location id as the `chw_referral_hf` obs value and the task
+`groupId`, matching the manual referral behaviour.
 
 ---
 
@@ -58,14 +64,17 @@ behaviour.
   `getFacilitiesKeyAndName()`.
 - Carrying the selected facility (id + name) through `NcdReferralInputs` into
   `NcdReferralTaskHelper`.
-- Using the facility id for the `chw_referral_hf` obs value and the task `groupId`.
-- Loading facilities off the main thread (DB read), alongside the existing caregiver fetch.
+- Using the facility id for the `chw_referral_hf` obs value and the task
+  `groupId`.
+- Loading facilities off the main thread (DB read), alongside the existing
+  caregiver fetch.
 
 ### Out of scope
 
 - The manual referral form path (already complete).
 - Changing how facilities are sourced / the location hierarchy.
-- A searchable/hierarchical facility picker (a flat spinner mirrors the form's spinner).
+- A searchable/hierarchical facility picker (a flat spinner mirrors the form's
+  spinner).
 
 ---
 
@@ -73,44 +82,48 @@ behaviour.
 
 ### 4.1 Dialog
 
-Add a **facility** section to `dialog_ncd_referral_prompt.xml` (above the Skip/Create buttons):
+Add a **facility** section to `dialog_ncd_referral_prompt.xml` (above the
+Skip/Create buttons):
 
 - label `@string/ncd_referral_prompt_facility_label`,
-- `Spinner ncd_referral_facility` whose first entry is a non-selectable placeholder
-  (`@string/ncd_referral_prompt_facility_hint`, e.g. "Choose referral facility"), followed by the
-  facility names.
+- `Spinner ncd_referral_facility` whose first entry is a non-selectable
+  placeholder (`@string/ncd_referral_prompt_facility_hint`, e.g. "Choose
+  referral facility"), followed by the facility names.
 
-The dialog keeps a parallel `List<String>` of facility ids (index-aligned with the spinner) so the
-selected position resolves back to an id.
+The dialog keeps a parallel `List<String>` of facility ids (index-aligned with
+the spinner) so the selected position resolves back to an id.
 
-Facility is **required** (the manual form marks `chw_referral_hf` required): the Create button must
-not proceed until a real facility is chosen. Implement by validating on the positive click and
-showing a toast / keeping the dialog open when nothing is selected (override the positive button's
-click listener so the dialog isn't auto-dismissed on invalid input).
+Facility is **required** (the manual form marks `chw_referral_hf` required): the
+Create button must not proceed until a real facility is chosen. Implement by
+validating on the positive click and showing a toast / keeping the dialog open
+when nothing is selected (override the positive button's click listener so the
+dialog isn't auto-dismissed on invalid input).
 
 ### 4.2 Data loading (off main thread)
 
-`NcdCaseManagementVisitActivity.submittedAndClose` already resolves the caregiver on
-`appExecutors.diskIO()`. Resolve the facility map there too
+`NcdCaseManagementVisitActivity.submittedAndClose` already resolves the
+caregiver on `appExecutors.diskIO()`. Resolve the facility map there too
 (`LocationUtils.INSTANCE.getFacilitiesKeyAndName()`), then pass it into
-`NcdReferralPromptDialog.show(...)` so the spinner is built on the UI thread from in-memory data.
+`NcdReferralPromptDialog.show(...)` so the spinner is built on the UI thread
+from in-memory data.
 
 ### 4.3 Inputs
 
-Extend `NcdReferralInputs` with `referralFacilityId` and `referralFacilityName` (immutable,
-nullable). Update the existing constructor or add a fuller one; the dialog populates both from the
-selection.
+Extend `NcdReferralInputs` with `referralFacilityId` and `referralFacilityName`
+(immutable, nullable). Update the existing constructor or add a fuller one; the
+dialog populates both from the selection.
 
 ### 4.4 Event + task (NcdReferralTaskHelper)
 
-- `buildAndPersistReferralEvent`: set the existing `REFERRAL_HF` (`chw_referral_hf`) obs **value**
-  to `inputs.referralFacilityId` when present (fallback to `locationId` to preserve current
-  behaviour when inputs/facility are null). Attach the facility name as `humanReadableValues` so
+- `buildAndPersistReferralEvent`: set the existing `REFERRAL_HF`
+  (`chw_referral_hf`) obs **value** to `inputs.referralFacilityId` when present
+  (fallback to `locationId` to preserve current behaviour when inputs/facility
+  are null). Attach the facility name as `humanReadableValues` so
   register/detail views can show it without a second lookup.
-- `createTask`: set `groupId` to `inputs.referralFacilityId` when present (fallback to
-  `fetchUserLocalityId(...)`).
-- Keep the null-safe overload contract from the emergency/supporter work: when `inputs` is null the
-  behaviour is unchanged.
+- `createTask`: set `groupId` to `inputs.referralFacilityId` when present
+  (fallback to `fetchUserLocalityId(...)`).
+- Keep the null-safe overload contract from the emergency/supporter work: when
+  `inputs` is null the behaviour is unchanged.
 
 ---
 
@@ -119,27 +132,31 @@ selection.
 - `custom_views/NcdReferralPromptDialog.java`: facility spinner and id list,
   required-facility validation, and pass facility into inputs.
 - `res/layout/dialog_ncd_referral_prompt.xml`: facility label and spinner.
-- `activity/NcdCaseManagementVisitActivity.java`: load the facility map off the main thread and pass
-  it into the dialog.
-- `model/NcdReferralInputs.java`: add `referralFacilityId` and `referralFacilityName`.
-- `util/NcdReferralTaskHelper.java`: use the facility id for the `chw_referral_hf` obs value and
-  task `groupId`.
-- `res/values/strings.xml` and `res/values-sw/strings.xml`: facility label, hint, and validation
-  message.
-- `test/.../NcdReferralTaskHelperTest`: cover HF value and groupId from facility, plus
-  null/fallback.
+- `activity/NcdCaseManagementVisitActivity.java`: load the facility map off the
+  main thread and pass it into the dialog.
+- `model/NcdReferralInputs.java`: add `referralFacilityId` and
+  `referralFacilityName`.
+- `util/NcdReferralTaskHelper.java`: use the facility id for the
+  `chw_referral_hf` obs value and task `groupId`.
+- `res/values/strings.xml` and `res/values-sw/strings.xml`: facility label,
+  hint, and validation message.
+- `test/.../NcdReferralTaskHelperTest`: cover HF value and groupId from
+  facility, plus null/fallback.
 
 ---
 
 ## 6. Acceptance criteria
 
-1. The post-visit prompt shows a facility spinner populated from `getFacilitiesKeyAndName()`.
-2. Create is blocked until a facility is chosen (with a clear message); Skip is unaffected.
-3. On confirm, the event's `chw_referral_hf` obs value is the selected facility's location id (with
-   the facility name as humanReadableValue).
+1. The post-visit prompt shows a facility spinner populated from
+   `getFacilitiesKeyAndName()`.
+2. Create is blocked until a facility is chosen (with a clear message); Skip is
+   unaffected.
+3. On confirm, the event's `chw_referral_hf` obs value is the selected
+   facility's location id (with the facility name as humanReadableValue).
 4. The created task's `groupId` is the selected facility's location id.
 5. The facility map is read off the main thread.
-6. With `inputs` null (legacy callers), behaviour is unchanged (CHW locality fallback).
+6. With `inputs` null (legacy callers), behaviour is unchanged (CHW locality
+   fallback).
 7. New strings exist in `values` and `values-sw`.
 
 ---
@@ -147,18 +164,19 @@ selection.
 ## 7. Test plan
 
 - Unit: `NcdReferralTaskHelper` obs value + (where testable) groupId derive from
-  `referralFacilityId`; fallback to locality when null. (Task creation hits repositories/prefs, so
-  groupId may be asserted via a thin seam or left to the obs-level assertion; decide during
-  implementation.)
+  `referralFacilityId`; fallback to locality when null. (Task creation hits
+  repositories/prefs, so groupId may be asserted via a thin seam or left to the
+  obs-level assertion; decide during implementation.)
 - Unit: `NcdReferralInputs` getters for the new fields.
 
 ---
 
 ## 8. Decisions (resolved)
 
-- **Facility is required** - Create is blocked until a facility is chosen (mirrors the form's
-  `chw_referral_hf` required_status).
-- **No default selection** - the spinner opens on a non-selectable "Choose referral facility"
-  placeholder, forcing an explicit choice.
-- **Only `chw_referral_hf` obs + task `groupId`** take the selected facility id. `event.locationId`
-  and `task.location` stay as the CHW's locality (current behaviour).
+- **Facility is required** - Create is blocked until a facility is chosen
+  (mirrors the form's `chw_referral_hf` required_status).
+- **No default selection** - the spinner opens on a non-selectable "Choose
+  referral facility" placeholder, forcing an explicit choice.
+- **Only `chw_referral_hf` obs + task `groupId`** take the selected facility id.
+  `event.locationId` and `task.location` stay as the CHW's locality (current
+  behaviour).

--- a/docs/specs/ncd-auto-referral-facility-selection.md
+++ b/docs/specs/ncd-auto-referral-facility-selection.md
@@ -1,0 +1,141 @@
+# SPEC — Facility selection on auto-generated NCD referrals
+
+**Branch:** `feat/ncd-auto-referral-emergency-supporter` (follows the emergency/supporter work)
+**Approach:** Extend the post-visit confirmation prompt (same dialog as the emergency/supporter feature)
+**Status:** Draft / not started
+
+---
+
+## 1. Background
+
+The manual NCD referral (profile floating menu → `ncd_referral_form.json`) makes the CHW pick the
+**referral facility** via the `chw_referral_hf` spinner. That selection drives two things downstream:
+
+- the **`chw_referral_hf` obs** on the Referral Registration event, and
+- the **task `groupId`** (and is also surfaced in the referral register / details views).
+
+Facility options are loaded at runtime from
+`org.smartregister.chw.referral.util.LocationUtils.INSTANCE.getFacilitiesKeyAndName()`, which returns a
+`Map<facilityLocationId, facilityName>`. In the spinner the option **key is the facility location id**
+and the text is the display name.
+
+The **auto** referral path (post follow-up visit → `NcdReferralPromptDialog` → `NcdReferralTaskHelper`)
+builds the event programmatically and has **no facility picker**. It hardcodes the CHW's own locality:
+
+| Field | Auto path today | Should be |
+|---|---|---|
+| `chw_referral_hf` obs (`DBConstants.Key.REFERRAL_HF`) value | `sharedPreferences.fetchDefaultLocalityId(providerId)` | selected facility location id |
+| task `groupId` | `sharedPreferences.fetchUserLocalityId(...)` | selected facility location id |
+| task `location` | `fetchUserLocalityId(...)` | (decision — see §8) |
+| event `locationId` | `fetchDefaultLocalityId(...)` | (decision — see §8) |
+
+`DBConstants.Key.REFERRAL_HF` already resolves to the string `"chw_referral_hf"`, so the obs field code
+is correct — only its **value** is wrong (and there is no UI to choose it).
+
+---
+
+## 2. Goal
+
+Let the CHW choose the referral facility on the post-visit prompt, and use that facility's location id
+as the `chw_referral_hf` obs value and the task `groupId`, matching the manual referral behaviour.
+
+---
+
+## 3. Scope
+
+### In scope
+- A required facility spinner on `NcdReferralPromptDialog`, populated from `getFacilitiesKeyAndName()`.
+- Carrying the selected facility (id + name) through `NcdReferralInputs` into `NcdReferralTaskHelper`.
+- Using the facility id for the `chw_referral_hf` obs value and the task `groupId`.
+- Loading facilities off the main thread (DB read), alongside the existing caregiver fetch.
+
+### Out of scope
+- The manual referral form path (already complete).
+- Changing how facilities are sourced / the location hierarchy.
+- A searchable/hierarchical facility picker (a flat spinner mirrors the form's spinner).
+
+---
+
+## 4. Design
+
+### 4.1 Dialog
+Add a **facility** section to `dialog_ncd_referral_prompt.xml` (above the Skip/Create buttons):
+- label `@string/ncd_referral_prompt_facility_label`,
+- `Spinner ncd_referral_facility` whose first entry is a non-selectable placeholder
+  (`@string/ncd_referral_prompt_facility_hint`, e.g. "Choose referral facility"), followed by the
+  facility names.
+
+The dialog keeps a parallel `List<String>` of facility ids (index-aligned with the spinner) so the
+selected position resolves back to an id.
+
+Facility is **required** (the manual form marks `chw_referral_hf` required): the Create button must not
+proceed until a real facility is chosen. Implement by validating on the positive click and showing a
+toast / keeping the dialog open when nothing is selected (override the positive button's click listener
+so the dialog isn't auto-dismissed on invalid input).
+
+### 4.2 Data loading (off main thread)
+`NcdCaseManagementVisitActivity.submittedAndClose` already resolves the caregiver on
+`appExecutors.diskIO()`. Resolve the facility map there too
+(`LocationUtils.INSTANCE.getFacilitiesKeyAndName()`), then pass it into `NcdReferralPromptDialog.show(...)`
+so the spinner is built on the UI thread from in-memory data.
+
+### 4.3 Inputs
+Extend `NcdReferralInputs` with `referralFacilityId` and `referralFacilityName` (immutable, nullable).
+Update the existing constructor or add a fuller one; the dialog populates both from the selection.
+
+### 4.4 Event + task (NcdReferralTaskHelper)
+- `buildAndPersistReferralEvent`: set the existing `REFERRAL_HF` (`chw_referral_hf`) obs **value** to
+  `inputs.referralFacilityId` when present (fallback to `locationId` to preserve current behaviour when
+  inputs/facility are null). Attach the facility name as `humanReadableValues` so register/detail views
+  can show it without a second lookup.
+- `createTask`: set `groupId` to `inputs.referralFacilityId` when present (fallback to
+  `fetchUserLocalityId(...)`).
+- Keep the null-safe overload contract from the emergency/supporter work: when `inputs` is null the
+  behaviour is unchanged.
+
+---
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `custom_views/NcdReferralPromptDialog.java` | Facility spinner + id list, required-facility validation, pass facility into inputs |
+| `res/layout/dialog_ncd_referral_prompt.xml` | Facility label + spinner |
+| `activity/NcdCaseManagementVisitActivity.java` | Load facility map off-main-thread; pass into dialog |
+| `model/NcdReferralInputs.java` | Add `referralFacilityId` / `referralFacilityName` |
+| `util/NcdReferralTaskHelper.java` | Use facility id for `chw_referral_hf` obs value + task `groupId` |
+| `res/values/strings.xml`, `res/values-sw/strings.xml` | Facility label + hint + "select a facility" validation message |
+| `test/.../NcdReferralTaskHelperTest` | Cover HF value + groupId from facility, and null/fallback |
+
+---
+
+## 6. Acceptance criteria
+
+1. The post-visit prompt shows a facility spinner populated from `getFacilitiesKeyAndName()`.
+2. Create is blocked until a facility is chosen (with a clear message); Skip is unaffected.
+3. On confirm, the event's `chw_referral_hf` obs value is the selected facility's location id (with the
+   facility name as humanReadableValue).
+4. The created task's `groupId` is the selected facility's location id.
+5. The facility map is read off the main thread.
+6. With `inputs` null (legacy callers), behaviour is unchanged (CHW locality fallback).
+7. New strings exist in `values` and `values-sw`.
+
+---
+
+## 7. Test plan
+
+- Unit: `NcdReferralTaskHelper` obs value + (where testable) groupId derive from `referralFacilityId`;
+  fallback to locality when null. (Task creation hits repositories/prefs, so groupId may be asserted via
+  a thin seam or left to the obs-level assertion — decide during implementation.)
+- Unit: `NcdReferralInputs` getters for the new fields.
+
+---
+
+## 8. Decisions (resolved)
+
+- **Facility is required** — Create is blocked until a facility is chosen (mirrors the form's
+  `chw_referral_hf` required_status).
+- **No default selection** — the spinner opens on a non-selectable "Choose referral facility"
+  placeholder, forcing an explicit choice.
+- **Only `chw_referral_hf` obs + task `groupId`** take the selected facility id. `event.locationId`
+  and `task.location` stay as the CHW's locality (current behaviour).

--- a/docs/specs/ncd-auto-referral-supporter-emergency.md
+++ b/docs/specs/ncd-auto-referral-supporter-emergency.md
@@ -1,0 +1,155 @@
+# SPEC — Capture emergency-case & treatment-supporter details on auto-generated NCD referrals
+
+**Branch:** `add-is-emergence-on-sw-ncd-ref`
+**Approach:** A — enrich the post-visit confirmation dialog (no full form, no extra Activity)
+**Status:** Draft / not started
+
+---
+
+## 1. Background
+
+NCD follow-up visits run through `NcdCaseManagementVisitActivity`. When a visit produces a
+danger sign or medicine side effect, the interactor stages a `PendingNcdReferral` and, on
+`submittedAndClose`, a confirm/skip dialog (`NcdReferralPromptDialog`) is shown. On confirm,
+`NcdReferralTaskHelper.createReferralIfNeeded(...)` **builds the Referral Registration event
+programmatically** and creates the linked task.
+
+There are two NCD referral paths today, and they are asymmetric:
+
+| | Manual (profile floating menu) | Auto (this spec) |
+|---|---|---|
+| UI | `ncd_referral_form.json` NeatForm | confirm/skip `AlertDialog` |
+| Event built by | referral-library save path (from form data) | `NcdReferralTaskHelper.buildAndPersistReferralEvent` |
+| `is_emergency_case` | ✅ in form | ❌ missing |
+| `has_treatment_supporter` / `_name` / `_phone` | ✅ in form, prefilled + editable via `TreatmentSupporterFormUtil` | ❌ missing |
+
+**Goal:** the auto path must also emit `is_emergency_case`, `has_treatment_supporter`,
+`treatment_supporter_name`, `treatment_supporter_phone` (and, for parity,
+`treatment_supporter_relationship`) on its Referral Registration event. The treatment
+supporter must be **editable for this referral only** — never writing back to the client's
+registration record. Editing is for the case where the client presents a different supporter
+at referral time.
+
+---
+
+## 2. Scope
+
+### In scope
+- A richer post-visit dialog that captures the emergency flag and an editable treatment-supporter section, prefilled from `TreatmentSupporterDao.getRegisteredCaregiver`.
+- Threading the captured values into `NcdReferralTaskHelper.createReferralIfNeeded` and emitting them as obs on the Referral Registration event.
+- English + Swahili strings for the new dialog controls.
+
+### Out of scope
+- The manual referral form path (already complete).
+- Editing/persisting the client's registered caregiver record.
+- Changing the alert-detection logic that stages `PendingNcdReferral`.
+- Letting the CHW edit the detected problem list or referral health facility (that is Approach B territory).
+
+---
+
+## 3. Obs to emit (target event shape)
+
+Added to the event inside `buildAndPersistReferralEvent`, mirroring the existing single-value
+obs shape (`fieldType = "concept"`, `parentCode = ""`):
+
+| formSubmissionField / fieldCode | Value | Persisted when |
+|---|---|---|
+| `is_emergency_case` | `"Yes"` / `"No"` | always |
+| `has_treatment_supporter` | `"Yes"` / `"No"` | always |
+| `treatment_supporter_name` | edited text | gate = `Yes` and non-blank |
+| `treatment_supporter_phone` | edited text | gate = `Yes` and non-blank |
+| `treatment_supporter_relationship` | spinner option key | gate = `Yes` and non-blank |
+
+When the gate is `No`, only `is_emergency_case` and `has_treatment_supporter` (= `No`) are
+written; the three detail obs are omitted. This matches `TreatmentSupporterFormUtil`'s
+"details only when gate is Yes" rule.
+
+---
+
+## 4. Defaults & prefill
+
+- **`is_emergency_case`** default: `Yes` when `alertLevel == ALERT_RED`, else `No`. CHW-overridable.
+- **Treatment supporter:** load `TreatmentSupporterDao.getRegisteredCaregiver(baseEntityId)` off the main thread *before* showing the dialog.
+  - If a caregiver `isPresent()`: gate defaults to `Yes`; name/phone/relationship prefilled and editable.
+  - If none on record: gate defaults to `No`; detail fields empty (shown when gate flipped to `Yes`).
+- Relationship spinner uses the same 18 options as the form's `treatment_supporter_relationship` field (Mother, Father, Brother, Sister, Grandfather, Grandmother, Friend, Uncle, Aunt, Police, Guardian, Son, Daughter, Work Colleague, Brother in Law, Sister in Law, Wife, Husband).
+
+---
+
+## 5. Design
+
+### 5.1 New dialog (`NcdReferralPromptDialog` → custom layout)
+Replace the plain `AlertDialog` message with a custom view (`dialog_ncd_referral_prompt.xml`)
+containing, top to bottom:
+1. Title (existing urgent / non-emergency string).
+2. Body + bulleted reasons (existing behavior).
+3. **Emergency case** — labeled Yes/No control (RadioGroup), seeded per §4.
+4. **Treatment supporter**:
+   - Has-supporter gate (Yes/No). Toggling controls visibility of the detail block.
+   - Name (EditText), Phone (EditText, `inputType=phone`), Relationship (Spinner).
+5. Skip / Create buttons (existing strings).
+
+The dialog collects values into a small immutable result and hands them to the confirm callback.
+
+### 5.2 Inputs object
+Introduce `NcdReferralInputs` (plain data holder): `isEmergencyCase` (bool/`"Yes"`/`"No"`),
+`hasTreatmentSupporter`, `supporterName`, `supporterPhone`, `supporterRelationship`. Prefer this
+over expanding the `createReferralIfNeeded` argument list further.
+
+### 5.3 Callback / helper signature
+`NcdReferralPromptDialog.Callbacks.onConfirm()` → `onConfirm(NcdReferralInputs inputs)`.
+`NcdCaseManagementVisitActivity` passes `inputs` to a new overload:
+```
+createReferralIfNeeded(baseEntityId, triggeringFormSubmissionId, alertLevel,
+                       description, problemKeys, reasons, NcdReferralInputs inputs)
+```
+Keep/forward the existing signature (passing `null` inputs) so other callers are unaffected.
+
+### 5.4 Event building
+In `buildAndPersistReferralEvent`, after the existing obs, append the §3 obs from `inputs`
+(guarded for null inputs → emit nothing, preserving current behavior). Add concept-key
+constants to `Constants.NcdReferral`.
+
+### 5.5 Threading
+`submittedAndClose` currently reads the pending referral and shows the dialog on the UI thread.
+Add a background fetch of the caregiver (via `appExecutors.diskIO()`), then `runOnUiThread` to
+show the dialog prefilled. The DB read must not run on the main thread.
+
+---
+
+## 6. Files touched
+
+| File | Change |
+|---|---|
+| `custom_views/NcdReferralPromptDialog.java` | Custom layout, collect emergency + supporter, new callback signature |
+| `res/layout/dialog_ncd_referral_prompt.xml` | **New** dialog layout |
+| `activity/NcdCaseManagementVisitActivity.java` | Background caregiver fetch; pass `NcdReferralInputs` to helper |
+| `util/NcdReferralTaskHelper.java` | New overload; emit the 4–5 obs; null-safe |
+| `util/Constants.java` (`NcdReferral`) | Concept-key constants |
+| `model/NcdReferralInputs.java` (or nested) | **New** data holder |
+| `res/values/strings.xml` | New labels/hints |
+| `res/values-sw/strings.xml` | Swahili translations |
+| `test/.../NcdReferralTaskHelperTest` (if present) | Cover obs emission / gate rules |
+
+---
+
+## 7. Acceptance criteria
+
+1. Confirming an auto NCD referral writes a Referral Registration event that includes
+   `is_emergency_case` and `has_treatment_supporter` obs; when the gate is Yes and details are
+   present, `treatment_supporter_name`/`_phone`/`_relationship` are included too.
+2. `is_emergency_case` defaults to Yes for red alerts, No for yellow, and the CHW can change it.
+3. Supporter fields prefill from the registered caregiver and are editable; edits appear on the
+   referral event and the client's `ec_family_member` registration record is unchanged.
+4. With the gate set to No, no supporter detail obs are emitted.
+5. Skip still writes no event or task.
+6. The caregiver DB lookup runs off the main thread.
+7. New strings are present in both `values` and `values-sw`.
+
+---
+
+## 8. Decisions (resolved)
+
+- **`is_emergency_case`** is CHW-**editable**: a Yes/No control seeded from alert level (red→Yes, yellow→No).
+- **`treatment_supporter_relationship`** is **included** on the auto path (18-option spinner) for parity with the manual form.
+- **Phone validation** is **lenient**: `inputType=phone`, any non-blank value accepted — matches the form's handling.

--- a/docs/specs/ncd-auto-referral-supporter-emergency.md
+++ b/docs/specs/ncd-auto-referral-supporter-emergency.md
@@ -1,89 +1,105 @@
-# SPEC — Capture emergency-case & treatment-supporter details on auto-generated NCD referrals
+# SPEC - Capture emergency-case & treatment-supporter details on auto-generated NCD referrals
 
-**Branch:** `add-is-emergence-on-sw-ncd-ref`
-**Approach:** A — enrich the post-visit confirmation dialog (no full form, no extra Activity)
-**Status:** Draft / not started
+**Branch:** `add-is-emergence-on-sw-ncd-ref` **Approach:** A - enrich the post-visit confirmation
+dialog (no full form, no extra Activity) **Status:** Draft / not started
 
 ---
 
 ## 1. Background
 
-NCD follow-up visits run through `NcdCaseManagementVisitActivity`. When a visit produces a
-danger sign or medicine side effect, the interactor stages a `PendingNcdReferral` and, on
+NCD follow-up visits run through `NcdCaseManagementVisitActivity`. When a visit produces a danger
+sign or medicine side effect, the interactor stages a `PendingNcdReferral` and, on
 `submittedAndClose`, a confirm/skip dialog (`NcdReferralPromptDialog`) is shown. On confirm,
 `NcdReferralTaskHelper.createReferralIfNeeded(...)` **builds the Referral Registration event
 programmatically** and creates the linked task.
 
 There are two NCD referral paths today, and they are asymmetric:
 
-| | Manual (profile floating menu) | Auto (this spec) |
-|---|---|---|
-| UI | `ncd_referral_form.json` NeatForm | confirm/skip `AlertDialog` |
-| Event built by | referral-library save path (from form data) | `NcdReferralTaskHelper.buildAndPersistReferralEvent` |
-| `is_emergency_case` | ✅ in form | ❌ missing |
-| `has_treatment_supporter` / `_name` / `_phone` | ✅ in form, prefilled + editable via `TreatmentSupporterFormUtil` | ❌ missing |
+- UI:
+  - Manual: `ncd_referral_form.json` NeatForm
+  - Auto: confirm/skip `AlertDialog`
+- Event builder:
+  - Manual: referral-library save path from form data
+  - Auto: `NcdReferralTaskHelper.buildAndPersistReferralEvent`
+- `is_emergency_case`:
+  - Manual: present in form
+  - Auto: missing
+- `has_treatment_supporter`, `_name`, and `_phone`:
+  - Manual: present in form, prefilled and editable via `TreatmentSupporterFormUtil`
+  - Auto: missing
 
 **Goal:** the auto path must also emit `is_emergency_case`, `has_treatment_supporter`,
 `treatment_supporter_name`, `treatment_supporter_phone` (and, for parity,
-`treatment_supporter_relationship`) on its Referral Registration event. The treatment
-supporter must be **editable for this referral only** — never writing back to the client's
-registration record. Editing is for the case where the client presents a different supporter
-at referral time.
+`treatment_supporter_relationship`) on its Referral Registration event. The treatment supporter must
+be **editable for this referral only**; never writing back to the client's registration record.
+Editing is for the case where the client presents a different supporter at referral time.
 
 ---
 
 ## 2. Scope
 
 ### In scope
-- A richer post-visit dialog that captures the emergency flag and an editable treatment-supporter section, prefilled from `TreatmentSupporterDao.getRegisteredCaregiver`.
-- Threading the captured values into `NcdReferralTaskHelper.createReferralIfNeeded` and emitting them as obs on the Referral Registration event.
+
+- A richer post-visit dialog that captures the emergency flag and an editable treatment-supporter
+  section, prefilled from `TreatmentSupporterDao.getRegisteredCaregiver`.
+- Threading the captured values into `NcdReferralTaskHelper.createReferralIfNeeded` and emitting
+  them as obs on the Referral Registration event.
 - English + Swahili strings for the new dialog controls.
 
 ### Out of scope
+
 - The manual referral form path (already complete).
 - Editing/persisting the client's registered caregiver record.
 - Changing the alert-detection logic that stages `PendingNcdReferral`.
-- Letting the CHW edit the detected problem list or referral health facility (that is Approach B territory).
+- Letting the CHW edit the detected problem list or referral health facility (that is Approach B
+  territory).
 
 ---
 
 ## 3. Obs to emit (target event shape)
 
-Added to the event inside `buildAndPersistReferralEvent`, mirroring the existing single-value
-obs shape (`fieldType = "concept"`, `parentCode = ""`):
+Added to the event inside `buildAndPersistReferralEvent`, mirroring the existing single-value obs
+shape (`fieldType = "concept"`, `parentCode = ""`):
 
-| formSubmissionField / fieldCode | Value | Persisted when |
-|---|---|---|
-| `is_emergency_case` | `"Yes"` / `"No"` | always |
-| `has_treatment_supporter` | `"Yes"` / `"No"` | always |
-| `treatment_supporter_name` | edited text | gate = `Yes` and non-blank |
-| `treatment_supporter_phone` | edited text | gate = `Yes` and non-blank |
+| formSubmissionField / fieldCode    | Value              | Persisted when             |
+| ---------------------------------- | ------------------ | -------------------------- |
+| `is_emergency_case`                | `"Yes"` / `"No"`   | always                     |
+| `has_treatment_supporter`          | `"Yes"` / `"No"`   | always                     |
+| `treatment_supporter_name`         | edited text        | gate = `Yes` and non-blank |
+| `treatment_supporter_phone`        | edited text        | gate = `Yes` and non-blank |
 | `treatment_supporter_relationship` | spinner option key | gate = `Yes` and non-blank |
 
-When the gate is `No`, only `is_emergency_case` and `has_treatment_supporter` (= `No`) are
-written; the three detail obs are omitted. This matches `TreatmentSupporterFormUtil`'s
-"details only when gate is Yes" rule.
+When the gate is `No`, only `is_emergency_case` and `has_treatment_supporter` (= `No`) are written;
+the three detail obs are omitted. This matches `TreatmentSupporterFormUtil`'s "details only when
+gate is Yes" rule.
 
 ---
 
 ## 4. Defaults & prefill
 
 - **`is_emergency_case`** default: `Yes` when `alertLevel == ALERT_RED`, else `No`. CHW-overridable.
-- **Treatment supporter:** load `TreatmentSupporterDao.getRegisteredCaregiver(baseEntityId)` off the main thread *before* showing the dialog.
-  - If a caregiver `isPresent()`: gate defaults to `Yes`; name/phone/relationship prefilled and editable.
-  - If none on record: gate defaults to `No`; detail fields empty (shown when gate flipped to `Yes`).
-- Relationship spinner uses the same 18 options as the form's `treatment_supporter_relationship` field (Mother, Father, Brother, Sister, Grandfather, Grandmother, Friend, Uncle, Aunt, Police, Guardian, Son, Daughter, Work Colleague, Brother in Law, Sister in Law, Wife, Husband).
+- **Treatment supporter:** load `TreatmentSupporterDao.getRegisteredCaregiver(baseEntityId)` off the
+  main thread _before_ showing the dialog.
+  - If a caregiver `isPresent()`: gate defaults to `Yes`; name/phone/relationship prefilled and
+    editable.
+  - If none on record: gate defaults to `No`; detail fields empty (shown when gate flipped to
+    `Yes`).
+- Relationship spinner uses the same 18 options as the form's `treatment_supporter_relationship`
+  field (Mother, Father, Brother, Sister, Grandfather, Grandmother, Friend, Uncle, Aunt, Police,
+  Guardian, Son, Daughter, Work Colleague, Brother in Law, Sister in Law, Wife, Husband).
 
 ---
 
 ## 5. Design
 
-### 5.1 New dialog (`NcdReferralPromptDialog` → custom layout)
+### 5.1 New dialog (`NcdReferralPromptDialog` to custom layout)
+
 Replace the plain `AlertDialog` message with a custom view (`dialog_ncd_referral_prompt.xml`)
 containing, top to bottom:
+
 1. Title (existing urgent / non-emergency string).
 2. Body + bulleted reasons (existing behavior).
-3. **Emergency case** — labeled Yes/No control (RadioGroup), seeded per §4.
+3. **Emergency case** - labeled Yes/No control (RadioGroup), seeded per section 4.
 4. **Treatment supporter**:
    - Has-supporter gate (Yes/No). Toggling controls visibility of the detail block.
    - Name (EditText), Phone (EditText, `inputType=phone`), Relationship (Spinner).
@@ -92,44 +108,50 @@ containing, top to bottom:
 The dialog collects values into a small immutable result and hands them to the confirm callback.
 
 ### 5.2 Inputs object
+
 Introduce `NcdReferralInputs` (plain data holder): `isEmergencyCase` (bool/`"Yes"`/`"No"`),
 `hasTreatmentSupporter`, `supporterName`, `supporterPhone`, `supporterRelationship`. Prefer this
 over expanding the `createReferralIfNeeded` argument list further.
 
 ### 5.3 Callback / helper signature
-`NcdReferralPromptDialog.Callbacks.onConfirm()` → `onConfirm(NcdReferralInputs inputs)`.
+
+`NcdReferralPromptDialog.Callbacks.onConfirm()` becomes `onConfirm(NcdReferralInputs inputs)`.
 `NcdCaseManagementVisitActivity` passes `inputs` to a new overload:
+
 ```
 createReferralIfNeeded(baseEntityId, triggeringFormSubmissionId, alertLevel,
                        description, problemKeys, reasons, NcdReferralInputs inputs)
 ```
+
 Keep/forward the existing signature (passing `null` inputs) so other callers are unaffected.
 
 ### 5.4 Event building
-In `buildAndPersistReferralEvent`, after the existing obs, append the §3 obs from `inputs`
-(guarded for null inputs → emit nothing, preserving current behavior). Add concept-key
+
+In `buildAndPersistReferralEvent`, after the existing obs, append the section 3 obs from `inputs`
+(guarded for null inputs, emitting nothing and preserving current behavior). Add concept-key
 constants to `Constants.NcdReferral`.
 
 ### 5.5 Threading
-`submittedAndClose` currently reads the pending referral and shows the dialog on the UI thread.
-Add a background fetch of the caregiver (via `appExecutors.diskIO()`), then `runOnUiThread` to
-show the dialog prefilled. The DB read must not run on the main thread.
+
+`submittedAndClose` currently reads the pending referral and shows the dialog on the UI thread. Add
+a background fetch of the caregiver (via `appExecutors.diskIO()`), then `runOnUiThread` to show the
+dialog prefilled. The DB read must not run on the main thread.
 
 ---
 
 ## 6. Files touched
 
-| File | Change |
-|---|---|
-| `custom_views/NcdReferralPromptDialog.java` | Custom layout, collect emergency + supporter, new callback signature |
-| `res/layout/dialog_ncd_referral_prompt.xml` | **New** dialog layout |
-| `activity/NcdCaseManagementVisitActivity.java` | Background caregiver fetch; pass `NcdReferralInputs` to helper |
-| `util/NcdReferralTaskHelper.java` | New overload; emit the 4–5 obs; null-safe |
-| `util/Constants.java` (`NcdReferral`) | Concept-key constants |
-| `model/NcdReferralInputs.java` (or nested) | **New** data holder |
-| `res/values/strings.xml` | New labels/hints |
-| `res/values-sw/strings.xml` | Swahili translations |
-| `test/.../NcdReferralTaskHelperTest` (if present) | Cover obs emission / gate rules |
+- `custom_views/NcdReferralPromptDialog.java`: custom layout, emergency/supporter collection, and
+  new callback signature.
+- `res/layout/dialog_ncd_referral_prompt.xml`: new dialog layout.
+- `activity/NcdCaseManagementVisitActivity.java`: background caregiver fetch and pass
+  `NcdReferralInputs` to the helper.
+- `util/NcdReferralTaskHelper.java`: new overload, obs emission, and null-safety.
+- `util/Constants.java` (`NcdReferral`): concept-key constants.
+- `model/NcdReferralInputs.java`: new data holder.
+- `res/values/strings.xml`: new labels and hints.
+- `res/values-sw/strings.xml`: Swahili translations.
+- `test/.../NcdReferralTaskHelperTest`: obs emission and gate-rule coverage.
 
 ---
 
@@ -150,6 +172,9 @@ show the dialog prefilled. The DB read must not run on the main thread.
 
 ## 8. Decisions (resolved)
 
-- **`is_emergency_case`** is CHW-**editable**: a Yes/No control seeded from alert level (red→Yes, yellow→No).
-- **`treatment_supporter_relationship`** is **included** on the auto path (18-option spinner) for parity with the manual form.
-- **Phone validation** is **lenient**: `inputType=phone`, any non-blank value accepted — matches the form's handling.
+- **`is_emergency_case`** is CHW-**editable**: a Yes/No control seeded from alert level (red maps to
+  Yes, yellow maps to No).
+- **`treatment_supporter_relationship`** is **included** on the auto path (18-option spinner) for
+  parity with the manual form.
+- **Phone validation** is **lenient**: `inputType=phone`, any non-blank value accepted; matches the
+  form's handling.

--- a/docs/specs/ncd-auto-referral-supporter-emergency.md
+++ b/docs/specs/ncd-auto-referral-supporter-emergency.md
@@ -1,17 +1,21 @@
-# SPEC - Capture emergency-case & treatment-supporter details on auto-generated NCD referrals
+<!-- markdownlint-disable MD043 -->
 
-**Branch:** `add-is-emergence-on-sw-ncd-ref` **Approach:** A - enrich the post-visit confirmation
-dialog (no full form, no extra Activity) **Status:** Draft / not started
+# SPEC - Auto NCD referral emergency/supporter details
+
+**Branch:** `add-is-emergence-on-sw-ncd-ref` **Approach:** A - enrich the
+post-visit confirmation dialog (no full form, no extra Activity) **Status:**
+Draft / not started
 
 ---
 
 ## 1. Background
 
-NCD follow-up visits run through `NcdCaseManagementVisitActivity`. When a visit produces a danger
-sign or medicine side effect, the interactor stages a `PendingNcdReferral` and, on
-`submittedAndClose`, a confirm/skip dialog (`NcdReferralPromptDialog`) is shown. On confirm,
-`NcdReferralTaskHelper.createReferralIfNeeded(...)` **builds the Referral Registration event
-programmatically** and creates the linked task.
+NCD follow-up visits run through `NcdCaseManagementVisitActivity`. When a visit
+produces a danger sign or medicine side effect, the interactor stages a
+`PendingNcdReferral` and, on `submittedAndClose`, a confirm/skip dialog
+(`NcdReferralPromptDialog`) is shown. On confirm,
+`NcdReferralTaskHelper.createReferralIfNeeded(...)` **builds the Referral
+Registration event programmatically** and creates the linked task.
 
 There are two NCD referral paths today, and they are asymmetric:
 
@@ -25,14 +29,17 @@ There are two NCD referral paths today, and they are asymmetric:
   - Manual: present in form
   - Auto: missing
 - `has_treatment_supporter`, `_name`, and `_phone`:
-  - Manual: present in form, prefilled and editable via `TreatmentSupporterFormUtil`
+  - Manual: present in form, prefilled and editable via
+    `TreatmentSupporterFormUtil`
   - Auto: missing
 
-**Goal:** the auto path must also emit `is_emergency_case`, `has_treatment_supporter`,
-`treatment_supporter_name`, `treatment_supporter_phone` (and, for parity,
-`treatment_supporter_relationship`) on its Referral Registration event. The treatment supporter must
-be **editable for this referral only**; never writing back to the client's registration record.
-Editing is for the case where the client presents a different supporter at referral time.
+**Goal:** the auto path must also emit `is_emergency_case`,
+`has_treatment_supporter`, `treatment_supporter_name`,
+`treatment_supporter_phone` (and, for parity,
+`treatment_supporter_relationship`) on its Referral Registration event. The
+treatment supporter must be **editable for this referral only**; never writing
+back to the client's registration record. Editing is for the case where the
+client presents a different supporter at referral time.
 
 ---
 
@@ -40,10 +47,12 @@ Editing is for the case where the client presents a different supporter at refer
 
 ### In scope
 
-- A richer post-visit dialog that captures the emergency flag and an editable treatment-supporter
-  section, prefilled from `TreatmentSupporterDao.getRegisteredCaregiver`.
-- Threading the captured values into `NcdReferralTaskHelper.createReferralIfNeeded` and emitting
-  them as obs on the Referral Registration event.
+- A richer post-visit dialog that captures the emergency flag and an editable
+  treatment-supporter section, prefilled from
+  `TreatmentSupporterDao.getRegisteredCaregiver`.
+- Threading the captured values into
+  `NcdReferralTaskHelper.createReferralIfNeeded` and emitting them as obs on the
+  Referral Registration event.
 - English + Swahili strings for the new dialog controls.
 
 ### Out of scope
@@ -51,42 +60,46 @@ Editing is for the case where the client presents a different supporter at refer
 - The manual referral form path (already complete).
 - Editing/persisting the client's registered caregiver record.
 - Changing the alert-detection logic that stages `PendingNcdReferral`.
-- Letting the CHW edit the detected problem list or referral health facility (that is Approach B
-  territory).
+- Letting the CHW edit the detected problem list or referral health facility
+  (that is Approach B territory).
 
 ---
 
 ## 3. Obs to emit (target event shape)
 
-Added to the event inside `buildAndPersistReferralEvent`, mirroring the existing single-value obs
-shape (`fieldType = "concept"`, `parentCode = ""`):
+Added to the event inside `buildAndPersistReferralEvent`, mirroring the existing
+single-value obs shape (`fieldType = "concept"`, `parentCode = ""`):
 
-| formSubmissionField / fieldCode    | Value              | Persisted when             |
-| ---------------------------------- | ------------------ | -------------------------- |
-| `is_emergency_case`                | `"Yes"` / `"No"`   | always                     |
-| `has_treatment_supporter`          | `"Yes"` / `"No"`   | always                     |
-| `treatment_supporter_name`         | edited text        | gate = `Yes` and non-blank |
-| `treatment_supporter_phone`        | edited text        | gate = `Yes` and non-blank |
-| `treatment_supporter_relationship` | spinner option key | gate = `Yes` and non-blank |
+- `is_emergency_case`: `"Yes"` / `"No"`, always persisted.
+- `has_treatment_supporter`: `"Yes"` / `"No"`, always persisted.
+- `treatment_supporter_name`: edited text, persisted when gate is `Yes` and
+  non-blank.
+- `treatment_supporter_phone`: edited text, persisted when gate is `Yes` and
+  non-blank.
+- `treatment_supporter_relationship`: spinner option key, persisted when gate is
+  `Yes` and non-blank.
 
-When the gate is `No`, only `is_emergency_case` and `has_treatment_supporter` (= `No`) are written;
-the three detail obs are omitted. This matches `TreatmentSupporterFormUtil`'s "details only when
-gate is Yes" rule.
+When the gate is `No`, only `is_emergency_case` and `has_treatment_supporter` (=
+`No`) are written; the three detail obs are omitted. This matches
+`TreatmentSupporterFormUtil`'s "details only when gate is Yes" rule.
 
 ---
 
 ## 4. Defaults & prefill
 
-- **`is_emergency_case`** default: `Yes` when `alertLevel == ALERT_RED`, else `No`. CHW-overridable.
-- **Treatment supporter:** load `TreatmentSupporterDao.getRegisteredCaregiver(baseEntityId)` off the
-  main thread _before_ showing the dialog.
-  - If a caregiver `isPresent()`: gate defaults to `Yes`; name/phone/relationship prefilled and
-    editable.
-  - If none on record: gate defaults to `No`; detail fields empty (shown when gate flipped to
-    `Yes`).
-- Relationship spinner uses the same 18 options as the form's `treatment_supporter_relationship`
-  field (Mother, Father, Brother, Sister, Grandfather, Grandmother, Friend, Uncle, Aunt, Police,
-  Guardian, Son, Daughter, Work Colleague, Brother in Law, Sister in Law, Wife, Husband).
+- **`is_emergency_case`** default: `Yes` when `alertLevel == ALERT_RED`, else
+  `No`. CHW-overridable.
+- **Treatment supporter:** load
+  `TreatmentSupporterDao.getRegisteredCaregiver(baseEntityId)` off the main
+  thread _before_ showing the dialog.
+  - If a caregiver `isPresent()`: gate defaults to `Yes`;
+    name/phone/relationship prefilled and editable.
+  - If none on record: gate defaults to `No`; detail fields empty (shown when
+    gate flipped to `Yes`).
+- Relationship spinner uses the same 18 options as the form's
+  `treatment_supporter_relationship` field (Mother, Father, Brother, Sister,
+  Grandfather, Grandmother, Friend, Uncle, Aunt, Police, Guardian, Son,
+  Daughter, Work Colleague, Brother in Law, Sister in Law, Wife, Husband).
 
 ---
 
@@ -94,59 +107,75 @@ gate is Yes" rule.
 
 ### 5.1 New dialog (`NcdReferralPromptDialog` to custom layout)
 
-Replace the plain `AlertDialog` message with a custom view (`dialog_ncd_referral_prompt.xml`)
-containing, top to bottom:
+Replace the plain `AlertDialog` message with a custom view
+(`dialog_ncd_referral_prompt.xml`) containing, top to bottom:
 
 1. Title (existing urgent / non-emergency string).
 2. Body + bulleted reasons (existing behavior).
-3. **Emergency case** - labeled Yes/No control (RadioGroup), seeded per section 4.
+3. **Emergency case** - labeled Yes/No control (RadioGroup), seeded per
+   section 4.
 4. **Treatment supporter**:
-   - Has-supporter gate (Yes/No). Toggling controls visibility of the detail block.
-   - Name (EditText), Phone (EditText, `inputType=phone`), Relationship (Spinner).
+   - Has-supporter gate (Yes/No). Toggling controls visibility of the detail
+     block.
+   - Name (EditText), Phone (EditText, `inputType=phone`), Relationship
+     (Spinner).
 5. Skip / Create buttons (existing strings).
 
-The dialog collects values into a small immutable result and hands them to the confirm callback.
+The dialog collects values into a small immutable result and hands them to the
+confirm callback.
 
 ### 5.2 Inputs object
 
-Introduce `NcdReferralInputs` (plain data holder): `isEmergencyCase` (bool/`"Yes"`/`"No"`),
-`hasTreatmentSupporter`, `supporterName`, `supporterPhone`, `supporterRelationship`. Prefer this
-over expanding the `createReferralIfNeeded` argument list further.
+Introduce `NcdReferralInputs` (plain data holder): `isEmergencyCase`
+(bool/`"Yes"`/`"No"`), `hasTreatmentSupporter`, `supporterName`,
+`supporterPhone`, `supporterRelationship`. Prefer this over expanding the
+`createReferralIfNeeded` argument list further.
 
 ### 5.3 Callback / helper signature
 
-`NcdReferralPromptDialog.Callbacks.onConfirm()` becomes `onConfirm(NcdReferralInputs inputs)`.
-`NcdCaseManagementVisitActivity` passes `inputs` to a new overload:
+`NcdReferralPromptDialog.Callbacks.onConfirm()` becomes
+`onConfirm(NcdReferralInputs inputs)`. `NcdCaseManagementVisitActivity` passes
+`inputs` to a new overload:
 
-```
-createReferralIfNeeded(baseEntityId, triggeringFormSubmissionId, alertLevel,
-                       description, problemKeys, reasons, NcdReferralInputs inputs)
+```text
+createReferralIfNeeded(
+    baseEntityId,
+    triggeringFormSubmissionId,
+    alertLevel,
+    description,
+    problemKeys,
+    reasons,
+    NcdReferralInputs inputs
+)
 ```
 
-Keep/forward the existing signature (passing `null` inputs) so other callers are unaffected.
+Keep/forward the existing signature (passing `null` inputs) so other callers are
+unaffected.
 
 ### 5.4 Event building
 
-In `buildAndPersistReferralEvent`, after the existing obs, append the section 3 obs from `inputs`
-(guarded for null inputs, emitting nothing and preserving current behavior). Add concept-key
-constants to `Constants.NcdReferral`.
+In `buildAndPersistReferralEvent`, after the existing obs, append the section 3
+obs from `inputs` (guarded for null inputs, emitting nothing and preserving
+current behavior). Add concept-key constants to `Constants.NcdReferral`.
 
 ### 5.5 Threading
 
-`submittedAndClose` currently reads the pending referral and shows the dialog on the UI thread. Add
-a background fetch of the caregiver (via `appExecutors.diskIO()`), then `runOnUiThread` to show the
-dialog prefilled. The DB read must not run on the main thread.
+`submittedAndClose` currently reads the pending referral and shows the dialog on
+the UI thread. Add a background fetch of the caregiver (via
+`appExecutors.diskIO()`), then `runOnUiThread` to show the dialog prefilled. The
+DB read must not run on the main thread.
 
 ---
 
 ## 6. Files touched
 
-- `custom_views/NcdReferralPromptDialog.java`: custom layout, emergency/supporter collection, and
-  new callback signature.
+- `custom_views/NcdReferralPromptDialog.java`: custom layout,
+  emergency/supporter collection, and new callback signature.
 - `res/layout/dialog_ncd_referral_prompt.xml`: new dialog layout.
-- `activity/NcdCaseManagementVisitActivity.java`: background caregiver fetch and pass
-  `NcdReferralInputs` to the helper.
-- `util/NcdReferralTaskHelper.java`: new overload, obs emission, and null-safety.
+- `activity/NcdCaseManagementVisitActivity.java`: background caregiver fetch and
+  pass `NcdReferralInputs` to the helper.
+- `util/NcdReferralTaskHelper.java`: new overload, obs emission, and
+  null-safety.
 - `util/Constants.java` (`NcdReferral`): concept-key constants.
 - `model/NcdReferralInputs.java`: new data holder.
 - `res/values/strings.xml`: new labels and hints.
@@ -157,12 +186,15 @@ dialog prefilled. The DB read must not run on the main thread.
 
 ## 7. Acceptance criteria
 
-1. Confirming an auto NCD referral writes a Referral Registration event that includes
-   `is_emergency_case` and `has_treatment_supporter` obs; when the gate is Yes and details are
-   present, `treatment_supporter_name`/`_phone`/`_relationship` are included too.
-2. `is_emergency_case` defaults to Yes for red alerts, No for yellow, and the CHW can change it.
-3. Supporter fields prefill from the registered caregiver and are editable; edits appear on the
-   referral event and the client's `ec_family_member` registration record is unchanged.
+1. Confirming an auto NCD referral writes a Referral Registration event that
+   includes `is_emergency_case` and `has_treatment_supporter` obs; when the gate
+   is Yes and details are present,
+   `treatment_supporter_name`/`_phone`/`_relationship` are included too.
+2. `is_emergency_case` defaults to Yes for red alerts, No for yellow, and the
+   CHW can change it.
+3. Supporter fields prefill from the registered caregiver and are editable;
+   edits appear on the referral event and the client's `ec_family_member`
+   registration record is unchanged.
 4. With the gate set to No, no supporter detail obs are emitted.
 5. Skip still writes no event or task.
 6. The caregiver DB lookup runs off the main thread.
@@ -172,9 +204,9 @@ dialog prefilled. The DB read must not run on the main thread.
 
 ## 8. Decisions (resolved)
 
-- **`is_emergency_case`** is CHW-**editable**: a Yes/No control seeded from alert level (red maps to
-  Yes, yellow maps to No).
-- **`treatment_supporter_relationship`** is **included** on the auto path (18-option spinner) for
-  parity with the manual form.
-- **Phone validation** is **lenient**: `inputType=phone`, any non-blank value accepted; matches the
-  form's handling.
+- **`is_emergency_case`** is CHW-**editable**: a Yes/No control seeded from
+  alert level (red maps to Yes, yellow maps to No).
+- **`treatment_supporter_relationship`** is **included** on the auto path
+  (18-option spinner) for parity with the manual form.
+- **Phone validation** is **lenient**: `inputType=phone`, any non-blank value
+  accepted; matches the form's handling.

--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -330,6 +330,9 @@ dependencies {
     implementation('org.smartregister:opensrp-client-chw-core:2.1.1-MOH-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-plan-evaluator'
+        // Pull opensrp-chw-ncd directly (below) instead of the version chw-core resolves to,
+        // until chw-core is rebuilt against the newer ncd library.
+        exclude group: 'org.smartregister', module: 'opensrp-chw-ncd'
         exclude group: 'com.android.support', module: 'appcompat-v7'
         exclude group: 'androidx.legacy', module: 'legacy-support-v4'
         exclude group: 'androidx.appcompat', module: 'appcompat'
@@ -349,6 +352,12 @@ dependencies {
         exclude group: "jakarta.activation", module: "jakarta.activation-api"
         exclude group: "javax.xml.bind", module: "jaxb-api"
         exclude group: 'com.github.lecho', module: 'hellocharts-library'
+    }
+
+    // Direct dependency on the NCD library (excluded from chw-core above) so the app builds
+    // against the newer published version without waiting on a chw-core rebuild.
+    implementation('org.smartregister:opensrp-chw-ncd:0.1.1-SNAPSHOT@aar') {
+        transitive = false
     }
 
     implementation 'com.getkeepsafe.relinker:relinker:1.4.5'

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -35,7 +35,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
 
     private static final String CLOSE_REASON_DECEASED = "deceased";
 
-    private final LinkedHashMap<String, BaseNcdVisitAction> completeActionList = new LinkedHashMap<>();
+    private final LinkedHashMap<String, BaseNcdVisitAction> completeActionList =
+            new LinkedHashMap<>();
     private final AppExecutors appExecutors = new AppExecutors();
     private String pendingMortalityResult;
 
@@ -43,7 +44,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
         Intent intent = new Intent(activity, NcdCaseManagementVisitActivity.class);
         intent.putExtra(Constants.ACTIVITY_PAYLOAD.BASE_ENTITY_ID, baseEntityId);
         intent.putExtra(Constants.ACTIVITY_PAYLOAD.EDIT_MODE, isEditMode);
-        intent.putExtra(Constants.ACTIVITY_PAYLOAD.PROFILE_TYPE, Constants.PROFILE_TYPES.SKELETON_PROFILE);
+        intent.putExtra(Constants.ACTIVITY_PAYLOAD.PROFILE_TYPE,
+                Constants.PROFILE_TYPES.SKELETON_PROFILE);
         activity.startActivity(intent);
     }
 
@@ -96,7 +98,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
             return null;
         }
         for (BaseNcdVisitAction action : actions.values()) {
-            if (org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_STATUS.equals(action.getFormName())) {
+            if (org.smartregister.chw.util.Constants.JsonForm.NCD_FOLLOWUP_STATUS.equals(
+                    action.getFormName())) {
                 return action;
             }
         }
@@ -124,7 +127,7 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
 
         // Resolve the open-referral guard, registered caregiver, and referral facility list off
         // the main thread (these DB reads must not run on the UI thread). When the client already
-        // has an open NCD referral, skip the prompt entirely — createReferralIfNeeded would dedupe
+        // has an open NCD referral, skip the prompt entirely; createReferralIfNeeded would dedupe
         // it anyway, so asking the CHW to fill a form that produces nothing is misleading.
         appExecutors.diskIO().execute(() -> {
             if (NcdCaseManagementDao.hasOpenReferral(pending.baseEntityId)) {
@@ -140,7 +143,7 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
     }
 
     private void skipReferralPrompt(PendingNcdReferral pending, String results) {
-        Timber.i("NCD referral prompt skipped — open referral already exists for %s",
+        Timber.i("NCD referral prompt skipped; open referral already exists for %s",
                 pending.baseEntityId);
         displayToast(getString(org.smartregister.chw.R.string.ncd_referral_already_open));
         clearPendingReferral();
@@ -150,7 +153,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
     private void showReferralPrompt(PendingNcdReferral pending,
                                     TreatmentSupporterDao.Caregiver caregiver,
                                     Map<String, String> facilities, String results) {
-        NcdReferralPromptDialog.show(this, pending, caregiver, facilities, new NcdReferralPromptDialog.Callbacks() {
+        NcdReferralPromptDialog.show(this, pending, caregiver, facilities,
+                new NcdReferralPromptDialog.Callbacks() {
             @Override
             public void onConfirm(NcdReferralInputs inputs) {
                 NcdReferralTaskHelper.createReferralIfNeeded(
@@ -223,7 +227,8 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
                     if (tvSubmit != null) {
                         tvSubmit.setEnabled(true);
                     }
-                    displayToast(getString(org.smartregister.chw.R.string.ncd_death_registration_save_failed));
+                    displayToast(getString(
+                            org.smartregister.chw.R.string.ncd_death_registration_save_failed));
                 });
             }
         });
@@ -246,18 +251,27 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
 
     private PendingNcdReferral readPendingReferral() {
         NcdCaseManagementInteractor interactor = getCaseManagementInteractor();
-        return interactor != null ? interactor.getPendingReferral() : null;
+        if (interactor != null) {
+            return interactor.getPendingReferral();
+        }
+        return null;
     }
 
     private NcdCaseManagementInteractor getCaseManagementInteractor() {
-        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) return null;
+        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) {
+            return null;
+        }
         return ((NcdCaseManagementVisitPresenter) presenter).getCaseManagementInteractor();
     }
 
     private void clearPendingReferral() {
-        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) return;
+        if (!(presenter instanceof NcdCaseManagementVisitPresenter)) {
+            return;
+        }
         NcdCaseManagementInteractor interactor =
                 ((NcdCaseManagementVisitPresenter) presenter).getCaseManagementInteractor();
-        if (interactor != null) interactor.clearPendingReferral();
+        if (interactor != null) {
+            interactor.clearPendingReferral();
+        }
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -12,6 +12,7 @@ import org.smartregister.chw.interactor.NcdCaseManagementInteractor.PendingNcdRe
 import org.smartregister.chw.dao.NcdCaseManagementDao;
 import org.smartregister.chw.dao.TreatmentSupporterDao;
 import org.smartregister.chw.model.NcdReferralInputs;
+import org.smartregister.chw.referral.util.LocationUtils;
 import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
 import org.smartregister.chw.ncd.util.Constants;
 import org.smartregister.chw.ncd.util.AppExecutors;
@@ -121,18 +122,35 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
             return;
         }
 
-        // Resolve the registered caregiver off the main thread, then prompt the CHW with the
-        // supporter prefilled and editable. The DB read must not run on the UI thread.
+        // Resolve the open-referral guard, registered caregiver, and referral facility list off
+        // the main thread (these DB reads must not run on the UI thread). When the client already
+        // has an open NCD referral, skip the prompt entirely — createReferralIfNeeded would dedupe
+        // it anyway, so asking the CHW to fill a form that produces nothing is misleading.
         appExecutors.diskIO().execute(() -> {
+            if (NcdCaseManagementDao.hasOpenReferral(pending.baseEntityId)) {
+                appExecutors.mainThread().execute(() -> skipReferralPrompt(pending, results));
+                return;
+            }
             TreatmentSupporterDao.Caregiver caregiver =
                     TreatmentSupporterDao.getRegisteredCaregiver(pending.baseEntityId);
-            appExecutors.mainThread().execute(() -> showReferralPrompt(pending, caregiver, results));
+            Map<String, String> facilities = LocationUtils.INSTANCE.getFacilitiesKeyAndName();
+            appExecutors.mainThread().execute(() ->
+                    showReferralPrompt(pending, caregiver, facilities, results));
         });
     }
 
+    private void skipReferralPrompt(PendingNcdReferral pending, String results) {
+        Timber.i("NCD referral prompt skipped — open referral already exists for %s",
+                pending.baseEntityId);
+        displayToast(getString(org.smartregister.chw.R.string.ncd_referral_already_open));
+        clearPendingReferral();
+        super.submittedAndClose(results);
+    }
+
     private void showReferralPrompt(PendingNcdReferral pending,
-                                    TreatmentSupporterDao.Caregiver caregiver, String results) {
-        NcdReferralPromptDialog.show(this, pending, caregiver, new NcdReferralPromptDialog.Callbacks() {
+                                    TreatmentSupporterDao.Caregiver caregiver,
+                                    Map<String, String> facilities, String results) {
+        NcdReferralPromptDialog.show(this, pending, caregiver, facilities, new NcdReferralPromptDialog.Callbacks() {
             @Override
             public void onConfirm(NcdReferralInputs inputs) {
                 NcdReferralTaskHelper.createReferralIfNeeded(

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/NcdCaseManagementVisitActivity.java
@@ -10,6 +10,8 @@ import org.smartregister.chw.custom_views.NcdReferralPromptDialog;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor.PendingNcdReferral;
 import org.smartregister.chw.dao.NcdCaseManagementDao;
+import org.smartregister.chw.dao.TreatmentSupporterDao;
+import org.smartregister.chw.model.NcdReferralInputs;
 import org.smartregister.chw.ncd.model.BaseNcdVisitAction;
 import org.smartregister.chw.ncd.util.Constants;
 import org.smartregister.chw.ncd.util.AppExecutors;
@@ -119,16 +121,28 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
             return;
         }
 
-        runOnUiThread(() -> NcdReferralPromptDialog.show(this, pending, new NcdReferralPromptDialog.Callbacks() {
+        // Resolve the registered caregiver off the main thread, then prompt the CHW with the
+        // supporter prefilled and editable. The DB read must not run on the UI thread.
+        appExecutors.diskIO().execute(() -> {
+            TreatmentSupporterDao.Caregiver caregiver =
+                    TreatmentSupporterDao.getRegisteredCaregiver(pending.baseEntityId);
+            appExecutors.mainThread().execute(() -> showReferralPrompt(pending, caregiver, results));
+        });
+    }
+
+    private void showReferralPrompt(PendingNcdReferral pending,
+                                    TreatmentSupporterDao.Caregiver caregiver, String results) {
+        NcdReferralPromptDialog.show(this, pending, caregiver, new NcdReferralPromptDialog.Callbacks() {
             @Override
-            public void onConfirm() {
+            public void onConfirm(NcdReferralInputs inputs) {
                 NcdReferralTaskHelper.createReferralIfNeeded(
                         pending.baseEntityId,
                         null,
                         pending.alertLevel,
                         pending.description,
                         pending.problemKeys,
-                        pending.reasons);
+                        pending.reasons,
+                        inputs);
                 clearPendingReferral();
                 NcdCaseManagementVisitActivity.super.submittedAndClose(results);
             }
@@ -140,7 +154,7 @@ public class NcdCaseManagementVisitActivity extends NcdVisitActivity {
                 clearPendingReferral();
                 NcdCaseManagementVisitActivity.super.submittedAndClose(results);
             }
-        }));
+        });
     }
 
     @Override

--- a/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * behind (the visit itself is already persisted by the time this dialog is shown).
  *
  * <p>The supporter is prefilled from the registered caregiver but edited <em>for this referral
- * only</em> — the dialog never writes back to the registration record.
+ * only</em>; the dialog never writes back to the registration record.
  */
 public final class NcdReferralPromptDialog {
 
@@ -47,6 +47,8 @@ public final class NcdReferralPromptDialog {
             "Uncle", "Aunt", "Police", "Guardian", "Son", "Daughter", "Work Colleague",
             "Brother in Law", "Sister in Law", "Wife", "Husband"
     };
+    private static final String YES = "Yes";
+    private static final String NO = "No";
 
     private NcdReferralPromptDialog() {
         // utility
@@ -62,7 +64,9 @@ public final class NcdReferralPromptDialog {
                             TreatmentSupporterDao.Caregiver caregiver,
                             Map<String, String> facilities, Callbacks callbacks) {
         if (activity == null || activity.isFinishing() || pending == null || callbacks == null) {
-            if (callbacks != null) callbacks.onSkip();
+            if (callbacks != null) {
+                callbacks.onSkip();
+            }
             return;
         }
 
@@ -71,14 +75,17 @@ public final class NcdReferralPromptDialog {
                 ? R.string.ncd_referral_prompt_title_urgent
                 : R.string.ncd_referral_prompt_title_non_emergency;
 
-        View view = LayoutInflater.from(activity).inflate(R.layout.dialog_ncd_referral_prompt, null);
+        View view = LayoutInflater.from(activity).inflate(
+                R.layout.dialog_ncd_referral_prompt, null);
 
         TextView reasonsView = view.findViewById(R.id.ncd_referral_reasons);
         reasonsView.setText(buildMessage(activity, pending.reasons));
 
         // Emergency defaults: Yes for red alerts, No for yellow. CHW can override.
         RadioGroup emergencyGroup = view.findViewById(R.id.ncd_referral_emergency_group);
-        emergencyGroup.check(isRed ? R.id.ncd_referral_emergency_yes : R.id.ncd_referral_emergency_no);
+        emergencyGroup.check(isRed
+                ? R.id.ncd_referral_emergency_yes
+                : R.id.ncd_referral_emergency_no);
 
         // Treatment supporter: gate defaults to Yes when a caregiver is on record.
         boolean hasCaregiver = caregiver != null && caregiver.isPresent();
@@ -94,12 +101,20 @@ public final class NcdReferralPromptDialog {
         relationshipView.setAdapter(relationshipAdapter);
 
         if (hasCaregiver) {
-            if (!TextUtils.isEmpty(caregiver.getName())) nameView.setText(caregiver.getName().trim());
-            if (!TextUtils.isEmpty(caregiver.getPhone())) phoneView.setText(caregiver.getPhone().trim());
+            if (!TextUtils.isEmpty(caregiver.getName())) {
+                nameView.setText(caregiver.getName().trim());
+            }
+            if (!TextUtils.isEmpty(caregiver.getPhone())) {
+                phoneView.setText(caregiver.getPhone().trim());
+            }
             int relIndex = relationshipIndex(caregiver.getRelationship());
-            if (relIndex >= 0) relationshipView.setSelection(relIndex);
+            if (relIndex >= 0) {
+                relationshipView.setSelection(relIndex);
+            }
         }
-        supporterGroup.check(hasCaregiver ? R.id.ncd_referral_supporter_yes : R.id.ncd_referral_supporter_no);
+        supporterGroup.check(hasCaregiver
+                ? R.id.ncd_referral_supporter_yes
+                : R.id.ncd_referral_supporter_no);
         supporterDetails.setVisibility(hasCaregiver ? View.VISIBLE : View.GONE);
         supporterGroup.setOnCheckedChangeListener((group, checkedId) ->
                 supporterDetails.setVisibility(
@@ -143,34 +158,43 @@ public final class NcdReferralPromptDialog {
                             Toast.LENGTH_SHORT).show();
                     return;
                 }
-                callbacks.onConfirm(collectInputs(emergencyGroup, supporterGroup, nameView, phoneView,
-                        relationshipView, facilityIds.get(pos), facilityNames.get(pos)));
+                callbacks.onConfirm(collectInputs(emergencyGroup, supporterGroup, nameView,
+                        phoneView, relationshipView, facilityIds.get(pos),
+                        facilityNames.get(pos)));
                 dialog.dismiss();
             });
         });
         dialog.show();
     }
 
-    private static NcdReferralInputs collectInputs(RadioGroup emergencyGroup, RadioGroup supporterGroup,
+    private static NcdReferralInputs collectInputs(RadioGroup emergencyGroup,
+                                                   RadioGroup supporterGroup,
                                                    EditText nameView, EditText phoneView,
                                                    Spinner relationshipView,
                                                    String facilityId, String facilityName) {
-        String isEmergency = emergencyGroup.getCheckedRadioButtonId() == R.id.ncd_referral_emergency_yes
-                ? "Yes" : "No";
-        boolean gateYes = supporterGroup.getCheckedRadioButtonId() == R.id.ncd_referral_supporter_yes;
+        String isEmergency = emergencyGroup.getCheckedRadioButtonId()
+                == R.id.ncd_referral_emergency_yes
+                ? YES : NO;
+        boolean gateYes = supporterGroup.getCheckedRadioButtonId()
+                == R.id.ncd_referral_supporter_yes;
         if (!gateYes) {
-            return new NcdReferralInputs(isEmergency, "No", null, null, null, facilityId, facilityName);
+            return new NcdReferralInputs(isEmergency, NO, null, null, null, facilityId,
+                    facilityName);
         }
         String name = textOf(nameView);
         String phone = textOf(phoneView);
         String relationship = relationshipView.getSelectedItem() != null
                 ? relationshipView.getSelectedItem().toString() : null;
-        return new NcdReferralInputs(isEmergency, "Yes", name, phone, relationship, facilityId, facilityName);
+        return new NcdReferralInputs(isEmergency, YES, name, phone, relationship, facilityId,
+                facilityName);
     }
 
     private static String textOf(EditText editText) {
         String value = editText.getText() != null ? editText.getText().toString().trim() : "";
-        return TextUtils.isEmpty(value) ? null : value;
+        if (TextUtils.isEmpty(value)) {
+            return null;
+        }
+        return value;
     }
 
     private static int relationshipIndex(String relationship) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
@@ -5,10 +5,12 @@ import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.EditText;
 import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AlertDialog;
 
@@ -18,7 +20,9 @@ import org.smartregister.chw.interactor.NcdCaseManagementInteractor;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor.PendingNcdReferral;
 import org.smartregister.chw.model.NcdReferralInputs;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Confirmation prompt shown after an NCD Monthly Follow-Up visit is submitted and the
@@ -55,7 +59,8 @@ public final class NcdReferralPromptDialog {
     }
 
     public static void show(Activity activity, PendingNcdReferral pending,
-                            TreatmentSupporterDao.Caregiver caregiver, Callbacks callbacks) {
+                            TreatmentSupporterDao.Caregiver caregiver,
+                            Map<String, String> facilities, Callbacks callbacks) {
         if (activity == null || activity.isFinishing() || pending == null || callbacks == null) {
             if (callbacks != null) callbacks.onSkip();
             return;
@@ -100,32 +105,67 @@ public final class NcdReferralPromptDialog {
                 supporterDetails.setVisibility(
                         checkedId == R.id.ncd_referral_supporter_yes ? View.VISIBLE : View.GONE));
 
-        new AlertDialog.Builder(activity)
+        // Referral facility: index 0 is a non-selectable placeholder, then one entry per facility.
+        // facilityIds is index-aligned with the spinner (id is null at the placeholder position).
+        Spinner facilityView = view.findViewById(R.id.ncd_referral_facility);
+        List<String> facilityNames = new ArrayList<>();
+        List<String> facilityIds = new ArrayList<>();
+        facilityNames.add(activity.getString(R.string.ncd_referral_prompt_facility_hint));
+        facilityIds.add(null);
+        if (facilities != null) {
+            for (Map.Entry<String, String> entry : facilities.entrySet()) {
+                facilityIds.add(entry.getKey());
+                facilityNames.add(entry.getValue());
+            }
+        }
+        ArrayAdapter<String> facilityAdapter = new ArrayAdapter<>(activity,
+                android.R.layout.simple_spinner_item, facilityNames);
+        facilityAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        facilityView.setAdapter(facilityAdapter);
+
+        AlertDialog dialog = new AlertDialog.Builder(activity)
                 .setTitle(titleRes)
                 .setView(view)
                 .setCancelable(false)
                 .setNegativeButton(R.string.ncd_referral_prompt_button_skip,
                         (d, w) -> callbacks.onSkip())
-                .setPositiveButton(R.string.ncd_referral_prompt_button_create,
-                        (d, w) -> callbacks.onConfirm(collectInputs(
-                                emergencyGroup, supporterGroup, nameView, phoneView, relationshipView)))
-                .show();
+                .setPositiveButton(R.string.ncd_referral_prompt_button_create, null)
+                .create();
+
+        // Override the positive button after show() so an unselected facility keeps the dialog
+        // open (the default listener would auto-dismiss).
+        dialog.setOnShowListener(d -> {
+            Button create = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+            create.setOnClickListener(v -> {
+                int pos = facilityView.getSelectedItemPosition();
+                if (pos <= 0) {
+                    Toast.makeText(activity, R.string.ncd_referral_prompt_facility_required,
+                            Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                callbacks.onConfirm(collectInputs(emergencyGroup, supporterGroup, nameView, phoneView,
+                        relationshipView, facilityIds.get(pos), facilityNames.get(pos)));
+                dialog.dismiss();
+            });
+        });
+        dialog.show();
     }
 
     private static NcdReferralInputs collectInputs(RadioGroup emergencyGroup, RadioGroup supporterGroup,
                                                    EditText nameView, EditText phoneView,
-                                                   Spinner relationshipView) {
+                                                   Spinner relationshipView,
+                                                   String facilityId, String facilityName) {
         String isEmergency = emergencyGroup.getCheckedRadioButtonId() == R.id.ncd_referral_emergency_yes
                 ? "Yes" : "No";
         boolean gateYes = supporterGroup.getCheckedRadioButtonId() == R.id.ncd_referral_supporter_yes;
         if (!gateYes) {
-            return new NcdReferralInputs(isEmergency, "No", null, null, null);
+            return new NcdReferralInputs(isEmergency, "No", null, null, null, facilityId, facilityName);
         }
         String name = textOf(nameView);
         String phone = textOf(phoneView);
         String relationship = relationshipView.getSelectedItem() != null
                 ? relationshipView.getSelectedItem().toString() : null;
-        return new NcdReferralInputs(isEmergency, "Yes", name, phone, relationship);
+        return new NcdReferralInputs(isEmergency, "Yes", name, phone, relationship, facilityId, facilityName);
     }
 
     private static String textOf(EditText editText) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/custom_views/NcdReferralPromptDialog.java
@@ -1,52 +1,148 @@
 package org.smartregister.chw.custom_views;
 
 import android.app.Activity;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.RadioGroup;
+import android.widget.Spinner;
+import android.widget.TextView;
 
 import androidx.appcompat.app.AlertDialog;
 
 import org.smartregister.chw.R;
+import org.smartregister.chw.dao.TreatmentSupporterDao;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor;
 import org.smartregister.chw.interactor.NcdCaseManagementInteractor.PendingNcdReferral;
+import org.smartregister.chw.model.NcdReferralInputs;
 
 import java.util.List;
 
 /**
  * Confirmation prompt shown after an NCD Monthly Follow-Up visit is submitted and the
- * interactor has staged a {@link PendingNcdReferral}. The CHW sees the triggering reasons
- * and chooses to create the referral or skip it. Only the Confirm path invokes
+ * interactor has staged a {@link PendingNcdReferral}. The CHW sees the triggering reasons,
+ * confirms whether the case is an emergency, and reviews/edits the treatment supporter before
+ * the referral is created. Only the Confirm path invokes
  * {@code NcdReferralTaskHelper.createReferralIfNeeded(...)}; Skip leaves no event or task
  * behind (the visit itself is already persisted by the time this dialog is shown).
+ *
+ * <p>The supporter is prefilled from the registered caregiver but edited <em>for this referral
+ * only</em> — the dialog never writes back to the registration record.
  */
 public final class NcdReferralPromptDialog {
+
+    /**
+     * Relationship spinner options. Kept in sync with the
+     * {@code treatment_supporter_relationship} field on {@code ncd_referral_form.json} so the
+     * option keys emitted as obs match the manual referral path.
+     */
+    private static final String[] RELATIONSHIP_OPTIONS = {
+            "Mother", "Father", "Brother", "Sister", "Grandfather", "Grandmother", "Friend",
+            "Uncle", "Aunt", "Police", "Guardian", "Son", "Daughter", "Work Colleague",
+            "Brother in Law", "Sister in Law", "Wife", "Husband"
+    };
 
     private NcdReferralPromptDialog() {
         // utility
     }
 
     public interface Callbacks {
-        void onConfirm();
+        void onConfirm(NcdReferralInputs inputs);
+
         void onSkip();
     }
 
-    public static void show(Activity activity, PendingNcdReferral pending, Callbacks callbacks) {
+    public static void show(Activity activity, PendingNcdReferral pending,
+                            TreatmentSupporterDao.Caregiver caregiver, Callbacks callbacks) {
         if (activity == null || activity.isFinishing() || pending == null || callbacks == null) {
             if (callbacks != null) callbacks.onSkip();
             return;
         }
 
-        int titleRes = NcdCaseManagementInteractor.ALERT_RED.equals(pending.alertLevel)
+        boolean isRed = NcdCaseManagementInteractor.ALERT_RED.equals(pending.alertLevel);
+        int titleRes = isRed
                 ? R.string.ncd_referral_prompt_title_urgent
                 : R.string.ncd_referral_prompt_title_non_emergency;
 
+        View view = LayoutInflater.from(activity).inflate(R.layout.dialog_ncd_referral_prompt, null);
+
+        TextView reasonsView = view.findViewById(R.id.ncd_referral_reasons);
+        reasonsView.setText(buildMessage(activity, pending.reasons));
+
+        // Emergency defaults: Yes for red alerts, No for yellow. CHW can override.
+        RadioGroup emergencyGroup = view.findViewById(R.id.ncd_referral_emergency_group);
+        emergencyGroup.check(isRed ? R.id.ncd_referral_emergency_yes : R.id.ncd_referral_emergency_no);
+
+        // Treatment supporter: gate defaults to Yes when a caregiver is on record.
+        boolean hasCaregiver = caregiver != null && caregiver.isPresent();
+        RadioGroup supporterGroup = view.findViewById(R.id.ncd_referral_supporter_group);
+        View supporterDetails = view.findViewById(R.id.ncd_referral_supporter_details);
+        EditText nameView = view.findViewById(R.id.ncd_referral_supporter_name);
+        EditText phoneView = view.findViewById(R.id.ncd_referral_supporter_phone);
+        Spinner relationshipView = view.findViewById(R.id.ncd_referral_supporter_relationship);
+
+        ArrayAdapter<String> relationshipAdapter = new ArrayAdapter<>(activity,
+                android.R.layout.simple_spinner_item, RELATIONSHIP_OPTIONS);
+        relationshipAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        relationshipView.setAdapter(relationshipAdapter);
+
+        if (hasCaregiver) {
+            if (!TextUtils.isEmpty(caregiver.getName())) nameView.setText(caregiver.getName().trim());
+            if (!TextUtils.isEmpty(caregiver.getPhone())) phoneView.setText(caregiver.getPhone().trim());
+            int relIndex = relationshipIndex(caregiver.getRelationship());
+            if (relIndex >= 0) relationshipView.setSelection(relIndex);
+        }
+        supporterGroup.check(hasCaregiver ? R.id.ncd_referral_supporter_yes : R.id.ncd_referral_supporter_no);
+        supporterDetails.setVisibility(hasCaregiver ? View.VISIBLE : View.GONE);
+        supporterGroup.setOnCheckedChangeListener((group, checkedId) ->
+                supporterDetails.setVisibility(
+                        checkedId == R.id.ncd_referral_supporter_yes ? View.VISIBLE : View.GONE));
+
         new AlertDialog.Builder(activity)
                 .setTitle(titleRes)
-                .setMessage(buildMessage(activity, pending.reasons))
+                .setView(view)
                 .setCancelable(false)
                 .setNegativeButton(R.string.ncd_referral_prompt_button_skip,
                         (d, w) -> callbacks.onSkip())
                 .setPositiveButton(R.string.ncd_referral_prompt_button_create,
-                        (d, w) -> callbacks.onConfirm())
+                        (d, w) -> callbacks.onConfirm(collectInputs(
+                                emergencyGroup, supporterGroup, nameView, phoneView, relationshipView)))
                 .show();
+    }
+
+    private static NcdReferralInputs collectInputs(RadioGroup emergencyGroup, RadioGroup supporterGroup,
+                                                   EditText nameView, EditText phoneView,
+                                                   Spinner relationshipView) {
+        String isEmergency = emergencyGroup.getCheckedRadioButtonId() == R.id.ncd_referral_emergency_yes
+                ? "Yes" : "No";
+        boolean gateYes = supporterGroup.getCheckedRadioButtonId() == R.id.ncd_referral_supporter_yes;
+        if (!gateYes) {
+            return new NcdReferralInputs(isEmergency, "No", null, null, null);
+        }
+        String name = textOf(nameView);
+        String phone = textOf(phoneView);
+        String relationship = relationshipView.getSelectedItem() != null
+                ? relationshipView.getSelectedItem().toString() : null;
+        return new NcdReferralInputs(isEmergency, "Yes", name, phone, relationship);
+    }
+
+    private static String textOf(EditText editText) {
+        String value = editText.getText() != null ? editText.getText().toString().trim() : "";
+        return TextUtils.isEmpty(value) ? null : value;
+    }
+
+    private static int relationshipIndex(String relationship) {
+        if (TextUtils.isEmpty(relationship)) {
+            return -1;
+        }
+        for (int i = 0; i < RELATIONSHIP_OPTIONS.length; i++) {
+            if (RELATIONSHIP_OPTIONS[i].equalsIgnoreCase(relationship.trim())) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static CharSequence buildMessage(Activity activity, List<String> reasons) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
@@ -23,17 +23,32 @@ public class NcdReferralInputs {
     private final String supporterName;
     private final String supporterPhone;
     private final String supporterRelationship;
+    private final String referralFacilityId;
+    private final String referralFacilityName;
 
     public NcdReferralInputs(@Nullable String isEmergencyCase,
                              @Nullable String hasTreatmentSupporter,
                              @Nullable String supporterName,
                              @Nullable String supporterPhone,
                              @Nullable String supporterRelationship) {
+        this(isEmergencyCase, hasTreatmentSupporter, supporterName, supporterPhone,
+                supporterRelationship, null, null);
+    }
+
+    public NcdReferralInputs(@Nullable String isEmergencyCase,
+                             @Nullable String hasTreatmentSupporter,
+                             @Nullable String supporterName,
+                             @Nullable String supporterPhone,
+                             @Nullable String supporterRelationship,
+                             @Nullable String referralFacilityId,
+                             @Nullable String referralFacilityName) {
         this.isEmergencyCase = isEmergencyCase;
         this.hasTreatmentSupporter = hasTreatmentSupporter;
         this.supporterName = supporterName;
         this.supporterPhone = supporterPhone;
         this.supporterRelationship = supporterRelationship;
+        this.referralFacilityId = referralFacilityId;
+        this.referralFacilityName = referralFacilityName;
     }
 
     /** @return {@code "Yes"} / {@code "No"}, or {@code null} if not captured. */
@@ -66,5 +81,17 @@ public class NcdReferralInputs {
     /** @return whether the treatment-supporter gate is "Yes" (case-insensitive). */
     public boolean isTreatmentSupporterGateYes() {
         return "Yes".equalsIgnoreCase(hasTreatmentSupporter);
+    }
+
+    /** @return the selected referral facility's location id, or {@code null} if none was chosen. */
+    @Nullable
+    public String getReferralFacilityId() {
+        return referralFacilityId;
+    }
+
+    /** @return the selected referral facility's display name, or {@code null} if none was chosen. */
+    @Nullable
+    public String getReferralFacilityName() {
+        return referralFacilityName;
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
@@ -8,7 +8,7 @@ import androidx.annotation.Nullable;
  * {@code NcdReferralTaskHelper.createReferralIfNeeded(...)} so they can be emitted as obs on
  * the auto-generated Referral Registration event.
  *
- * <p>The supporter values are edited <em>for this referral only</em> — they are never written
+ * <p>The supporter values are edited <em>for this referral only</em>; they are never written
  * back to the client's registration record. {@link #hasTreatmentSupporter} acts as the gate:
  * when it is not {@code "Yes"}, the name/phone/relationship fields are ignored by the event
  * builder.
@@ -89,7 +89,9 @@ public class NcdReferralInputs {
         return referralFacilityId;
     }
 
-    /** @return the selected referral facility's display name, or {@code null} if none was chosen. */
+    /**
+     * @return the selected referral facility's display name, or {@code null} if none was chosen.
+     */
     @Nullable
     public String getReferralFacilityName() {
         return referralFacilityName;

--- a/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/model/NcdReferralInputs.java
@@ -1,0 +1,70 @@
+package org.smartregister.chw.model;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Immutable holder for the emergency-case and treatment-supporter values captured on the
+ * post-visit NCD referral prompt ({@code NcdReferralPromptDialog}) and carried into
+ * {@code NcdReferralTaskHelper.createReferralIfNeeded(...)} so they can be emitted as obs on
+ * the auto-generated Referral Registration event.
+ *
+ * <p>The supporter values are edited <em>for this referral only</em> — they are never written
+ * back to the client's registration record. {@link #hasTreatmentSupporter} acts as the gate:
+ * when it is not {@code "Yes"}, the name/phone/relationship fields are ignored by the event
+ * builder.
+ *
+ * <p>Values use the same {@code "Yes"}/{@code "No"} option keys as the spinners on
+ * {@code ncd_referral_form.json}.
+ */
+public class NcdReferralInputs {
+
+    private final String isEmergencyCase;
+    private final String hasTreatmentSupporter;
+    private final String supporterName;
+    private final String supporterPhone;
+    private final String supporterRelationship;
+
+    public NcdReferralInputs(@Nullable String isEmergencyCase,
+                             @Nullable String hasTreatmentSupporter,
+                             @Nullable String supporterName,
+                             @Nullable String supporterPhone,
+                             @Nullable String supporterRelationship) {
+        this.isEmergencyCase = isEmergencyCase;
+        this.hasTreatmentSupporter = hasTreatmentSupporter;
+        this.supporterName = supporterName;
+        this.supporterPhone = supporterPhone;
+        this.supporterRelationship = supporterRelationship;
+    }
+
+    /** @return {@code "Yes"} / {@code "No"}, or {@code null} if not captured. */
+    @Nullable
+    public String getIsEmergencyCase() {
+        return isEmergencyCase;
+    }
+
+    /** @return the gate value {@code "Yes"} / {@code "No"}, or {@code null} if not captured. */
+    @Nullable
+    public String getHasTreatmentSupporter() {
+        return hasTreatmentSupporter;
+    }
+
+    @Nullable
+    public String getSupporterName() {
+        return supporterName;
+    }
+
+    @Nullable
+    public String getSupporterPhone() {
+        return supporterPhone;
+    }
+
+    @Nullable
+    public String getSupporterRelationship() {
+        return supporterRelationship;
+    }
+
+    /** @return whether the treatment-supporter gate is "Yes" (case-insensitive). */
+    public boolean isTreatmentSupporterGateYes() {
+        return "Yes".equalsIgnoreCase(hasTreatmentSupporter);
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -79,7 +79,8 @@ public class Constants extends CoreConstants {
         public static final String FOCUS_NCD_DANGER_SIGNS = "NCD Danger Signs";
         public static final String FOCUS_NCD_CLINICAL_CONCERN = "NCD Clinical Concern";
         // Coded problem keys used as a fallback when no specific reason was captured,
-        // so the referral event's "problem" obs still carries a key alongside its human-readable value.
+        // so the referral event's "problem" obs still carries a key alongside its
+        // human-readable value.
         public static final String PROBLEM_KEY_DANGER_SIGNS = "ncd_danger_signs";
         public static final String PROBLEM_KEY_CLINICAL_CONCERN = "ncd_clinical_concern";
         // Concept keys for the emergency-case and treatment-supporter obs captured on the
@@ -89,7 +90,8 @@ public class Constants extends CoreConstants {
         public static final String HAS_TREATMENT_SUPPORTER = "has_treatment_supporter";
         public static final String TREATMENT_SUPPORTER_NAME = "treatment_supporter_name";
         public static final String TREATMENT_SUPPORTER_PHONE = "treatment_supporter_phone";
-        public static final String TREATMENT_SUPPORTER_RELATIONSHIP = "treatment_supporter_relationship";
+        public static final String TREATMENT_SUPPORTER_RELATIONSHIP =
+                "treatment_supporter_relationship";
     }
 
     public static class ChildIllnessViewType {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/Constants.java
@@ -82,6 +82,14 @@ public class Constants extends CoreConstants {
         // so the referral event's "problem" obs still carries a key alongside its human-readable value.
         public static final String PROBLEM_KEY_DANGER_SIGNS = "ncd_danger_signs";
         public static final String PROBLEM_KEY_CLINICAL_CONCERN = "ncd_clinical_concern";
+        // Concept keys for the emergency-case and treatment-supporter obs captured on the
+        // post-visit referral prompt and emitted on the auto-generated Referral Registration
+        // event (mirrors the fields on ncd_referral_form.json).
+        public static final String IS_EMERGENCY_CASE = "is_emergency_case";
+        public static final String HAS_TREATMENT_SUPPORTER = "has_treatment_supporter";
+        public static final String TREATMENT_SUPPORTER_NAME = "treatment_supporter_name";
+        public static final String TREATMENT_SUPPORTER_PHONE = "treatment_supporter_phone";
+        public static final String TREATMENT_SUPPORTER_RELATIONSHIP = "treatment_supporter_relationship";
     }
 
     public static class ChildIllnessViewType {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
@@ -7,6 +7,7 @@ import org.smartregister.chw.anc.util.NCUtils;
 import org.smartregister.chw.core.application.CoreChwApplication;
 import org.smartregister.chw.core.utils.CoreConstants;
 import org.smartregister.chw.dao.NcdCaseManagementDao;
+import org.smartregister.chw.model.NcdReferralInputs;
 import org.smartregister.chw.referral.util.DBConstants;
 import org.smartregister.clientandeventmodel.Event;
 import org.smartregister.clientandeventmodel.Obs;
@@ -46,6 +47,17 @@ public class NcdReferralTaskHelper {
     }
 
     /**
+     * Backward-compatible overload that creates a referral with no emergency/treatment-supporter
+     * details captured. Equivalent to passing {@code null} inputs.
+     */
+    public static boolean createReferralIfNeeded(String baseEntityId, String triggeringFormSubmissionId,
+                                                  String alertStatus, String description,
+                                                  List<String> problemKeys, List<String> problemHumanReadableValues) {
+        return createReferralIfNeeded(baseEntityId, triggeringFormSubmissionId, alertStatus,
+                description, problemKeys, problemHumanReadableValues, null);
+    }
+
+    /**
      * Creates a Referral Registration event and a linked task if no open referral exists.
      *
      * @param baseEntityId             client ID
@@ -54,11 +66,13 @@ public class NcdReferralTaskHelper {
      * @param description              human-readable description of the referral reason (kept on the task)
      * @param problemKeys              coded concept keys for each problem; persisted as the "problem" obs values
      * @param problemHumanReadableValues human-readable label per problem; persisted as the obs humanReadableValues (parallel to problemKeys)
+     * @param inputs                   emergency-case + treatment-supporter values captured on the prompt; may be {@code null}
      * @return true if a referral was created, false if skipped
      */
     public static boolean createReferralIfNeeded(String baseEntityId, String triggeringFormSubmissionId,
                                                   String alertStatus, String description,
-                                                  List<String> problemKeys, List<String> problemHumanReadableValues) {
+                                                  List<String> problemKeys, List<String> problemHumanReadableValues,
+                                                  NcdReferralInputs inputs) {
         if (!"red".equals(alertStatus) && !"yellow".equals(alertStatus)) {
             return false;
         }
@@ -98,7 +112,7 @@ public class NcdReferralTaskHelper {
             problemReadable.add(description);
         }
 
-        Event referralEvent = buildAndPersistReferralEvent(baseEntityId, focus, problemValues, problemReadable);
+        Event referralEvent = buildAndPersistReferralEvent(baseEntityId, focus, problemValues, problemReadable, inputs);
         if (referralEvent == null) {
             Timber.e("NCD referral event could not be persisted for %s — skipping task creation", baseEntityId);
             return false;
@@ -116,7 +130,8 @@ public class NcdReferralTaskHelper {
      * formSubmissionId as the task's reasonReference.
      */
     private static Event buildAndPersistReferralEvent(String baseEntityId, String referralService,
-                                                      List<String> problemValues, List<String> problemHumanReadableValues) {
+                                                      List<String> problemValues, List<String> problemHumanReadableValues,
+                                                      NcdReferralInputs inputs) {
         AllSharedPreferences sharedPreferences = org.smartregister.util.Utils.getAllSharedPreferences();
         String providerId = sharedPreferences.fetchRegisteredANM();
         String locationId = sharedPreferences.fetchDefaultLocalityId(providerId);
@@ -198,6 +213,8 @@ public class NcdReferralTaskHelper {
                 .withFieldCode(DBConstants.Key.REFERRAL_HF)
                 .withValue(locationId));
 
+        addReferralInputObs(event, inputs);
+
         try {
             org.smartregister.chw.util.JsonFormUtils.tagSyncMetadata(sharedPreferences, event);
             NCUtils.processEvent(event.getBaseEntityId(),
@@ -209,6 +226,38 @@ public class NcdReferralTaskHelper {
         }
     }
 
+    /**
+     * Appends the emergency-case and treatment-supporter obs captured on the post-visit prompt.
+     * {@code is_emergency_case} and {@code has_treatment_supporter} are always written when
+     * present; the name/phone/relationship details are written only when the supporter gate is
+     * "Yes" and the value is non-blank — mirroring the manual referral form's behaviour. No-op
+     * when {@code inputs} is null.
+     */
+    @androidx.annotation.VisibleForTesting
+    static void addReferralInputObs(Event event, NcdReferralInputs inputs) {
+        if (inputs == null) {
+            return;
+        }
+        addConceptObs(event, Constants.NcdReferral.IS_EMERGENCY_CASE, inputs.getIsEmergencyCase());
+        addConceptObs(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER, inputs.getHasTreatmentSupporter());
+        if (inputs.isTreatmentSupporterGateYes()) {
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME, inputs.getSupporterName());
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE, inputs.getSupporterPhone());
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP, inputs.getSupporterRelationship());
+        }
+    }
+
+    private static void addConceptObs(Event event, String conceptKey, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return;
+        }
+        event.addObs(new Obs()
+                .withFormSubmissionField(conceptKey)
+                .withFieldType(JsonFormUtils.CONCEPT)
+                .withFieldCode(conceptKey)
+                .withValue(value.trim()));
+    }
+
     private static void createTask(String baseEntityId, String referralEventFormSubmissionId,
                                    String taskCode, String focus, String description, int priority) {
         AllSharedPreferences sharedPreferences = org.smartregister.util.Utils.getAllSharedPreferences();
@@ -216,6 +265,7 @@ public class NcdReferralTaskHelper {
         Task task = new Task();
         task.setIdentifier(UUID.randomUUID().toString());
         task.setPlanIdentifier(CoreConstants.REFERRAL_PLAN_ID);
+        // change this to selected facility we might need to include facility selection on the new dialog
         task.setGroupIdentifier(
                 sharedPreferences.fetchUserLocalityId(sharedPreferences.fetchRegisteredANM()));
         task.setStatus(Task.TaskStatus.READY);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
@@ -118,7 +118,9 @@ public class NcdReferralTaskHelper {
             return false;
         }
 
-        createTask(baseEntityId, referralEvent.getFormSubmissionId(), taskCode, focus, description, priority);
+        String referralFacilityId = inputs != null ? inputs.getReferralFacilityId() : null;
+        createTask(baseEntityId, referralEvent.getFormSubmissionId(), taskCode, focus, description,
+                priority, referralFacilityId);
         return true;
     }
 
@@ -207,11 +209,7 @@ public class NcdReferralTaskHelper {
                 .withFieldCode(DBConstants.Key.REFERRAL_APPOINTMENT_DATE)
                 .withValue(now.getTime()));
 
-        event.addObs(new Obs()
-                .withFormSubmissionField(DBConstants.Key.REFERRAL_HF)
-                .withFieldType(JsonFormUtils.CONCEPT)
-                .withFieldCode(DBConstants.Key.REFERRAL_HF)
-                .withValue(locationId));
+        event.addObs(buildReferralHfObs(inputs, locationId));
 
         addReferralInputObs(event, inputs);
 
@@ -247,6 +245,50 @@ public class NcdReferralTaskHelper {
         }
     }
 
+    /**
+     * Builds the {@code chw_referral_hf} obs. The value is the CHW-selected referral facility's
+     * location id (falling back to the CHW's locality when none was captured), and the facility
+     * name is attached as the humanReadableValue so register/detail views can display it without a
+     * second lookup.
+     */
+    @androidx.annotation.VisibleForTesting
+    static Obs buildReferralHfObs(NcdReferralInputs inputs, String fallbackLocationId) {
+        Obs obs = new Obs()
+                .withFormSubmissionField(DBConstants.Key.REFERRAL_HF)
+                .withFieldType(JsonFormUtils.CONCEPT)
+                .withFieldCode(DBConstants.Key.REFERRAL_HF)
+                .withValue(referralFacilityId(inputs, fallbackLocationId));
+        if (inputs != null && isNotBlank(inputs.getReferralFacilityName())) {
+            obs.withHumanReadableValues(new ArrayList<Object>(
+                    java.util.Collections.singletonList(inputs.getReferralFacilityName().trim())));
+        }
+        return obs;
+    }
+
+    /**
+     * Resolves the referral facility's location id from the captured inputs, falling back to the
+     * CHW's locality id when no facility was selected (preserving the pre-facility behaviour).
+     */
+    private static String referralFacilityId(NcdReferralInputs inputs, String fallbackLocationId) {
+        if (inputs != null && isNotBlank(inputs.getReferralFacilityId())) {
+            return inputs.getReferralFacilityId().trim();
+        }
+        return fallbackLocationId;
+    }
+
+    /**
+     * The task groupIdentifier: the selected facility's location id, or the CHW's locality id when
+     * no facility was captured.
+     */
+    @androidx.annotation.VisibleForTesting
+    static String resolveGroupIdentifier(String referralFacilityId, String fallbackLocalityId) {
+        return isNotBlank(referralFacilityId) ? referralFacilityId.trim() : fallbackLocalityId;
+    }
+
+    private static boolean isNotBlank(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
     private static void addConceptObs(Event event, String conceptKey, String value) {
         if (value == null || value.trim().isEmpty()) {
             return;
@@ -259,15 +301,17 @@ public class NcdReferralTaskHelper {
     }
 
     private static void createTask(String baseEntityId, String referralEventFormSubmissionId,
-                                   String taskCode, String focus, String description, int priority) {
+                                   String taskCode, String focus, String description, int priority,
+                                   String referralFacilityId) {
         AllSharedPreferences sharedPreferences = org.smartregister.util.Utils.getAllSharedPreferences();
 
         Task task = new Task();
         task.setIdentifier(UUID.randomUUID().toString());
         task.setPlanIdentifier(CoreConstants.REFERRAL_PLAN_ID);
-        // change this to selected facility we might need to include facility selection on the new dialog
-        task.setGroupIdentifier(
-                sharedPreferences.fetchUserLocalityId(sharedPreferences.fetchRegisteredANM()));
+        // Group the task by the CHW-selected referral facility (its location id), falling back to
+        // the CHW's own locality when no facility was captured.
+        task.setGroupIdentifier(resolveGroupIdentifier(referralFacilityId,
+                sharedPreferences.fetchUserLocalityId(sharedPreferences.fetchRegisteredANM())));
         task.setStatus(Task.TaskStatus.READY);
         task.setBusinessStatus(CoreConstants.BUSINESS_STATUS.REFERRED);
         task.setPriority(priority);

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/NcdReferralTaskHelper.java
@@ -33,7 +33,7 @@ import timber.log.Timber;
  *   2. A Task in ec_tasks whose reasonReference points to that event's formSubmissionId
  *
  * Phase 1 originally only created the task and passed the NCD case-management visit's
- * formSubmissionId as reasonReference — which left the referral orphaned from any
+ * formSubmissionId as reasonReference, which left the referral orphaned from any
  * Referral Registration event. This helper now creates the event first, persists it,
  * and uses its formSubmissionId to link the task.
  *
@@ -50,9 +50,11 @@ public class NcdReferralTaskHelper {
      * Backward-compatible overload that creates a referral with no emergency/treatment-supporter
      * details captured. Equivalent to passing {@code null} inputs.
      */
-    public static boolean createReferralIfNeeded(String baseEntityId, String triggeringFormSubmissionId,
+    public static boolean createReferralIfNeeded(String baseEntityId,
+                                                  String triggeringFormSubmissionId,
                                                   String alertStatus, String description,
-                                                  List<String> problemKeys, List<String> problemHumanReadableValues) {
+                                                  List<String> problemKeys,
+                                                  List<String> problemHumanReadableValues) {
         return createReferralIfNeeded(baseEntityId, triggeringFormSubmissionId, alertStatus,
                 description, problemKeys, problemHumanReadableValues, null);
     }
@@ -60,25 +62,27 @@ public class NcdReferralTaskHelper {
     /**
      * Creates a Referral Registration event and a linked task if no open referral exists.
      *
-     * @param baseEntityId             client ID
-     * @param triggeringFormSubmissionId form submission of the case-management visit that triggered this referral (optional context, not used for reasonReference)
-     * @param alertStatus              "red" or "yellow"
-     * @param description              human-readable description of the referral reason (kept on the task)
-     * @param problemKeys              coded concept keys for each problem; persisted as the "problem" obs values
-     * @param problemHumanReadableValues human-readable label per problem; persisted as the obs humanReadableValues (parallel to problemKeys)
-     * @param inputs                   emergency-case + treatment-supporter values captured on the prompt; may be {@code null}
+     * @param baseEntityId client ID
+     * @param triggeringFormSubmissionId case-management visit form submission; optional context
+     * @param alertStatus "red" or "yellow"
+     * @param description human-readable referral reason kept on the task
+     * @param problemKeys coded concept keys persisted as the "problem" obs values
+     * @param problemHumanReadableValues labels persisted as matching obs humanReadableValues
+     * @param inputs emergency-case and treatment-supporter prompt values; may be {@code null}
      * @return true if a referral was created, false if skipped
      */
-    public static boolean createReferralIfNeeded(String baseEntityId, String triggeringFormSubmissionId,
+    public static boolean createReferralIfNeeded(String baseEntityId,
+                                                  String triggeringFormSubmissionId,
                                                   String alertStatus, String description,
-                                                  List<String> problemKeys, List<String> problemHumanReadableValues,
+                                                  List<String> problemKeys,
+                                                  List<String> problemHumanReadableValues,
                                                   NcdReferralInputs inputs) {
         if (!"red".equals(alertStatus) && !"yellow".equals(alertStatus)) {
             return false;
         }
 
         if (NcdCaseManagementDao.hasOpenReferral(baseEntityId)) {
-            Timber.d("NCD referral skipped — open referral already exists for %s", baseEntityId);
+            Timber.d("NCD referral skipped; open referral already exists for %s", baseEntityId);
             return false;
         }
 
@@ -112,9 +116,11 @@ public class NcdReferralTaskHelper {
             problemReadable.add(description);
         }
 
-        Event referralEvent = buildAndPersistReferralEvent(baseEntityId, focus, problemValues, problemReadable, inputs);
+        Event referralEvent = buildAndPersistReferralEvent(baseEntityId, focus, problemValues,
+                problemReadable, inputs);
         if (referralEvent == null) {
-            Timber.e("NCD referral event could not be persisted for %s — skipping task creation", baseEntityId);
+            Timber.e("NCD referral event could not be persisted for %s; skipping task creation",
+                    baseEntityId);
             return false;
         }
 
@@ -132,9 +138,11 @@ public class NcdReferralTaskHelper {
      * formSubmissionId as the task's reasonReference.
      */
     private static Event buildAndPersistReferralEvent(String baseEntityId, String referralService,
-                                                      List<String> problemValues, List<String> problemHumanReadableValues,
+                                                      List<String> problemValues,
+                                                      List<String> problemHumanReadableValues,
                                                       NcdReferralInputs inputs) {
-        AllSharedPreferences sharedPreferences = org.smartregister.util.Utils.getAllSharedPreferences();
+        AllSharedPreferences sharedPreferences =
+                org.smartregister.util.Utils.getAllSharedPreferences();
         String providerId = sharedPreferences.fetchRegisteredANM();
         String locationId = sharedPreferences.fetchDefaultLocalityId(providerId);
         String teamId = sharedPreferences.fetchDefaultTeamId(providerId);
@@ -187,7 +195,8 @@ public class NcdReferralTaskHelper {
                 .withFormSubmissionField(DBConstants.Key.REFERRAL_TYPE)
                 .withFieldType(JsonFormUtils.CONCEPT)
                 .withFieldCode(DBConstants.Key.REFERRAL_TYPE)
-                .withValue(org.smartregister.chw.referral.util.Constants.ReferralType.COMMUNITY_TO_FACILITY_REFERRAL));
+                .withValue(org.smartregister.chw.referral.util.Constants.ReferralType
+                        .COMMUNITY_TO_FACILITY_REFERRAL));
 
         Date now = new Date();
         event.addObs(new Obs()
@@ -216,7 +225,8 @@ public class NcdReferralTaskHelper {
         try {
             org.smartregister.chw.util.JsonFormUtils.tagSyncMetadata(sharedPreferences, event);
             NCUtils.processEvent(event.getBaseEntityId(),
-                    new JSONObject(org.smartregister.chw.anc.util.JsonFormUtils.gson.toJson(event)));
+                    new JSONObject(
+                            org.smartregister.chw.anc.util.JsonFormUtils.gson.toJson(event)));
             return event;
         } catch (Exception e) {
             Timber.e(e, "Failed to persist NCD Referral Registration event for %s", baseEntityId);
@@ -228,7 +238,7 @@ public class NcdReferralTaskHelper {
      * Appends the emergency-case and treatment-supporter obs captured on the post-visit prompt.
      * {@code is_emergency_case} and {@code has_treatment_supporter} are always written when
      * present; the name/phone/relationship details are written only when the supporter gate is
-     * "Yes" and the value is non-blank — mirroring the manual referral form's behaviour. No-op
+     * "Yes" and the value is non-blank, mirroring the manual referral form's behaviour. No-op
      * when {@code inputs} is null.
      */
     @androidx.annotation.VisibleForTesting
@@ -237,11 +247,15 @@ public class NcdReferralTaskHelper {
             return;
         }
         addConceptObs(event, Constants.NcdReferral.IS_EMERGENCY_CASE, inputs.getIsEmergencyCase());
-        addConceptObs(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER, inputs.getHasTreatmentSupporter());
+        addConceptObs(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER,
+                inputs.getHasTreatmentSupporter());
         if (inputs.isTreatmentSupporterGateYes()) {
-            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME, inputs.getSupporterName());
-            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE, inputs.getSupporterPhone());
-            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP, inputs.getSupporterRelationship());
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME,
+                    inputs.getSupporterName());
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE,
+                    inputs.getSupporterPhone());
+            addConceptObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP,
+                    inputs.getSupporterRelationship());
         }
     }
 
@@ -282,7 +296,10 @@ public class NcdReferralTaskHelper {
      */
     @androidx.annotation.VisibleForTesting
     static String resolveGroupIdentifier(String referralFacilityId, String fallbackLocalityId) {
-        return isNotBlank(referralFacilityId) ? referralFacilityId.trim() : fallbackLocalityId;
+        if (isNotBlank(referralFacilityId)) {
+            return referralFacilityId.trim();
+        }
+        return fallbackLocalityId;
     }
 
     private static boolean isNotBlank(String value) {
@@ -303,7 +320,8 @@ public class NcdReferralTaskHelper {
     private static void createTask(String baseEntityId, String referralEventFormSubmissionId,
                                    String taskCode, String focus, String description, int priority,
                                    String referralFacilityId) {
-        AllSharedPreferences sharedPreferences = org.smartregister.util.Utils.getAllSharedPreferences();
+        AllSharedPreferences sharedPreferences =
+                org.smartregister.util.Utils.getAllSharedPreferences();
 
         Task task = new Task();
         task.setIdentifier(UUID.randomUUID().toString());

--- a/opensrp-chw/src/main/res/layout/dialog_ncd_referral_prompt.xml
+++ b/opensrp-chw/src/main/res/layout/dialog_ncd_referral_prompt.xml
@@ -137,6 +137,23 @@
                 android:minHeight="48dp" />
         </LinearLayout>
 
+        <!-- Referral facility (required) -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/ncd_referral_prompt_facility_label"
+            android:textColor="@color/primary"
+            android:textStyle="bold"
+            android:textSize="15sp" />
+
+        <Spinner
+            android:id="@+id/ncd_referral_facility"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:minHeight="48dp" />
+
     </LinearLayout>
 
 </ScrollView>

--- a/opensrp-chw/src/main/res/layout/dialog_ncd_referral_prompt.xml
+++ b/opensrp-chw/src/main/res/layout/dialog_ncd_referral_prompt.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="24dp"
+        android:paddingRight="24dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="8dp">
+
+        <!-- Body + bulleted triggering reasons, populated programmatically -->
+        <TextView
+            android:id="@+id/ncd_referral_reasons"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/medical_text_inner"
+            android:textSize="14sp" />
+
+        <!-- Emergency case -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/ncd_referral_prompt_emergency_question"
+            android:textColor="@color/primary"
+            android:textStyle="bold"
+            android:textSize="15sp" />
+
+        <RadioGroup
+            android:id="@+id/ncd_referral_emergency_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/ncd_referral_emergency_yes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                android:minHeight="48dp"
+                android:text="@string/yes"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+
+            <RadioButton
+                android:id="@+id/ncd_referral_emergency_no"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:text="@string/no"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+        </RadioGroup>
+
+        <!-- Treatment supporter -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/ncd_referral_prompt_supporter_question"
+            android:textColor="@color/primary"
+            android:textStyle="bold"
+            android:textSize="15sp" />
+
+        <RadioGroup
+            android:id="@+id/ncd_referral_supporter_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:id="@+id/ncd_referral_supporter_yes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
+                android:minHeight="48dp"
+                android:text="@string/yes"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+
+            <RadioButton
+                android:id="@+id/ncd_referral_supporter_no"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:text="@string/no"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+        </RadioGroup>
+
+        <!-- Supporter detail block; visibility toggled by the gate above -->
+        <LinearLayout
+            android:id="@+id/ncd_referral_supporter_details"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <EditText
+                android:id="@+id/ncd_referral_supporter_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/ncd_referral_prompt_supporter_name_hint"
+                android:inputType="textPersonName|textCapWords"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+
+            <EditText
+                android:id="@+id/ncd_referral_supporter_phone"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/ncd_referral_prompt_supporter_phone_hint"
+                android:inputType="phone"
+                android:textColor="@color/medical_text_inner"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/ncd_referral_prompt_supporter_relationship_label"
+                android:textColor="@color/grey"
+                android:textSize="13sp" />
+
+            <Spinner
+                android:id="@+id/ncd_referral_supporter_relationship"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:minHeight="48dp" />
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -757,6 +757,10 @@
     <string name="ncd_referral_prompt_supporter_name_hint">Jina la msaidizi</string>
     <string name="ncd_referral_prompt_supporter_phone_hint">Simu ya msaidizi</string>
     <string name="ncd_referral_prompt_supporter_relationship_label">Uhusiano na mteja</string>
+    <string name="ncd_referral_prompt_facility_label">Kituo cha rufaa</string>
+    <string name="ncd_referral_prompt_facility_hint">Chagua kituo cha rufaa</string>
+    <string name="ncd_referral_prompt_facility_required">Tafadhali chagua kituo cha rufaa</string>
+    <string name="ncd_referral_already_open">Tayari kuna rufaa iliyo wazi kwa mteja huyu</string>
     <string name="hps_high_bp_detected">Shinikizo la damu lililoinuka limegunduliwa</string>
     <string name="hps_screen_for_diabetes">Pima Kisukari</string>
     <string name="ncd_referral_reason_high_bp">Shinikizo la damu lililoinuka</string>

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -752,6 +752,11 @@
     <string name="ncd_referral_prompt_body">Mteja huyu anaonyesha dalili zinazohitaji kushughulikiwa:</string>
     <string name="ncd_referral_prompt_button_create">Tengeneza rufaa</string>
     <string name="ncd_referral_prompt_button_skip">Ruka</string>
+    <string name="ncd_referral_prompt_emergency_question">Je, hii ni kesi ya dharura?</string>
+    <string name="ncd_referral_prompt_supporter_question">Msaidizi wa matibabu</string>
+    <string name="ncd_referral_prompt_supporter_name_hint">Jina la msaidizi</string>
+    <string name="ncd_referral_prompt_supporter_phone_hint">Simu ya msaidizi</string>
+    <string name="ncd_referral_prompt_supporter_relationship_label">Uhusiano na mteja</string>
     <string name="hps_high_bp_detected">Shinikizo la damu lililoinuka limegunduliwa</string>
     <string name="hps_screen_for_diabetes">Pima Kisukari</string>
     <string name="ncd_referral_reason_high_bp">Shinikizo la damu lililoinuka</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -724,6 +724,11 @@
     <string name="ncd_referral_prompt_body">This client shows signs that need attention:</string>
     <string name="ncd_referral_prompt_button_create">Create referral</string>
     <string name="ncd_referral_prompt_button_skip">Skip</string>
+    <string name="ncd_referral_prompt_emergency_question">Is this an emergency case?</string>
+    <string name="ncd_referral_prompt_supporter_question">Treatment supporter</string>
+    <string name="ncd_referral_prompt_supporter_name_hint">Supporter name</string>
+    <string name="ncd_referral_prompt_supporter_phone_hint">Supporter phone</string>
+    <string name="ncd_referral_prompt_supporter_relationship_label">Relationship to client</string>
     <string name="hps_high_bp_detected">Elevated blood pressure detected</string>
     <string name="hps_screen_for_diabetes">Screen for Diabetes</string>
     <string name="ncd_referral_reason_high_bp">Elevated blood pressure</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -729,6 +729,10 @@
     <string name="ncd_referral_prompt_supporter_name_hint">Supporter name</string>
     <string name="ncd_referral_prompt_supporter_phone_hint">Supporter phone</string>
     <string name="ncd_referral_prompt_supporter_relationship_label">Relationship to client</string>
+    <string name="ncd_referral_prompt_facility_label">Referral facility</string>
+    <string name="ncd_referral_prompt_facility_hint">Choose referral facility</string>
+    <string name="ncd_referral_prompt_facility_required">Please select a referral facility</string>
+    <string name="ncd_referral_already_open">An open referral already exists for this client</string>
     <string name="hps_high_bp_detected">Elevated blood pressure detected</string>
     <string name="hps_screen_for_diabetes">Screen for Diabetes</string>
     <string name="ncd_referral_reason_high_bp">Elevated blood pressure</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/model/NcdReferralInputsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/model/NcdReferralInputsTest.java
@@ -32,4 +32,21 @@ public class NcdReferralInputsTest {
         Assert.assertFalse(new NcdReferralInputs("Yes", null, null, null, null)
                 .isTreatmentSupporterGateYes());
     }
+
+    @Test
+    public void facilityGettersReturnSuppliedValues() {
+        NcdReferralInputs inputs = new NcdReferralInputs(
+                "Yes", "No", null, null, null, "facility-123", "Sinza Hospital");
+
+        Assert.assertEquals("facility-123", inputs.getReferralFacilityId());
+        Assert.assertEquals("Sinza Hospital", inputs.getReferralFacilityName());
+    }
+
+    @Test
+    public void facilityIsNullViaFiveArgConstructor() {
+        NcdReferralInputs inputs = new NcdReferralInputs("Yes", "No", null, null, null);
+
+        Assert.assertNull(inputs.getReferralFacilityId());
+        Assert.assertNull(inputs.getReferralFacilityName());
+    }
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/model/NcdReferralInputsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/model/NcdReferralInputsTest.java
@@ -1,0 +1,35 @@
+package org.smartregister.chw.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NcdReferralInputsTest {
+
+    @Test
+    public void gettersReturnSuppliedValues() {
+        NcdReferralInputs inputs = new NcdReferralInputs(
+                "Yes", "Yes", "Chausiku Kibange", "0788994488", "Friend");
+
+        Assert.assertEquals("Yes", inputs.getIsEmergencyCase());
+        Assert.assertEquals("Yes", inputs.getHasTreatmentSupporter());
+        Assert.assertEquals("Chausiku Kibange", inputs.getSupporterName());
+        Assert.assertEquals("0788994488", inputs.getSupporterPhone());
+        Assert.assertEquals("Friend", inputs.getSupporterRelationship());
+    }
+
+    @Test
+    public void gateYesIsCaseInsensitive() {
+        Assert.assertTrue(new NcdReferralInputs("No", "Yes", null, null, null)
+                .isTreatmentSupporterGateYes());
+        Assert.assertTrue(new NcdReferralInputs("No", "yes", null, null, null)
+                .isTreatmentSupporterGateYes());
+    }
+
+    @Test
+    public void gateNotYesWhenNoOrNull() {
+        Assert.assertFalse(new NcdReferralInputs("Yes", "No", null, null, null)
+                .isTreatmentSupporterGateYes());
+        Assert.assertFalse(new NcdReferralInputs("Yes", null, null, null, null)
+                .isTreatmentSupporterGateYes());
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
@@ -85,4 +85,39 @@ public class NcdReferralTaskHelperTest {
         Assert.assertEquals("Jane Doe", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
         Assert.assertEquals("0788", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
     }
+
+    @Test
+    public void referralHfObsUsesSelectedFacilityIdAndName() {
+        NcdReferralInputs inputs = new NcdReferralInputs(
+                "Yes", "No", null, null, null, "facility-123", "Sinza Hospital");
+
+        Obs obs = NcdReferralTaskHelper.buildReferralHfObs(inputs, "chw-locality");
+
+        Assert.assertEquals("chw_referral_hf", obs.getFieldCode());
+        Assert.assertEquals("facility-123", obs.getValue());
+        Assert.assertNotNull(obs.getHumanReadableValues());
+        Assert.assertEquals("Sinza Hospital", obs.getHumanReadableValues().get(0));
+    }
+
+    @Test
+    public void referralHfObsFallsBackToLocalityWhenNoFacility() {
+        Obs nullInputs = NcdReferralTaskHelper.buildReferralHfObs(null, "chw-locality");
+        Assert.assertEquals("chw-locality", nullInputs.getValue());
+        Assert.assertTrue(nullInputs.getHumanReadableValues() == null
+                || nullInputs.getHumanReadableValues().isEmpty());
+
+        Obs blankFacility = NcdReferralTaskHelper.buildReferralHfObs(
+                new NcdReferralInputs("Yes", "No", null, null, null, "  ", null), "chw-locality");
+        Assert.assertEquals("chw-locality", blankFacility.getValue());
+    }
+
+    @Test
+    public void groupIdentifierPrefersFacilityThenFallsBack() {
+        Assert.assertEquals("facility-123",
+                NcdReferralTaskHelper.resolveGroupIdentifier("  facility-123  ", "chw-locality"));
+        Assert.assertEquals("chw-locality",
+                NcdReferralTaskHelper.resolveGroupIdentifier(null, "chw-locality"));
+        Assert.assertEquals("chw-locality",
+                NcdReferralTaskHelper.resolveGroupIdentifier("   ", "chw-locality"));
+    }
 }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
@@ -1,0 +1,88 @@
+package org.smartregister.chw.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.smartregister.chw.model.NcdReferralInputs;
+import org.smartregister.clientandeventmodel.Event;
+import org.smartregister.clientandeventmodel.Obs;
+
+/**
+ * Unit tests for the emergency-case / treatment-supporter obs emission added to the
+ * auto-generated Referral Registration event by
+ * {@link NcdReferralTaskHelper#addReferralInputObs(Event, NcdReferralInputs)}.
+ */
+public class NcdReferralTaskHelperTest {
+
+    private static String obsValue(Event event, String fieldCode) {
+        for (Obs obs : event.getObs()) {
+            if (fieldCode.equals(obs.getFieldCode())) {
+                return obs.getValue() == null ? null : String.valueOf(obs.getValue());
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasObs(Event event, String fieldCode) {
+        for (Obs obs : event.getObs()) {
+            if (fieldCode.equals(obs.getFieldCode())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void nullInputsEmitsNoObs() {
+        Event event = new Event();
+        NcdReferralTaskHelper.addReferralInputObs(event, null);
+        Assert.assertTrue(event.getObs() == null || event.getObs().isEmpty());
+    }
+
+    @Test
+    public void gateYesEmitsEmergencyAndAllSupporterDetails() {
+        Event event = new Event();
+        NcdReferralTaskHelper.addReferralInputObs(event,
+                new NcdReferralInputs("Yes", "Yes", "Chausiku Kibange", "0788994488", "Friend"));
+
+        Assert.assertEquals("Yes", obsValue(event, Constants.NcdReferral.IS_EMERGENCY_CASE));
+        Assert.assertEquals("Yes", obsValue(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER));
+        Assert.assertEquals("Chausiku Kibange", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertEquals("0788994488", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+        Assert.assertEquals("Friend", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP));
+    }
+
+    @Test
+    public void gateNoOmitsSupporterDetailsButKeepsGateAndEmergency() {
+        Event event = new Event();
+        NcdReferralTaskHelper.addReferralInputObs(event,
+                new NcdReferralInputs("No", "No", "Someone", "0700000000", "Friend"));
+
+        Assert.assertEquals("No", obsValue(event, Constants.NcdReferral.IS_EMERGENCY_CASE));
+        Assert.assertEquals("No", obsValue(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP));
+    }
+
+    @Test
+    public void blankSupporterDetailsAreSkippedWhenGateYes() {
+        Event event = new Event();
+        NcdReferralTaskHelper.addReferralInputObs(event,
+                new NcdReferralInputs("Yes", "Yes", "  ", null, ""));
+
+        Assert.assertTrue(hasObs(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+        Assert.assertFalse(hasObs(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP));
+    }
+
+    @Test
+    public void valuesAreTrimmed() {
+        Event event = new Event();
+        NcdReferralTaskHelper.addReferralInputObs(event,
+                new NcdReferralInputs("Yes", "Yes", "  Jane Doe  ", "  0788  ", "Mother"));
+
+        Assert.assertEquals("Jane Doe", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertEquals("0788", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/NcdReferralTaskHelperTest.java
@@ -16,7 +16,10 @@ public class NcdReferralTaskHelperTest {
     private static String obsValue(Event event, String fieldCode) {
         for (Obs obs : event.getObs()) {
             if (fieldCode.equals(obs.getFieldCode())) {
-                return obs.getValue() == null ? null : String.valueOf(obs.getValue());
+                if (obs.getValue() == null) {
+                    return null;
+                }
+                return String.valueOf(obs.getValue());
             }
         }
         return null;
@@ -46,9 +49,12 @@ public class NcdReferralTaskHelperTest {
 
         Assert.assertEquals("Yes", obsValue(event, Constants.NcdReferral.IS_EMERGENCY_CASE));
         Assert.assertEquals("Yes", obsValue(event, Constants.NcdReferral.HAS_TREATMENT_SUPPORTER));
-        Assert.assertEquals("Chausiku Kibange", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
-        Assert.assertEquals("0788994488", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
-        Assert.assertEquals("Friend", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP));
+        Assert.assertEquals("Chausiku Kibange",
+                obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertEquals("0788994488",
+                obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+        Assert.assertEquals("Friend",
+                obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_RELATIONSHIP));
     }
 
     @Test
@@ -82,8 +88,10 @@ public class NcdReferralTaskHelperTest {
         NcdReferralTaskHelper.addReferralInputObs(event,
                 new NcdReferralInputs("Yes", "Yes", "  Jane Doe  ", "  0788  ", "Mother"));
 
-        Assert.assertEquals("Jane Doe", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
-        Assert.assertEquals("0788", obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
+        Assert.assertEquals("Jane Doe",
+                obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_NAME));
+        Assert.assertEquals("0788",
+                obsValue(event, Constants.NcdReferral.TREATMENT_SUPPORTER_PHONE));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Enriches the **auto-generated NCD referral** (the prompt shown after an NCD follow-up visit) so the Referral Registration event carries the same details the manual referral form captures. Previously the auto path built the event programmatically and omitted these.

Two commits:

### 1. Emergency case & treatment supporter
- Post-visit prompt now collects `is_emergency_case` (Yes/No, seeded from alert level — red→Yes, yellow→No, overridable) and a treatment-supporter section prefilled from the registered caregiver and **editable for this referral only** (never written back to the registration record).
- Values flow through a new `NcdReferralInputs` holder into a backward-compatible `createReferralIfNeeded` overload and are emitted as obs (supporter details only when the gate is Yes). Caregiver resolved off the main thread.

### 2. Facility selection & open-referral gating
- Required facility spinner (no default) populated from `LocationUtils.getFacilitiesKeyAndName()` (loaded off the main thread); Create is blocked until a facility is chosen.
- Selected facility's location id becomes the `chw_referral_hf` obs value (with the facility name as `humanReadableValue`) and the task `groupIdentifier`; falls back to the CHW locality when no facility is captured. `event.locationId` / `task.location` are left unchanged.
- The prompt is now **gated on `NcdCaseManagementDao.hasOpenReferral`**: clients with an open NCD referral skip the dialog with a brief message instead of filling a form that the dedup guard would discard.

## Tests
- Unit tests for obs emission and gate rules, HF obs value + groupId resolution, and `NcdReferralInputs` getters (13 tests, all passing).
- `:opensrp-chw:compileNacpDebugJavaWithJavac` and `:opensrp-chw:testNacpDebugUnitTest` green; nacp debug APK builds.

## Notes
- Strings added in EN + SW.
- Specs: `docs/specs/ncd-auto-referral-supporter-emergency.md`, `docs/specs/ncd-auto-referral-facility-selection.md`.
- Base is `add-is-emergence-on-sw-ncd-ref` so the diff is scoped to just this work.