### PR TITLE
Fix same-day AYP service duplication (#998)

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/AypOutSchoolMemberProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/AypOutSchoolMemberProfileActivity.java
@@ -43,6 +43,7 @@ import org.smartregister.chw.model.ReferralTypeModel;
 import org.smartregister.chw.util.JsonFormUtils;
 import com.vijay.jsonwizard.utils.FormUtils;
 import org.smartregister.chw.util.AllClientsUtils;
+import org.smartregister.chw.util.AypServiceDateUtils;
 import org.smartregister.commonregistry.CommonPersonObject;
 import org.smartregister.commonregistry.CommonPersonObjectClient;
 import org.smartregister.commonregistry.CommonRepository;
@@ -173,9 +174,19 @@ public class AypOutSchoolMemberProfileActivity extends CoreAypProfileActivity im
             }
         }
 
-        if(isAypOutSchoolServiceToday(memberObject.getBaseEntityId())) {
-            textViewRecordayp.setVisibility(View.GONE);
-        }
+        updateServiceButtonAvailability();
+    }
+
+    private void updateServiceButtonAvailability() {
+        Visit latestVisit = getAypOutSchoolVisit();
+        boolean serviceProvidedToday = AypServiceDateUtils.hasServiceToday(
+                isAypOutSchoolServiceToday(memberObject.getBaseEntityId()),
+                latestVisit == null ? null : latestVisit.getDate(),
+                new Date());
+
+        textViewRecordayp.setEnabled(!serviceProvidedToday);
+        textViewRecordayp.setClickable(!serviceProvidedToday);
+        textViewRecordayp.setAlpha(serviceProvidedToday ? 0.5f : 1.0f);
     }
 
     private void enforceProcessVisitVisibility() {
@@ -515,6 +526,10 @@ public class AypOutSchoolMemberProfileActivity extends CoreAypProfileActivity im
 
     @Override
     public void onClick(View view) {
+        if (view.getId() == R.id.textview_record_ayp
+                && !textViewRecordayp.isEnabled()) {
+            return;
+        }
         super.onClick(view);
         handleNotificationRowClick(this, view, notificationListAdapter, memberObject.getBaseEntityId());
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/AypServiceDateUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/AypServiceDateUtils.java
@@ -1,0 +1,30 @@
+package org.smartregister.chw.util;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public final class AypServiceDateUtils {
+
+    private AypServiceDateUtils() {
+    }
+
+    public static boolean hasServiceToday(boolean processedServiceToday, Date latestVisitDate,
+                                          Date currentDate) {
+        return processedServiceToday || isSameDay(latestVisitDate, currentDate);
+    }
+
+    private static boolean isSameDay(Date firstDate, Date secondDate) {
+        if (firstDate == null || secondDate == null) {
+            return false;
+        }
+
+        Calendar firstCalendar = Calendar.getInstance();
+        firstCalendar.setTime(firstDate);
+        Calendar secondCalendar = Calendar.getInstance();
+        secondCalendar.setTime(secondDate);
+
+        return firstCalendar.get(Calendar.ERA) == secondCalendar.get(Calendar.ERA)
+                && firstCalendar.get(Calendar.YEAR) == secondCalendar.get(Calendar.YEAR)
+                && firstCalendar.get(Calendar.DAY_OF_YEAR) == secondCalendar.get(Calendar.DAY_OF_YEAR);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/AypServiceDateUtilsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/AypServiceDateUtilsTest.java
@@ -1,0 +1,45 @@
+package org.smartregister.chw.util;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class AypServiceDateUtilsTest {
+
+    @Test
+    public void processedServiceDisablesButtonWithoutLocalVisit() {
+        assertTrue(AypServiceDateUtils.hasServiceToday(true, null, new Date()));
+    }
+
+    @Test
+    public void localVisitDisablesButtonBeforeProcessedEventIsAvailable() {
+        Calendar visit = dateAt(2026, Calendar.AUGUST, 4, 8);
+        Calendar now = dateAt(2026, Calendar.AUGUST, 4, 18);
+
+        assertTrue(AypServiceDateUtils.hasServiceToday(false, visit.getTime(), now.getTime()));
+    }
+
+    @Test
+    public void serviceBecomesAvailableOnNextDay() {
+        Calendar visit = dateAt(2026, Calendar.AUGUST, 4, 23);
+        Calendar now = dateAt(2026, Calendar.AUGUST, 5, 0);
+
+        assertFalse(AypServiceDateUtils.hasServiceToday(false, visit.getTime(), now.getTime()));
+    }
+
+    @Test
+    public void missingServiceHistoryKeepsButtonAvailable() {
+        assertFalse(AypServiceDateUtils.hasServiceToday(false, null, new Date()));
+    }
+
+    private Calendar dateAt(int year, int month, int day, int hour) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(year, month, day, hour, 0, 0);
+        return calendar;
+    }
+}


### PR DESCRIPTION
## Summary

- use the latest local AYP out-of-school visit as an immediate same-day service guard
- retain the processed follow-up event check as a persistence fallback
- keep the eligible service button visible but disabled and greyed after service is provided
- block disabled-button clicks and restore availability on a later calendar day

## Root cause

The profile only checked the processed follow-up table and hid the action. A newly saved local visit could exist before that table was updated, leaving a window where the service could be opened again on the same day.

## Testing

- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.util.AypServiceDateUtilsTest`
- NACP debug Java compilation completed as part of the focused test task

Closes #998
