### PR TITLE
Translate new Sober House discontinuation reasons

### DIFF
--- a/opensrp-chw/src/nacp/res/values-sw/strings.xml
+++ b/opensrp-chw/src/nacp/res/values-sw/strings.xml
@@ -1022,6 +1022,8 @@
     <string name="harm_reduction_sober_house_next_appointment_date">Tarehe ya miadi inayofuata</string>
     <string name="harm_reduction_sober_house_aa">Ustiri wa pombe (AA)</string>
     <string name="harm_reduction_sober_house_absconded">Ametoroka</string>
+    <string name="harm_reduction_sober_house_health_reasons">Sababu za kiafya</string>
+    <string name="harm_reduction_sober_house_misconduct">Utovu wa nidhamu</string>
     <string name="harm_reduction_sober_house_angry">Ana Hasira</string>
     <string name="harm_reduction_sober_house_anxious">Ana Wasiwasi</string>
     <string name="harm_reduction_sober_house_blood_pressure">Shinikizo la damu</string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -778,6 +778,8 @@
     <string name="harm_reduction_sober_house_next_appointment_date">Next Appointment Date</string>
     <string name="harm_reduction_sober_house_aa">Alcoholics Anonymous (AA)</string>
     <string name="harm_reduction_sober_house_absconded">Absconded</string>
+    <string name="harm_reduction_sober_house_health_reasons">Health reasons</string>
+    <string name="harm_reduction_sober_house_misconduct">Misconduct</string>
     <string name="harm_reduction_sober_house_angry">Angry</string>
     <string name="harm_reduction_sober_house_anxious">Anxious</string>
     <string name="harm_reduction_sober_house_blood_pressure">Blood pressure</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionVisitHistoryStringTranslationsTest.java
@@ -104,6 +104,8 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_health_education_other_specify", "Specify other health education provided");
         values.put("harm_reduction_health_education_provided", "Health education provided");
         values.put("harm_reduction_health_services_advocacy", "Health services advocacy");
+        values.put("harm_reduction_sober_house_health_reasons", "Health reasons");
+        values.put("harm_reduction_sober_house_misconduct", "Misconduct");
         values.put("harm_reduction_hepatitis_bc", "Hepatitis B/C");
         values.put("harm_reduction_hepatitis_b_screening", "Hepatitis B Screening");
         values.put("harm_reduction_hepatitis_bc_screening", "Hepatitis B/C Screening");
@@ -301,6 +303,8 @@ public class HarmReductionVisitHistoryStringTranslationsTest {
         values.put("harm_reduction_health_education_other_specify", "Bainisha elimu nyingine ya afya iliyotolewa");
         values.put("harm_reduction_health_education_provided", "Elimu ya afya iliyotolewa");
         values.put("harm_reduction_health_services_advocacy", "Uhamasishaji wa huduma za Afya");
+        values.put("harm_reduction_sober_house_health_reasons", "Sababu za kiafya");
+        values.put("harm_reduction_sober_house_misconduct", "Utovu wa nidhamu");
         values.put("harm_reduction_hepatitis_bc", "Homa ya Ini");
         values.put("harm_reduction_hepatitis_b_screening", "Uchunguzi wa Homa ya Ini B");
         values.put("harm_reduction_hepatitis_bc_screening", "Uchunguzi wa Homa ya Ini B/C");


### PR DESCRIPTION
## Root cause
Sober House history resolves stored option keys through app resources. Without resources for the newly added reasons, history would display raw codes.

## Changes
- Add English and Swahili history translations for `health_reasons` and `misconduct`.
- Extend the NACP visit-history translation regression test.

## Tests
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionVisitHistoryStringTranslationsTest`

Part of #997. Companion form PR: Digital-Square-Tanzania/opensrp-client-chw-harm-reduction#86