### PR TITLE
Require CTC number for HIV-positive KVP enrollment

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_registration.json
@@ -382,10 +382,10 @@
           "is_fixed_size": "true",
           "err": "Tafadhali ingiza namba sahihi ya CTC"
         },
-      "v_required": {
-        "value": true,
-        "err": "Tafadhali ingiza namba sahihi ya CTC"
-      },
+        "v_required": {
+          "value": true,
+          "err": "Tafadhali ingiza namba sahihi ya CTC"
+        },
         "relevance": {
           "step1:hiv_status": {
             "type": "string",

--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_registration.json
@@ -382,10 +382,10 @@
           "is_fixed_size": "true",
           "err": "Tafadhali ingiza namba sahihi ya CTC"
         },
-        "v_required": {
-          "value": false,
-          "err": "Tafadhali ingiza namba sahihi ya CTC"
-        },
+      "v_required": {
+        "value": true,
+        "err": "Tafadhali ingiza namba sahihi ya CTC"
+      },
         "relevance": {
           "step1:hiv_status": {
             "type": "string",

--- a/opensrp-chw/src/nacp/assets/json.form/kvp_prep_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form/kvp_prep_registration.json
@@ -382,10 +382,10 @@
           "is_fixed_size": "true",
           "err": "Please enter a valid CTC ID"
         },
-      "v_required": {
-        "value": true,
-        "err": "Please enter a valid CTC ID"
-      },
+        "v_required": {
+          "value": true,
+          "err": "Please enter a valid CTC ID"
+        },
         "relevance": {
           "step1:hiv_status": {
             "type": "string",

--- a/opensrp-chw/src/nacp/assets/json.form/kvp_prep_registration.json
+++ b/opensrp-chw/src/nacp/assets/json.form/kvp_prep_registration.json
@@ -382,10 +382,10 @@
           "is_fixed_size": "true",
           "err": "Please enter a valid CTC ID"
         },
-        "v_required": {
-          "value": false,
-          "err": "Please enter a valid CTC ID"
-        },
+      "v_required": {
+        "value": true,
+        "err": "Please enter a valid CTC ID"
+      },
         "relevance": {
           "step1:hiv_status": {
             "type": "string",

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepRegistrationFormAssetsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepRegistrationFormAssetsTest.java
@@ -1,0 +1,64 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class KvpPrepRegistrationFormAssetsTest {
+    private static final String[] FORM_PATHS = {
+            "src/nacp/assets/json.form/kvp_prep_registration.json",
+            "src/nacp/assets/json.form-sw/kvp_prep_registration.json"
+    };
+
+    @Test
+    public void ctcNumberIsRequiredOnlyForHivPositiveClients() throws Exception {
+        for (String formPath : FORM_PATHS) {
+            JSONObject form = new JSONObject(readText(formPath));
+            JSONObject ctcNumber = getField(form.getJSONObject("step1").getJSONArray("fields"), "ctc_number");
+
+            Assert.assertTrue("CTC number must be required in " + formPath,
+                    ctcNumber.getJSONObject("v_required").getBoolean("value"));
+            Assert.assertFalse("CTC validation message must not be blank in " + formPath,
+                    ctcNumber.getJSONObject("v_required").getString("err").trim().isEmpty());
+
+            JSONObject hivStatusRelevance = ctcNumber.getJSONObject("relevance")
+                    .getJSONObject("step1:hiv_status");
+            Assert.assertEquals("string", hivStatusRelevance.getString("type"));
+            Assert.assertEquals("equalTo(., \"positive\")", hivStatusRelevance.getString("ex"));
+        }
+    }
+
+    private static JSONObject getField(JSONArray fields, String key) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (key.equals(field.optString("key"))) {
+                return field;
+            }
+        }
+        throw new AssertionError("Missing field: " + key);
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Root cause

The English and Swahili KVP enrollment forms correctly showed `ctc_number` only when `hiv_status` was `positive`, but both configured `v_required.value` as `false`. Native-form validation therefore allowed a visible blank CTC number to be saved.

## Changes

- require `ctc_number` in both localized KVP enrollment forms
- preserve the existing positive-HIV relevance rule, so the field stays hidden and non-blocking for `unknown`
- add an asset regression test covering required validation, the error message, and conditional relevance in both languages

## Validation

- `jq empty opensrp-chw/src/nacp/assets/json.form/kvp_prep_registration.json opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_registration.json`
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.KvpPrepRegistrationFormAssetsTest`
- `git diff --check development...HEAD`

Closes #1011