### PR TITLE
Show appointment status on the MAT client list

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/fragment/HarmReductionMatClientsRegisterFragment.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/fragment/HarmReductionMatClientsRegisterFragment.java
@@ -5,11 +5,28 @@ import android.view.View;
 import org.smartregister.chw.activity.HarmReductionMatClientsProfileActivity;
 import org.smartregister.chw.core.R;
 import org.smartregister.chw.core.fragment.CoreHarmReductionRegisterFragment;
-import org.smartregister.chw.core.model.CoreHarmReductionRegisterFragmentModel;
+import org.smartregister.chw.model.HarmReductionMatClientsRegisterFragmentModel;
 import org.smartregister.chw.presenter.HarmReductionMatClientsRegisterFragmentPresenter;
+import org.smartregister.chw.provider.HarmReductionMatClientsRegisterProvider;
+import org.smartregister.cursoradapter.RecyclerViewPaginatedAdapter;
 import org.smartregister.view.customcontrols.CustomFontTextView;
 
+import java.util.Set;
+
 public class HarmReductionMatClientsRegisterFragment extends CoreHarmReductionRegisterFragment {
+
+    @Override
+    public void initializeAdapter(Set<org.smartregister.configurableviews.model.View> visibleColumns) {
+        HarmReductionMatClientsRegisterProvider registerProvider =
+                new HarmReductionMatClientsRegisterProvider(
+                        getActivity(), paginationViewHandler, registerActionHandler, visibleColumns
+                );
+        clientAdapter = new RecyclerViewPaginatedAdapter(
+                null, registerProvider, context().commonrepository(this.tablename)
+        );
+        clientAdapter.setCurrentlimit(20);
+        clientsView.setAdapter(clientAdapter);
+    }
 
     @Override
     public void setupViews(View view) {
@@ -30,6 +47,8 @@ public class HarmReductionMatClientsRegisterFragment extends CoreHarmReductionRe
         if (getActivity() == null) {
             return;
         }
-        presenter = new HarmReductionMatClientsRegisterFragmentPresenter(this, new CoreHarmReductionRegisterFragmentModel(), null);
+        presenter = new HarmReductionMatClientsRegisterFragmentPresenter(
+                this, new HarmReductionMatClientsRegisterFragmentModel(), null
+        );
     }
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/model/HarmReductionMatClientsRegisterFragmentModel.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/model/HarmReductionMatClientsRegisterFragmentModel.java
@@ -1,0 +1,27 @@
+package org.smartregister.chw.model;
+
+import org.smartregister.chw.core.model.CoreHarmReductionRegisterFragmentModel;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class HarmReductionMatClientsRegisterFragmentModel extends CoreHarmReductionRegisterFragmentModel {
+
+    static final String NEXT_APPOINTMENT_DATE = "next_appointment_date";
+    static final String MAT_FOLLOWUP_VISIT = "Harm Reduction MAT Clients Followup";
+
+    @Override
+    public String[] mainColumns(String tableName) {
+        List<String> columns = new ArrayList<>(Arrays.asList(super.mainColumns(tableName)));
+        columns.add("(SELECT vd.details FROM visit_details vd "
+                + "INNER JOIN visits v ON v.visit_id = vd.visit_id "
+                + "WHERE v.base_entity_id = " + tableName + ".base_entity_id "
+                + "AND v.visit_type = '" + MAT_FOLLOWUP_VISIT + "' "
+                + "AND vd.visit_key = '" + NEXT_APPOINTMENT_DATE + "' "
+                + "AND IFNULL(vd.details, '') <> '' "
+                + "ORDER BY CAST(v.visit_date AS INTEGER) DESC LIMIT 1) AS "
+                + NEXT_APPOINTMENT_DATE);
+        return columns.toArray(new String[0]);
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/provider/HarmReductionMatClientsRegisterProvider.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/provider/HarmReductionMatClientsRegisterProvider.java
@@ -1,0 +1,63 @@
+package org.smartregister.chw.provider;
+
+import android.content.Context;
+import android.database.Cursor;
+
+import org.joda.time.LocalDate;
+import org.smartregister.chw.R;
+import org.smartregister.chw.harmreduction.provider.HarmReductionRegisterProvider;
+import org.smartregister.chw.util.HarmReductionMatAppointmentStatus;
+import org.smartregister.commonregistry.CommonPersonObjectClient;
+import org.smartregister.util.Utils;
+import org.smartregister.view.contract.SmartRegisterClient;
+
+import java.util.Set;
+
+public class HarmReductionMatClientsRegisterProvider extends HarmReductionRegisterProvider {
+
+    private static final String NEXT_APPOINTMENT_DATE = "next_appointment_date";
+    private final Context context;
+
+    public HarmReductionMatClientsRegisterProvider(Context context,
+                                                   android.view.View.OnClickListener paginationClickListener,
+                                                   android.view.View.OnClickListener onClickListener,
+                                                   Set<org.smartregister.configurableviews.model.View> visibleColumns) {
+        super(context, paginationClickListener, onClickListener, visibleColumns);
+        this.context = context;
+    }
+
+    @Override
+    public void getView(Cursor cursor, SmartRegisterClient client, RegisterViewHolder viewHolder) {
+        super.getView(cursor, client, viewHolder);
+
+        CommonPersonObjectClient person = (CommonPersonObjectClient) client;
+        String appointmentDate = Utils.getValue(
+                person.getColumnmaps(), NEXT_APPOINTMENT_DATE, false
+        );
+        HarmReductionMatAppointmentStatus.Status status =
+                HarmReductionMatAppointmentStatus.classify(appointmentDate, LocalDate.now());
+
+        if (status == HarmReductionMatAppointmentStatus.Status.NONE) {
+            viewHolder.dueWrapper.setVisibility(android.view.View.GONE);
+            return;
+        }
+
+        viewHolder.dueWrapper.setVisibility(android.view.View.VISIBLE);
+        int label;
+        if (status == HarmReductionMatAppointmentStatus.Status.MISSED) {
+            label = R.string.harm_reduction_mat_appointment_missed;
+            viewHolder.dueButton.setBackgroundResource(org.smartregister.chw.core.R.drawable.record_btn_selector_overdue);
+        } else if (status == HarmReductionMatAppointmentStatus.Status.DUE) {
+            label = R.string.harm_reduction_mat_appointment_due;
+            viewHolder.dueButton.setBackgroundResource(org.smartregister.chw.core.R.drawable.record_btn_selector_due);
+        } else {
+            label = R.string.harm_reduction_mat_appointment_upcoming;
+            viewHolder.dueButton.setBackgroundResource(R.drawable.due_contact);
+        }
+        viewHolder.dueButton.setText(context.getString(
+                R.string.harm_reduction_mat_appointment_status,
+                context.getString(label),
+                HarmReductionMatAppointmentStatus.displayDate(appointmentDate)
+        ));
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/HarmReductionMatAppointmentStatus.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/HarmReductionMatAppointmentStatus.java
@@ -1,0 +1,52 @@
+package org.smartregister.chw.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+public final class HarmReductionMatAppointmentStatus {
+
+    private static final DateTimeFormatter STORED_DATE = DateTimeFormat.forPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter DISPLAY_DATE = DateTimeFormat.forPattern("dd-MM-yyyy");
+
+    public enum Status {
+        NONE,
+        UPCOMING,
+        DUE,
+        MISSED
+    }
+
+    private HarmReductionMatAppointmentStatus() {
+    }
+
+    public static Status classify(String value, LocalDate today) {
+        LocalDate appointmentDate = parse(value);
+        if (appointmentDate == null || today == null) {
+            return Status.NONE;
+        }
+        if (appointmentDate.isBefore(today)) {
+            return Status.MISSED;
+        }
+        if (appointmentDate.isEqual(today)) {
+            return Status.DUE;
+        }
+        return Status.UPCOMING;
+    }
+
+    public static String displayDate(String value) {
+        LocalDate appointmentDate = parse(value);
+        return appointmentDate == null ? value : DISPLAY_DATE.print(appointmentDate);
+    }
+
+    private static LocalDate parse(String value) {
+        if (StringUtils.isBlank(value)) {
+            return null;
+        }
+        try {
+            return STORED_DATE.parseLocalDate(value.trim());
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -17,6 +17,10 @@
     <string name="vaccine_service_due"><![CDATA[%1$s <font color=#000000> imefika (%2$s)</font></b>]]></string>
     <string name="vaccine_service_upcoming"><![CDATA[%1$s <font color=#7f7f7f> inakaribia (%2$s) </font> </b>]]></string>
     <string name="due_today">Zinazopaswa leo</string>
+    <string name="harm_reduction_mat_appointment_due">Miadi imefika</string>
+    <string name="harm_reduction_mat_appointment_missed">Amekosa miadi</string>
+    <string name="harm_reduction_mat_appointment_upcoming">Miadi ijayo</string>
+    <string name="harm_reduction_mat_appointment_status">%1$s\n%2$s</string>
 
     <string name="family_has_service_overdue"><![CDATA[Kaya ina <font color=#FF0000>huduma zilizopitiliza muda wake </font></b>]]></string>
     <string name="view_upcoming_services">Angalia huduma zinazokaribia</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
     <string name="vaccine_service_due"><![CDATA[%1$s <font color=#000000>due (%2$s)</font></b>]]></string>
     <string name="vaccine_service_upcoming"><![CDATA[%1$s <font color=#7f7f7f>upcoming (%2$s)</font></b>]]></string>
     <string name="due_today">Due Today</string>
+    <string name="harm_reduction_mat_appointment_due">Due</string>
+    <string name="harm_reduction_mat_appointment_missed">Missed</string>
+    <string name="harm_reduction_mat_appointment_upcoming">Upcoming</string>
+    <string name="harm_reduction_mat_appointment_status">%1$s\n%2$s</string>
 
     <string name="family_has_service_overdue"><![CDATA[Family has <font color=#FF0000>services overdue</font></b>]]></string>
     <string name="view_upcoming_services">View upcoming services</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/model/HarmReductionMatClientsRegisterFragmentModelTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/model/HarmReductionMatClientsRegisterFragmentModelTest.java
@@ -1,0 +1,19 @@
+package org.smartregister.chw.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HarmReductionMatClientsRegisterFragmentModelTest {
+
+    @Test
+    public void mainColumnsSelectLatestMatAppointmentDate() {
+        String[] columns = new HarmReductionMatClientsRegisterFragmentModel()
+                .mainColumns("ec_harm_reduction_risk_assessment");
+
+        String appointmentColumn = columns[columns.length - 1];
+        Assert.assertTrue(appointmentColumn.contains("v.visit_type = 'Harm Reduction MAT Clients Followup'"));
+        Assert.assertTrue(appointmentColumn.contains("vd.visit_key = 'next_appointment_date'"));
+        Assert.assertTrue(appointmentColumn.contains("ORDER BY CAST(v.visit_date AS INTEGER) DESC LIMIT 1"));
+        Assert.assertTrue(appointmentColumn.endsWith("AS next_appointment_date"));
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/HarmReductionMatAppointmentStatusTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/HarmReductionMatAppointmentStatusTest.java
@@ -1,0 +1,34 @@
+package org.smartregister.chw.util;
+
+import org.joda.time.LocalDate;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HarmReductionMatAppointmentStatusTest {
+
+    private static final LocalDate TODAY = new LocalDate(2026, 7, 20);
+
+    @Test
+    public void classifiesUpcomingDueAndMissedAppointments() {
+        Assert.assertEquals(HarmReductionMatAppointmentStatus.Status.UPCOMING,
+                HarmReductionMatAppointmentStatus.classify("2026-07-21", TODAY));
+        Assert.assertEquals(HarmReductionMatAppointmentStatus.Status.DUE,
+                HarmReductionMatAppointmentStatus.classify("2026-07-20", TODAY));
+        Assert.assertEquals(HarmReductionMatAppointmentStatus.Status.MISSED,
+                HarmReductionMatAppointmentStatus.classify("2026-07-19", TODAY));
+    }
+
+    @Test
+    public void invalidOrMissingDatesDoNotShowAppointmentStatus() {
+        Assert.assertEquals(HarmReductionMatAppointmentStatus.Status.NONE,
+                HarmReductionMatAppointmentStatus.classify("", TODAY));
+        Assert.assertEquals(HarmReductionMatAppointmentStatus.Status.NONE,
+                HarmReductionMatAppointmentStatus.classify("20-07-2026", TODAY));
+    }
+
+    @Test
+    public void formatsStoredDateForDisplay() {
+        Assert.assertEquals("20-07-2026",
+                HarmReductionMatAppointmentStatus.displayDate("2026-07-20"));
+    }
+}


### PR DESCRIPTION
## Root cause
The MAT register selected only risk-assessment and family columns, while next appointment dates are stored in MAT follow-up visit details. The existing follow-up button therefore had no appointment context.

## Changes
- Select each client's latest MAT follow-up `next_appointment_date`.
- Show upcoming, due-today, or missed status with the appointment date on the existing follow-up button.
- Preserve the button's existing follow-up action.
- Add English and Swahili status labels plus query and boundary tests.

## Tests
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.model.HarmReductionMatClientsRegisterFragmentModelTest --tests org.smartregister.chw.util.HarmReductionMatAppointmentStatusTest`

Closes #880