### PR TITLE
Persist Harm Reduction enrollment nicknames

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -273,7 +273,7 @@ android {
             buildConfigField "String", 'DEFAULT_LOCATION', '"Hamlet"'
             buildConfigField "String", 'DEFAULT_LOCATION_DEBUG', '"Hamlet"'
             buildConfigField "long", "MAPBOX_DOWNLOAD_TILE_LIMIT", "6001"
-            buildConfigField "int", "DATABASE_VERSION", '46'
+            buildConfigField "int", "DATABASE_VERSION", '47'
             buildConfigField "boolean", "ENABLE_REFERRAL_FOLLOWUP", "false"
         }
     }

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -11821,6 +11821,14 @@
           }
         },
         {
+          "column_name": "nickname",
+          "type": "Event",
+          "json_mapping": {
+            "field": "obs.fieldCode",
+            "concept": "nickname"
+          }
+        },
+        {
           "column_name": "maskani_name",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
@@ -179,6 +179,9 @@ public class ChwRepositoryFlv {
                 case 46:
                     upgradeToVersion46(db);
                     break;
+                case 47:
+                    upgradeToVersion47(db);
+                    break;
                 default:
                     break;
             }
@@ -1042,6 +1045,10 @@ public class ChwRepositoryFlv {
         addColumnIfMissing(db, "ec_kvp_prep_followup", "prep_follow_up");
         addColumnIfMissing(db, "ec_kvp_prep_followup", "prep_facility_b");
         addColumnIfMissing(db, "ec_kvp_prep_followup", "linked_to_prep");
+    }
+
+    private static void upgradeToVersion47(SQLiteDatabase db) {
+        addColumnIfMissing(db, "ec_harm_reduction_risk_assessment", "nickname");
     }
 
     private static void addColumnIfMissing(SQLiteDatabase db, String tableName, String columnName) {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionNicknameConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/HarmReductionNicknameConfigTest.java
@@ -1,0 +1,66 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HarmReductionNicknameConfigTest {
+
+    @Test
+    public void nicknameIsMappedAndMigratedForRiskAssessment() throws Exception {
+        JSONObject clientFields = new JSONObject(readText("src/nacp/assets/ec_client_fields.json"));
+        JSONObject riskAssessment = findTable(clientFields.getJSONArray("bindobjects"),
+                "ec_harm_reduction_risk_assessment");
+
+        Assert.assertTrue(hasColumn(riskAssessment.getJSONArray("columns"), "nickname"));
+
+        String repository = readText("src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java");
+        Assert.assertTrue(repository.contains(
+                "addColumnIfMissing(db, \"ec_harm_reduction_risk_assessment\", \"nickname\")"
+        ));
+        Assert.assertTrue(readText("build.gradle").contains(
+                "buildConfigField \"int\", \"DATABASE_VERSION\", '47'"
+        ));
+    }
+
+    private static JSONObject findTable(JSONArray tables, String name) throws Exception {
+        for (int i = 0; i < tables.length(); i++) {
+            JSONObject table = tables.getJSONObject(i);
+            if (name.equals(table.optString("name"))) {
+                return table;
+            }
+        }
+        throw new AssertionError("Missing table: " + name);
+    }
+
+    private static boolean hasColumn(JSONArray columns, String name) throws Exception {
+        for (int i = 0; i < columns.length(); i++) {
+            if (name.equals(columns.getJSONObject(i).optString("column_name"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Root cause
The NACP app mapping did not include nickname on the Harm Reduction risk-assessment table, and existing databases had no nickname column.

## Changes
- Map `nickname` into `ec_harm_reduction_risk_assessment`.
- Add an idempotent database version 47 upgrade for existing installations.
- Add focused mapping and migration coverage.

## Tests
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.HarmReductionNicknameConfigTest`

Part of #996. Companion PRs: Digital-Square-Tanzania/opensrp-client-chw-harm-reduction#88 and Digital-Square-Tanzania/opensrp-client-chw-core#74