### PR TITLE
Fix collection visit timestamp offset

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.java
@@ -51,10 +51,12 @@ import org.smartregister.util.Utils;
 import java.text.MessageFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import timber.log.Timber;
 
@@ -70,6 +72,12 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity extend
     private final Flavor flavor = new UsedNeedlesAndSyringesCollectionDetailsActivityFlv();
 
     private ProgressBar progressBar;
+
+    static String formatCollectionVisitTimestamp(Date date) {
+        SimpleDateFormat dateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.getDefault());
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat.format(date);
+    }
 
     public static void startMe(Activity activity, String baseEntityId) {
         Intent intent = new Intent(activity, HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity.class);
@@ -220,7 +228,6 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity extend
         }
 
         protected void processVisit(List<LinkedHashMap<String, String>> collectionVisits, Context context, List<Visit> visits) {
-            final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.getDefault());
             if (collectionVisits != null && !collectionVisits.isEmpty()) {
                 linearLayoutHealthFacilityVisit.setVisibility(View.VISIBLE);
 
@@ -251,7 +258,7 @@ public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity extend
                         }
                     });
 
-                    tvTypeOfService.setText(context.getString(R.string.harm_reduction_used_needles_collection) + " - " + simpleDateFormat.format(visit.getDate()));
+                    tvTypeOfService.setText(context.getString(R.string.harm_reduction_used_needles_collection) + " - " + formatCollectionVisitTimestamp(visit.getDate()));
 
                     for (Map.Entry<String, String> entry : vals.entrySet()) {
                         TextView visitDetailTv = new TextView(context);

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivityTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivityTest.java
@@ -1,0 +1,27 @@
+package org.smartregister.chw.activity;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+public class HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivityTest {
+
+    @Test
+    public void collectionTimestampDoesNotAddDeviceTimezoneOffset() {
+        TimeZone original = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("Africa/Dar_es_Salaam"));
+            Date storedWallClock = new Date(1784547290000L);
+
+            Assert.assertEquals(
+                    "20-07-2026 11:34:50",
+                    HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivity
+                            .formatCollectionVisitTimestamp(storedWallClock)
+            );
+        } finally {
+            TimeZone.setDefault(original);
+        }
+    }
+}


### PR DESCRIPTION
## Root cause
Collection visit dates are stored as normalized wall-clock timestamps, but the details screen formatted them in the device timezone. In Tanzania this added three hours to the displayed time.

## Changes
- Format only collection-history visit timestamps in UTC so the captured wall-clock time is preserved.
- Add a regression test using the Africa/Dar_es_Salaam timezone and the reported 11:34 to 14:34 failure case.

## Tests
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.activity.HarmReductionUsedNeedlesAndSyringesCollectionDetailsActivityTest`

Closes #993