### PR TITLE
Implement AYP HIV and PrEP medical workflow (#982)

### DIFF
--- a/opensrp-chw/build.gradle
+++ b/opensrp-chw/build.gradle
@@ -273,7 +273,7 @@ android {
             buildConfigField "String", 'DEFAULT_LOCATION', '"Hamlet"'
             buildConfigField "String", 'DEFAULT_LOCATION_DEBUG', '"Hamlet"'
             buildConfigField "long", "MAPBOX_DOWNLOAD_TILE_LIMIT", "6001"
-            buildConfigField "int", "DATABASE_VERSION", '48'
+            buildConfigField "int", "DATABASE_VERSION", '49'
             buildConfigField "boolean", "ENABLE_REFERRAL_FOLLOWUP", "false"
         }
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/AypOutSchoolMedicalServicesActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/AypOutSchoolMedicalServicesActionHelper.java
@@ -1,0 +1,267 @@
+package org.smartregister.chw.actionhelper;
+
+import static com.vijay.jsonwizard.utils.FormUtils.fields;
+import static com.vijay.jsonwizard.utils.FormUtils.getFieldJSONObject;
+import static org.smartregister.util.JsonFormUtils.STEP1;
+
+import android.content.Context;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.ayp.actionhelper.aypOutOfSchool.AypOutSchoolMedicalServiceActionHelper;
+import org.smartregister.chw.ayp.domain.MemberObject;
+import org.smartregister.chw.dao.AypOutSchoolDao;
+
+public class AypOutSchoolMedicalServicesActionHelper extends AypOutSchoolMedicalServiceActionHelper {
+
+    private static final String[] HIV_PREP_FIELDS = {
+            "hiv_tested_within_last_3_months",
+            "hiv_result_recent",
+            "ctc_number_a",
+            "on_prep",
+            "prep_facility_a",
+            "linked_to_prep_recent",
+            "linked_to_prep_recent_prompt",
+            "referred_for_hiv_test",
+            "referred_for_hiv_test_prompt",
+            "tested_for_hiv",
+            "testing_location",
+            "facility_name",
+            "test_date",
+            "hiv_result",
+            "ctc_number_b",
+            "prep_follow_up",
+            "prep_facility_b",
+            "linked_to_prep",
+            "linked_to_prep_prompt"
+    };
+
+    private static final String[] BRANCH_A_FIELDS = {
+            "hiv_result_recent",
+            "ctc_number_a",
+            "on_prep",
+            "prep_facility_a",
+            "linked_to_prep_recent"
+    };
+
+    private static final String[] BRANCH_B_FIELDS = {
+            "referred_for_hiv_test",
+            "tested_for_hiv",
+            "testing_location",
+            "facility_name",
+            "test_date",
+            "hiv_result",
+            "ctc_number_b",
+            "prep_follow_up",
+            "prep_facility_b",
+            "linked_to_prep"
+    };
+
+    private static final String[] REFERRED_FOR_HIV_DOWNSTREAM_FIELDS = {
+            "tested_for_hiv",
+            "testing_location",
+            "facility_name",
+            "test_date",
+            "hiv_result",
+            "ctc_number_b",
+            "prep_follow_up",
+            "prep_facility_b",
+            "linked_to_prep"
+    };
+
+    private static final String[] TESTED_FOR_HIV_DOWNSTREAM_FIELDS = {
+            "testing_location",
+            "facility_name",
+            "test_date",
+            "hiv_result",
+            "ctc_number_b",
+            "prep_follow_up",
+            "prep_facility_b",
+            "linked_to_prep"
+    };
+
+    private final String baseEntityId;
+
+    public AypOutSchoolMedicalServicesActionHelper(Context context, MemberObject memberObject) {
+        super(context, memberObject);
+        baseEntityId = memberObject.getBaseEntityId();
+    }
+
+    @Override
+    public String getPreProcessed() {
+        String preProcessedPayload = super.getPreProcessed();
+        if (StringUtils.isBlank(preProcessedPayload)) {
+            return null;
+        }
+
+        try {
+            JSONObject jsonObject = new JSONObject(preProcessedPayload);
+            if (isClientHivPositive()) {
+                suppressHivPrepFields(jsonObject);
+            }
+            return jsonObject.toString();
+        } catch (JSONException e) {
+            return null;
+        }
+    }
+
+    protected boolean isClientHivPositive() {
+        return AypOutSchoolDao.isClientHivPositive(baseEntityId);
+    }
+
+    @Override
+    public String postProcess(String jsonPayload) {
+        try {
+            JSONObject jsonObject = new JSONObject(jsonPayload);
+            JSONArray formFields = fields(jsonObject, STEP1);
+            clearInactiveBranchValues(formFields);
+            normalizePersistedHivState(formFields);
+            return jsonObject.toString();
+        } catch (JSONException e) {
+            return jsonPayload;
+        }
+    }
+
+    private void suppressHivPrepFields(JSONObject jsonObject) throws JSONException {
+        JSONArray formFields = fields(jsonObject, STEP1);
+        for (String fieldKey : HIV_PREP_FIELDS) {
+            JSONObject field = getField(formFields, fieldKey);
+            if (field != null) {
+                field.put("type", "hidden");
+                field.remove("relevance");
+            }
+        }
+    }
+
+    private void clearInactiveBranchValues(JSONArray formFields) throws JSONException {
+        String testedRecently = getValue(formFields, "hiv_tested_within_last_3_months");
+        if (!StringUtils.equalsIgnoreCase(testedRecently, "yes")) {
+            clearValues(formFields, BRANCH_A_FIELDS);
+        }
+        if (!StringUtils.equalsIgnoreCase(testedRecently, "no")) {
+            clearValues(formFields, BRANCH_B_FIELDS);
+        }
+
+        if (StringUtils.equalsIgnoreCase(testedRecently, "yes")) {
+            clearBranchAValues(formFields);
+        } else if (StringUtils.equalsIgnoreCase(testedRecently, "no")) {
+            clearBranchBValues(formFields);
+        }
+    }
+
+    private void clearBranchAValues(JSONArray formFields) throws JSONException {
+        String result = getValue(formFields, "hiv_result_recent");
+        if (StringUtils.equalsIgnoreCase(result, "positive")) {
+            clearValues(formFields, "on_prep", "prep_facility_a", "linked_to_prep_recent");
+        } else if (StringUtils.equalsIgnoreCase(result, "negative")) {
+            clearValues(formFields, "ctc_number_a");
+            clearPrepBranchValues(formFields, "on_prep", "prep_facility_a", "linked_to_prep_recent");
+        } else {
+            clearValues(formFields, "ctc_number_a", "on_prep", "prep_facility_a", "linked_to_prep_recent");
+        }
+    }
+
+    private void clearBranchBValues(JSONArray formFields) throws JSONException {
+        if (!StringUtils.equalsIgnoreCase(getValue(formFields, "referred_for_hiv_test"), "yes")) {
+            clearValues(formFields, REFERRED_FOR_HIV_DOWNSTREAM_FIELDS);
+            return;
+        }
+        if (!StringUtils.equalsIgnoreCase(getValue(formFields, "tested_for_hiv"), "yes")) {
+            clearValues(formFields, TESTED_FOR_HIV_DOWNSTREAM_FIELDS);
+            return;
+        }
+
+        String result = getValue(formFields, "hiv_result");
+        if (StringUtils.equalsIgnoreCase(result, "positive")) {
+            clearValues(formFields, "prep_follow_up", "prep_facility_b", "linked_to_prep");
+        } else if (StringUtils.equalsIgnoreCase(result, "negative")) {
+            clearValues(formFields, "ctc_number_b");
+            clearPrepBranchValues(formFields, "prep_follow_up", "prep_facility_b", "linked_to_prep");
+        } else {
+            clearValues(formFields, "ctc_number_b", "prep_follow_up", "prep_facility_b", "linked_to_prep");
+        }
+    }
+
+    private void clearPrepBranchValues(JSONArray formFields, String prepField, String facilityField,
+                                       String linkageField) throws JSONException {
+        String prepValue = getValue(formFields, prepField);
+        if (StringUtils.equalsIgnoreCase(prepValue, "yes")) {
+            clearValues(formFields, linkageField);
+        } else if (StringUtils.equalsIgnoreCase(prepValue, "no")) {
+            clearValues(formFields, facilityField);
+        } else {
+            clearValues(formFields, facilityField, linkageField);
+        }
+    }
+
+    private void normalizePersistedHivState(JSONArray formFields) throws JSONException {
+        String testedRecently = getValue(formFields, "hiv_tested_within_last_3_months");
+        String recentResult = getValue(formFields, "hiv_result_recent");
+        String referred = getValue(formFields, "referred_for_hiv_test");
+        String tested = getValue(formFields, "tested_for_hiv");
+        String testingLocation = getValue(formFields, "testing_location");
+        String result = getValue(formFields, "hiv_result");
+
+        boolean positive = isClientHivPositive()
+                || StringUtils.equalsIgnoreCase(recentResult, "positive")
+                || StringUtils.equalsIgnoreCase(result, "positive");
+        boolean negative = !positive && (StringUtils.equalsIgnoreCase(recentResult, "negative")
+                || StringUtils.equalsIgnoreCase(result, "negative"));
+
+        setValue(formFields, "client_hiv_status", positive ? "positive" : negative ? "negative" : "");
+        setValue(formFields, "hiv_positive", Boolean.toString(positive));
+        setValue(formFields, "ctc_number", positive
+                ? StringUtils.defaultIfBlank(getValue(formFields, "ctc_number_a"), getValue(formFields, "ctc_number_b"))
+                : "");
+        setValue(formFields, "tested_hiv", getCompatHivTested(testedRecently, recentResult, referred, tested));
+        setValue(formFields, "loc_test_conducted",
+                StringUtils.equalsIgnoreCase(tested, "yes") ? testingLocation : "");
+        setValue(formFields, "linked_to_prep_services",
+                StringUtils.defaultIfBlank(getValue(formFields, "linked_to_prep_recent"),
+                        getValue(formFields, "linked_to_prep")));
+    }
+
+    private String getCompatHivTested(String testedRecently, String recentResult, String referred,
+                                      String tested) {
+        if (StringUtils.equalsIgnoreCase(testedRecently, "yes") && StringUtils.isNotBlank(recentResult)) {
+            return "yes";
+        }
+        if (StringUtils.equalsIgnoreCase(testedRecently, "no")) {
+            if (StringUtils.equalsIgnoreCase(tested, "yes")) {
+                return "yes";
+            }
+            if (StringUtils.equalsIgnoreCase(referred, "no")
+                    || StringUtils.equalsIgnoreCase(tested, "no")) {
+                return "no";
+            }
+        }
+        return "";
+    }
+
+    private JSONObject getField(JSONArray formFields, String fieldKey) {
+        if (formFields == null || StringUtils.isBlank(fieldKey)) {
+            return null;
+        }
+        return getFieldJSONObject(formFields, fieldKey);
+    }
+
+    private String getValue(JSONArray formFields, String fieldKey) {
+        JSONObject field = getField(formFields, fieldKey);
+        return field == null ? null : field.optString("value", null);
+    }
+
+    private void clearValues(JSONArray formFields, String... fieldKeys) throws JSONException {
+        for (String fieldKey : fieldKeys) {
+            setValue(formFields, fieldKey, "");
+        }
+    }
+
+    private void setValue(JSONArray formFields, String fieldKey, String value) throws JSONException {
+        JSONObject field = getField(formFields, fieldKey);
+        if (field != null) {
+            field.put("value", StringUtils.defaultString(value));
+        }
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/AypOutSchoolClientServiceVisitActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/AypOutSchoolClientServiceVisitActivity.java
@@ -10,8 +10,10 @@ import android.os.Build;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.domain.Form;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONObject;
 import org.smartregister.chw.R;
+import org.smartregister.chw.actionhelper.AypOutSchoolMedicalServicesActionHelper;
 import org.smartregister.chw.ayp.activity.BaseAypVisitActivity;
 import org.smartregister.chw.ayp.dao.AypDao;
 import org.smartregister.chw.ayp.domain.MemberObject;
@@ -63,6 +65,8 @@ public class AypOutSchoolClientServiceVisitActivity extends BaseAypVisitActivity
     public void initializeActions(LinkedHashMap<String, BaseAypVisitAction> map) {
         actionList.clear();
 
+        configureMedicalServicesAction(map);
+
         //Necessary evil to rearrange the actions according to a specific arrangement
 
         if (map.containsKey(getString(R.string.ayp_out_school_service_status))) {
@@ -97,6 +101,24 @@ public class AypOutSchoolClientServiceVisitActivity extends BaseAypVisitActivity
         displayProgressBar(false);
     }
 
+    private void configureMedicalServicesAction(LinkedHashMap<String, BaseAypVisitAction> actions) {
+        BaseAypVisitAction medicalServicesAction = actions.get(getString(R.string.ayp_out_school_medical_services));
+        if (medicalServicesAction == null || StringUtils.isBlank(medicalServicesAction.getJsonPayload())) {
+            return;
+        }
+
+        AypOutSchoolMedicalServicesActionHelper actionHelper =
+                new AypOutSchoolMedicalServicesActionHelper(this, memberObject);
+        actionHelper.onJsonFormLoaded(medicalServicesAction.getJsonPayload(), this, null);
+        String preProcessedPayload = actionHelper.getPreProcessed();
+        if (StringUtils.isNotBlank(preProcessedPayload)) {
+            actionHelper.onPayloadReceived(preProcessedPayload);
+            medicalServicesAction.setaypVisitActionHelper(actionHelper);
+            medicalServicesAction.setProcessedJsonPayload(preProcessedPayload);
+            medicalServicesAction.evaluateStatus();
+        }
+    }
+
     @Override
     protected void attachBaseContext(Context base) {
         // get language from prefs
@@ -105,4 +127,3 @@ public class AypOutSchoolClientServiceVisitActivity extends BaseAypVisitActivity
     }
 
 }
-

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/AypOutSchoolDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/AypOutSchoolDao.java
@@ -27,4 +27,16 @@ public class AypOutSchoolDao extends AypDao {
         }
         return false;
     }
+
+    public static boolean isClientHivPositive(String baseEntityId) {
+        String sql = "SELECT base_entity_id FROM ec_ayp_out_school_client_followup_visits " +
+                "WHERE base_entity_id = '" + baseEntityId + "' " +
+                "AND (LOWER(COALESCE(hiv_positive, '')) = 'true' " +
+                "OR LOWER(COALESCE(client_hiv_status, '')) = 'positive' " +
+                "OR LOWER(COALESCE(hiv_result_recent, '')) = 'positive' " +
+                "OR LOWER(COALESCE(hiv_result, '')) = 'positive') LIMIT 1";
+        DataMap<String> dataMap = cursor -> getCursorValue(cursor, "base_entity_id");
+        List<String> results = readData(sql, dataMap);
+        return results != null && !results.isEmpty();
+    }
 }

--- a/opensrp-chw/src/nacp/assets/ec_client_fields.json
+++ b/opensrp-chw/src/nacp/assets/ec_client_fields.json
@@ -10805,6 +10805,96 @@
           }
         },
         {
+          "column_name": "hiv_positive",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "hiv_positive"}
+        },
+        {
+          "column_name": "client_hiv_status",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "client_hiv_status"}
+        },
+        {
+          "column_name": "ctc_number",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "ctc_number"}
+        },
+        {
+          "column_name": "hiv_tested_within_last_3_months",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "hiv_tested_within_last_3_months"}
+        },
+        {
+          "column_name": "hiv_result_recent",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "hiv_result_recent"}
+        },
+        {
+          "column_name": "ctc_number_a",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "ctc_number_a"}
+        },
+        {
+          "column_name": "on_prep",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "on_prep"}
+        },
+        {
+          "column_name": "prep_facility_a",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "prep_facility_a"}
+        },
+        {
+          "column_name": "linked_to_prep_recent",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "linked_to_prep_recent"}
+        },
+        {
+          "column_name": "tested_for_hiv",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "tested_for_hiv"}
+        },
+        {
+          "column_name": "testing_location",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "testing_location"}
+        },
+        {
+          "column_name": "facility_name",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "facility_name"}
+        },
+        {
+          "column_name": "test_date",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "test_date"}
+        },
+        {
+          "column_name": "hiv_result",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "hiv_result"}
+        },
+        {
+          "column_name": "ctc_number_b",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "ctc_number_b"}
+        },
+        {
+          "column_name": "prep_follow_up",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "prep_follow_up"}
+        },
+        {
+          "column_name": "prep_facility_b",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "prep_facility_b"}
+        },
+        {
+          "column_name": "linked_to_prep",
+          "type": "Event",
+          "json_mapping": {"field": "obs.fieldCode", "concept": "linked_to_prep"}
+        },
+        {
           "column_name": "tested_hiv",
           "type": "Event",
           "json_mapping": {

--- a/opensrp-chw/src/nacp/assets/json.form-sw/ayp_out_school_medical_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/ayp_out_school_medical_services.json
@@ -474,6 +474,99 @@
         }
       },
       {
+        "key": "hiv_tested_within_last_3_months",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_tested_within_last_3_months",
+        "type": "native_radio",
+        "label": "Je, mteja amepima VVU ndani ya miezi 3 iliyopita?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "hiv_result_recent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_result_recent",
+        "type": "native_radio",
+        "label": "Matokeo ya kipimo cha VVU yalikuwa nini?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "negative", "text": "Hasi", "openmrs_entity": "concept", "openmrs_entity_id": "negative"},
+          {"key": "positive", "text": "Chanya", "openmrs_entity": "concept", "openmrs_entity_id": "positive"}
+        ],
+        "relevance": {"step1:hiv_tested_within_last_3_months": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "ctc_number_a",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "ctc_number_a",
+        "type": "edit_text",
+        "hint": "Namba ya CTC",
+        "relevance": {"step1:hiv_result_recent": {"type": "string", "ex": "equalTo(., \"positive\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza Namba ya CTC"}
+      },
+      {
+        "key": "on_prep",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "on_prep",
+        "type": "native_radio",
+        "label": "Je, mteja anatumia PrEP kwa sasa?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:hiv_result_recent": {"type": "string", "ex": "equalTo(., \"negative\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "prep_facility_a",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_facility_a",
+        "type": "edit_text",
+        "hint": "Jina la kituo ambapo mteja alipata PrEP",
+        "relevance": {"step1:on_prep": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza jina la kituo"}
+      },
+      {
+        "key": "linked_to_prep_recent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "linked_to_prep_recent",
+        "type": "native_radio",
+        "label": "Je, mteja ameunganishwa na huduma za PrEP?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:on_prep": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "linked_to_prep_recent_prompt",
+        "type": "toaster_notes",
+        "text": "Mpe rufaa mteja kwenda kwenye huduma za PrEP.",
+        "openmrs_entity_id": "linked_to_prep_recent_prompt",
+        "openmrs_entity": "concept",
+        "openmrs_entity_parent": "",
+        "toaster_type": "warning",
+        "relevance": {"step1:linked_to_prep_recent": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {
         "key": "referred_for_hiv_test",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
@@ -483,141 +576,161 @@
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Ndiyo",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "Hapana",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhali jaza"
-        }
+        "relevance": {"step1:hiv_tested_within_last_3_months": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
       },
       {
-        "key": "tested_hiv",
+        "key": "referred_for_hiv_test_prompt",
+        "type": "toaster_notes",
+        "text": "Mpe rufaa mteja kwenda kupima VVU.",
+        "openmrs_entity_id": "referred_for_hiv_test_prompt",
+        "openmrs_entity": "concept",
+        "openmrs_entity_parent": "",
+        "toaster_type": "warning",
+        "relevance": {"step1:referred_for_hiv_test": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {
+        "key": "tested_for_hiv",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "tested_hiv",
+        "openmrs_entity_id": "tested_for_hiv",
         "type": "native_radio",
         "label": "Je, mteja alifanyiwa kipimo cha VVU?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Ndiyo",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "Hapana",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
-        "relevance": {
-          "step1:referred_for_hiv_test": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhili jaza"
-        }
+        "relevance": {"step1:referred_for_hiv_test": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
       },
       {
-        "key": "loc_test_conducted",
+        "key": "testing_location",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "loc_test_conducted",
+        "openmrs_entity_id": "testing_location",
         "type": "native_radio",
         "label": "Upimaji ulifanyika wapi?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "community",
-            "text": "Jamii",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "facility",
-            "text": "Kituoni",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "community", "text": "Jamii", "openmrs_entity": "concept", "openmrs_entity_id": "community"},
+          {"key": "facility", "text": "Kituoni", "openmrs_entity": "concept", "openmrs_entity_id": "facility"}
         ],
-        "relevance": {
-          "step1:tested_hiv": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhili jaza"
-        }
+        "relevance": {"step1:tested_for_hiv": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
       },
       {
-        "key": "linked_to_prep_services",
+        "key": "facility_name",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "linked_to_prep_services",
+        "openmrs_entity_id": "facility_name",
+        "type": "edit_text",
+        "hint": "Jina la kituo ambapo kipimo kilifanyika",
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza jina la kituo"}
+      },
+      {
+        "key": "test_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "test_date",
+        "type": "date_picker",
+        "label": "Tarehe ya kipimo",
+        "hint": "Tarehe ya kipimo",
+        "expanded": false,
+        "max_date": "today",
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza tarehe ya kipimo"}
+      },
+      {
+        "key": "hiv_result",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_result",
         "type": "native_radio",
-        "label": "Je, mteja aliunganishwa na huduma za PrEP?",
+        "label": "Matokeo ya kipimo cha VVU yalikuwa nini?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Ndiyo",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "Hapana",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "negative", "text": "Hasi", "openmrs_entity": "concept", "openmrs_entity_id": "negative"},
+          {"key": "positive", "text": "Chanya", "openmrs_entity": "concept", "openmrs_entity_id": "positive"}
         ],
-        "relevance": {
-          "step1:referred_for_hiv_test": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Tafadhili jaza"
-        }
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
       },
       {
-        "key": "linked_to_prep_services_toaster",
+        "key": "ctc_number_b",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "ctc_number_b",
+        "type": "edit_text",
+        "hint": "Namba ya CTC",
+        "relevance": {"step1:hiv_result": {"type": "string", "ex": "equalTo(., \"positive\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza Namba ya CTC"}
+      },
+      {
+        "key": "prep_follow_up",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_follow_up",
+        "type": "native_radio",
+        "label": "Je, mteja anatumia PrEP kwa sasa?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:hiv_result": {"type": "string", "ex": "equalTo(., \"negative\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "prep_facility_b",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_facility_b",
+        "type": "edit_text",
+        "hint": "Jina la kituo ambapo mteja alipata PrEP",
+        "relevance": {"step1:prep_follow_up": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali ingiza jina la kituo"}
+      },
+      {
+        "key": "linked_to_prep",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "linked_to_prep",
+        "type": "native_radio",
+        "label": "Je, mteja ameunganishwa na huduma za PrEP?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:prep_follow_up": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
+      },
+      {
+        "key": "linked_to_prep_prompt",
         "type": "toaster_notes",
-        "text": "Mpe rufaa mteja kwenda kwenye huduma za PrEP",
-        "openmrs_entity_id": "linked_to_prep_services_toaster",
+        "text": "Mpe rufaa mteja kwenda kwenye huduma za PrEP.",
+        "openmrs_entity_id": "linked_to_prep_prompt",
         "openmrs_entity": "concept",
         "openmrs_entity_parent": "",
-        "toaster_type": "info",
-        "relevance": {
-          "step1:linked_to_prep_services": {
-            "type": "string",
-            "ex": "equalTo(., \"no\")"
-          }
-        }
-      }
+        "toaster_type": "warning",
+        "relevance": {"step1:linked_to_prep": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {"key": "client_hiv_status", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "client_hiv_status", "type": "hidden"},
+      {"key": "ctc_number", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "ctc_number", "type": "hidden"},
+      {"key": "hiv_positive", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "hiv_positive", "type": "hidden"},
+      {"key": "tested_hiv", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "tested_hiv", "type": "hidden"},
+      {"key": "loc_test_conducted", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "loc_test_conducted", "type": "hidden"},
+      {"key": "linked_to_prep_services", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "linked_to_prep_services", "type": "hidden"}
     ]
   }
 }

--- a/opensrp-chw/src/nacp/assets/json.form/ayp_out_school_medical_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form/ayp_out_school_medical_services.json
@@ -474,150 +474,263 @@
         }
       },
       {
+        "key": "hiv_tested_within_last_3_months",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_tested_within_last_3_months",
+        "type": "native_radio",
+        "label": "Has the client been tested for HIV in the last 3 months?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "hiv_result_recent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_result_recent",
+        "type": "native_radio",
+        "label": "What were the results of the HIV test?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "negative", "text": "Negative", "openmrs_entity": "concept", "openmrs_entity_id": "negative"},
+          {"key": "positive", "text": "Positive", "openmrs_entity": "concept", "openmrs_entity_id": "positive"}
+        ],
+        "relevance": {"step1:hiv_tested_within_last_3_months": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "ctc_number_a",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "ctc_number_a",
+        "type": "edit_text",
+        "hint": "CTC Number",
+        "relevance": {"step1:hiv_result_recent": {"type": "string", "ex": "equalTo(., \"positive\")"}},
+        "v_required": {"value": "true", "err": "Please enter the CTC Number"}
+      },
+      {
+        "key": "on_prep",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "on_prep",
+        "type": "native_radio",
+        "label": "Is the client currently using PrEP?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:hiv_result_recent": {"type": "string", "ex": "equalTo(., \"negative\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "prep_facility_a",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_facility_a",
+        "type": "edit_text",
+        "hint": "Name of facility the client received PrEP",
+        "relevance": {"step1:on_prep": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Please enter the facility name"}
+      },
+      {
+        "key": "linked_to_prep_recent",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "linked_to_prep_recent",
+        "type": "native_radio",
+        "label": "Was the client linked to PrEP services?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:on_prep": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "linked_to_prep_recent_prompt",
+        "type": "toaster_notes",
+        "text": "Refer the client to PrEP services.",
+        "openmrs_entity_id": "linked_to_prep_recent_prompt",
+        "openmrs_entity": "concept",
+        "openmrs_entity_parent": "",
+        "toaster_type": "warning",
+        "relevance": {"step1:linked_to_prep_recent": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {
         "key": "referred_for_hiv_test",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
         "openmrs_entity_id": "referred_for_hiv_test",
         "type": "native_radio",
-        "label": "Was the client referred for HIV Testing",
+        "label": "Was the client referred for HIV Testing?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Yes",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "No",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
-        "v_required": {
-          "value": "true",
-          "err": "Please fill"
-        }
+        "relevance": {"step1:hiv_tested_within_last_3_months": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
       },
       {
-        "key": "tested_hiv",
+        "key": "referred_for_hiv_test_prompt",
+        "type": "toaster_notes",
+        "text": "Refer the client for HIV Testing.",
+        "openmrs_entity_id": "referred_for_hiv_test_prompt",
+        "openmrs_entity": "concept",
+        "openmrs_entity_parent": "",
+        "toaster_type": "warning",
+        "relevance": {"step1:referred_for_hiv_test": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {
+        "key": "tested_for_hiv",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "tested_hiv",
+        "openmrs_entity_id": "tested_for_hiv",
         "type": "native_radio",
-        "label": "Was the client tested for HIV",
+        "label": "Was the client tested for HIV?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Yes",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "No",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
-        "relevance": {
-          "step1:referred_for_hiv_test": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Please fill"
-        }
+        "relevance": {"step1:referred_for_hiv_test": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
       },
       {
-        "key": "loc_test_conducted",
+        "key": "testing_location",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "loc_test_conducted",
+        "openmrs_entity_id": "testing_location",
         "type": "native_radio",
         "label": "Where was the testing conducted?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "community",
-            "text": "Community",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "facility",
-            "text": "Facility",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "community", "text": "Community", "openmrs_entity": "concept", "openmrs_entity_id": "community"},
+          {"key": "facility", "text": "Facility", "openmrs_entity": "concept", "openmrs_entity_id": "facility"}
         ],
-        "relevance": {
-          "step1:tested_hiv": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Please fill"
-        }
+        "relevance": {"step1:tested_for_hiv": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
       },
       {
-        "key": "linked_to_prep_services",
+        "key": "facility_name",
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
-        "openmrs_entity_id": "linked_to_prep_services",
+        "openmrs_entity_id": "facility_name",
+        "type": "edit_text",
+        "hint": "Name of facility where the test was conducted",
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Please enter the facility name"}
+      },
+      {
+        "key": "test_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "test_date",
+        "type": "date_picker",
+        "label": "Date the test was conducted",
+        "hint": "Date the test was conducted",
+        "expanded": false,
+        "max_date": "today",
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Please enter the test date"}
+      },
+      {
+        "key": "hiv_result",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "hiv_result",
         "type": "native_radio",
-        "label": "Was the client linked to PrEP services ?",
+        "label": "What was the HIV test result?",
         "label_text_style": "normal",
         "text_color": "#C0C0C0",
         "options": [
-          {
-            "key": "yes",
-            "text": "Yes",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "yes"
-          },
-          {
-            "key": "no",
-            "text": "No",
-            "openmrs_entity": "concept",
-            "openmrs_entity_id": "no"
-          }
+          {"key": "negative", "text": "Negative", "openmrs_entity": "concept", "openmrs_entity_id": "negative"},
+          {"key": "positive", "text": "Positive", "openmrs_entity": "concept", "openmrs_entity_id": "positive"}
         ],
-        "relevance": {
-          "step1:referred_for_hiv_test": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        },
-        "v_required": {
-          "value": "true",
-          "err": "Please fill"
-        }
+        "relevance": {"step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
       },
       {
-        "key": "linked_to_prep_services_toaster",
+        "key": "ctc_number_b",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "ctc_number_b",
+        "type": "edit_text",
+        "hint": "CTC Number",
+        "relevance": {"step1:hiv_result": {"type": "string", "ex": "equalTo(., \"positive\")"}},
+        "v_required": {"value": "true", "err": "Please enter the CTC Number"}
+      },
+      {
+        "key": "prep_follow_up",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_follow_up",
+        "type": "native_radio",
+        "label": "Is the client currently using PrEP?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:hiv_result": {"type": "string", "ex": "equalTo(., \"negative\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "prep_facility_b",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "prep_facility_b",
+        "type": "edit_text",
+        "hint": "Name of facility the client received PrEP",
+        "relevance": {"step1:prep_follow_up": {"type": "string", "ex": "equalTo(., \"yes\")"}},
+        "v_required": {"value": "true", "err": "Please enter the facility name"}
+      },
+      {
+        "key": "linked_to_prep",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "linked_to_prep",
+        "type": "native_radio",
+        "label": "Was the client linked to PrEP services?",
+        "label_text_style": "normal",
+        "text_color": "#C0C0C0",
+        "options": [
+          {"key": "yes", "text": "Yes", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "no", "text": "No", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
+        ],
+        "relevance": {"step1:prep_follow_up": {"type": "string", "ex": "equalTo(., \"no\")"}},
+        "v_required": {"value": "true", "err": "Please select an answer"}
+      },
+      {
+        "key": "linked_to_prep_prompt",
         "type": "toaster_notes",
-        "text": "Refer the client to PrEP services ",
-        "openmrs_entity_id": "linked_to_prep_services_toaster",
+        "text": "Refer the client to PrEP services.",
+        "openmrs_entity_id": "linked_to_prep_prompt",
         "openmrs_entity": "concept",
         "openmrs_entity_parent": "",
-        "toaster_type": "info",
-        "relevance": {
-          "step1:linked_to_prep_services": {
-            "type": "string",
-            "ex": "equalTo(., \"no\")"
-          }
-        }
-      }
+        "toaster_type": "warning",
+        "relevance": {"step1:linked_to_prep": {"type": "string", "ex": "equalTo(., \"no\")"}}
+      },
+      {"key": "client_hiv_status", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "client_hiv_status", "type": "hidden"},
+      {"key": "ctc_number", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "ctc_number", "type": "hidden"},
+      {"key": "hiv_positive", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "hiv_positive", "type": "hidden"},
+      {"key": "tested_hiv", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "tested_hiv", "type": "hidden"},
+      {"key": "loc_test_conducted", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "loc_test_conducted", "type": "hidden"},
+      {"key": "linked_to_prep_services", "openmrs_entity_parent": "", "openmrs_entity": "concept", "openmrs_entity_id": "linked_to_prep_services", "type": "hidden"}
     ]
   }
 }

--- a/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
+++ b/opensrp-chw/src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java
@@ -184,6 +184,10 @@ public class ChwRepositoryFlv {
                     break;
                 case 48:
                     upgradeToVersion48(db);
+                    break;
+                case 49:
+                    upgradeToVersion49(db);
+                    break;
                 default:
                     break;
             }
@@ -1059,6 +1063,28 @@ public class ChwRepositoryFlv {
         addColumnIfMissing(db, tableName, "diabetes_treatment_after_screening");
         addColumnIfMissing(db, tableName, "other_conditions_result");
         addColumnIfMissing(db, tableName, "other_conditions_treatment_after_screening");
+    }
+
+    private static void upgradeToVersion49(SQLiteDatabase db) {
+        String tableName = "ec_ayp_out_school_client_followup_visits";
+        addColumnIfMissing(db, tableName, "hiv_positive");
+        addColumnIfMissing(db, tableName, "client_hiv_status");
+        addColumnIfMissing(db, tableName, "ctc_number");
+        addColumnIfMissing(db, tableName, "hiv_tested_within_last_3_months");
+        addColumnIfMissing(db, tableName, "hiv_result_recent");
+        addColumnIfMissing(db, tableName, "ctc_number_a");
+        addColumnIfMissing(db, tableName, "on_prep");
+        addColumnIfMissing(db, tableName, "prep_facility_a");
+        addColumnIfMissing(db, tableName, "linked_to_prep_recent");
+        addColumnIfMissing(db, tableName, "tested_for_hiv");
+        addColumnIfMissing(db, tableName, "testing_location");
+        addColumnIfMissing(db, tableName, "facility_name");
+        addColumnIfMissing(db, tableName, "test_date");
+        addColumnIfMissing(db, tableName, "hiv_result");
+        addColumnIfMissing(db, tableName, "ctc_number_b");
+        addColumnIfMissing(db, tableName, "prep_follow_up");
+        addColumnIfMissing(db, tableName, "prep_facility_b");
+        addColumnIfMissing(db, tableName, "linked_to_prep");
     }
   
     private static void addColumnIfMissing(SQLiteDatabase db, String tableName, String columnName) {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/AypOutSchoolMedicalServicesActionHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/AypOutSchoolMedicalServicesActionHelperTest.java
@@ -1,0 +1,155 @@
+package org.smartregister.chw.actionhelper;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.smartregister.chw.ayp.domain.MemberObject;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class AypOutSchoolMedicalServicesActionHelperTest {
+
+    private MemberObject memberObject;
+
+    @Before
+    public void setUp() {
+        memberObject = Mockito.mock(MemberObject.class);
+        Mockito.when(memberObject.getBaseEntityId()).thenReturn("ayp-client-id");
+        Mockito.when(memberObject.getGender()).thenReturn("Female");
+        Mockito.when(memberObject.getAge()).thenReturn(19);
+    }
+
+    @Test
+    public void previousPositiveResultSuppressesHivPrepFieldsButKeepsHpvVisible() throws Exception {
+        TestActionHelper helper = helper(true);
+        JSONObject form = loadForm();
+        helper.onJsonFormLoaded(form.toString(), null, null);
+
+        JSONObject processed = new JSONObject(helper.getPreProcessed());
+
+        assertEquals("native_radio", getField(processed, "received_hpv_vaccine").getString("type"));
+        assertEquals("hidden", getField(processed, "hiv_tested_within_last_3_months").getString("type"));
+        assertEquals("hidden", getField(processed, "hiv_result_recent").getString("type"));
+        assertEquals("hidden", getField(processed, "hiv_result").getString("type"));
+        assertEquals("hidden", getField(processed, "linked_to_prep").getString("type"));
+    }
+
+    @Test
+    public void recentPositiveResultClearsPrepAndFullFlowValues() throws Exception {
+        TestActionHelper helper = helper(false);
+        JSONObject form = loadForm();
+        setValue(form, "hiv_tested_within_last_3_months", "yes");
+        setValue(form, "hiv_result_recent", "positive");
+        setValue(form, "ctc_number_a", "CTC-123");
+        setValue(form, "on_prep", "yes");
+        setValue(form, "prep_facility_a", "Stale facility");
+        setValue(form, "referred_for_hiv_test", "yes");
+        setValue(form, "hiv_result", "negative");
+
+        JSONObject processed = new JSONObject(helper.postProcess(form.toString()));
+
+        assertEquals("", value(processed, "on_prep"));
+        assertEquals("", value(processed, "prep_facility_a"));
+        assertEquals("", value(processed, "referred_for_hiv_test"));
+        assertEquals("", value(processed, "hiv_result"));
+        assertEquals("positive", value(processed, "client_hiv_status"));
+        assertEquals("true", value(processed, "hiv_positive"));
+        assertEquals("CTC-123", value(processed, "ctc_number"));
+        assertEquals("yes", value(processed, "tested_hiv"));
+    }
+
+    @Test
+    public void fullFlowPositiveResultClearsPrepAndStoresCtcNumber() throws Exception {
+        TestActionHelper helper = helper(false);
+        JSONObject form = loadForm();
+        setValue(form, "hiv_tested_within_last_3_months", "no");
+        setValue(form, "referred_for_hiv_test", "yes");
+        setValue(form, "tested_for_hiv", "yes");
+        setValue(form, "testing_location", "facility");
+        setValue(form, "hiv_result", "positive");
+        setValue(form, "ctc_number_b", "CTC-456");
+        setValue(form, "prep_follow_up", "no");
+        setValue(form, "linked_to_prep", "yes");
+
+        JSONObject processed = new JSONObject(helper.postProcess(form.toString()));
+
+        assertEquals("", value(processed, "prep_follow_up"));
+        assertEquals("", value(processed, "linked_to_prep"));
+        assertEquals("positive", value(processed, "client_hiv_status"));
+        assertEquals("true", value(processed, "hiv_positive"));
+        assertEquals("CTC-456", value(processed, "ctc_number"));
+        assertEquals("facility", value(processed, "loc_test_conducted"));
+    }
+
+    @Test
+    public void negativeResultDoesNotSetPositiveFlagAndPreservesActiveLinkage() throws Exception {
+        TestActionHelper helper = helper(false);
+        JSONObject form = loadForm();
+        setValue(form, "hiv_tested_within_last_3_months", "yes");
+        setValue(form, "hiv_result_recent", "negative");
+        setValue(form, "on_prep", "no");
+        setValue(form, "linked_to_prep_recent", "no");
+        setValue(form, "ctc_number_a", "stale");
+
+        JSONObject processed = new JSONObject(helper.postProcess(form.toString()));
+
+        assertEquals("", value(processed, "ctc_number_a"));
+        assertEquals("negative", value(processed, "client_hiv_status"));
+        assertEquals("false", value(processed, "hiv_positive"));
+        assertEquals("no", value(processed, "linked_to_prep_services"));
+    }
+
+    private TestActionHelper helper(boolean hivPositive) {
+        return new TestActionHelper(memberObject, hivPositive);
+    }
+
+    private static JSONObject loadForm() throws Exception {
+        return new JSONObject(new String(Files.readAllBytes(resolvePath(
+                "src/nacp/assets/json.form/ayp_out_school_medical_services.json")), StandardCharsets.UTF_8));
+    }
+
+    private static JSONObject getField(JSONObject form, String key) throws Exception {
+        JSONArray fields = form.getJSONObject("step1").getJSONArray("fields");
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (key.equals(field.optString("key"))) {
+                return field;
+            }
+        }
+        throw new AssertionError("Missing field: " + key);
+    }
+
+    private static void setValue(JSONObject form, String key, String value) throws Exception {
+        getField(form, key).put("value", value);
+    }
+
+    private static String value(JSONObject form, String key) throws Exception {
+        return getField(form, key).optString("value");
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        return Files.exists(direct) ? direct : Paths.get("opensrp-chw").resolve(relativePath);
+    }
+
+    private static class TestActionHelper extends AypOutSchoolMedicalServicesActionHelper {
+        private final boolean hivPositive;
+
+        TestActionHelper(MemberObject memberObject, boolean hivPositive) {
+            super(null, memberObject);
+            this.hivPositive = hivPositive;
+        }
+
+        @Override
+        protected boolean isClientHivPositive() {
+            return hivPositive;
+        }
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/AypOutSchoolMedicalServicesConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/AypOutSchoolMedicalServicesConfigTest.java
@@ -1,0 +1,197 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class AypOutSchoolMedicalServicesConfigTest {
+
+    private static final String TABLE_NAME = "ec_ayp_out_school_client_followup_visits";
+    private static final String[] NEW_PERSISTED_FIELDS = {
+            "hiv_positive", "client_hiv_status", "ctc_number",
+            "hiv_tested_within_last_3_months", "hiv_result_recent", "ctc_number_a",
+            "on_prep", "prep_facility_a", "linked_to_prep_recent", "tested_for_hiv",
+            "testing_location", "facility_name", "test_date", "hiv_result", "ctc_number_b",
+            "prep_follow_up", "prep_facility_b", "linked_to_prep"
+    };
+
+    @Test
+    public void englishAndSwahiliFormsHaveMatchingWorkflowFields() throws Exception {
+        JSONObject english = form("json.form");
+        JSONObject swahili = form("json.form-sw");
+        JSONArray englishFields = fields(english);
+        JSONArray swahiliFields = fields(swahili);
+
+        Assert.assertEquals(fieldKeys(englishFields), fieldKeys(swahiliFields));
+        Assert.assertEquals(indexOf(englishFields, "received_hpv_vaccine") + 1,
+                indexOf(englishFields, "hiv_tested_within_last_3_months"));
+        Assert.assertEquals(indexOf(swahiliFields, "received_hpv_vaccine") + 1,
+                indexOf(swahiliFields, "hiv_tested_within_last_3_months"));
+
+        assertRequiredRadio(englishFields, "hiv_tested_within_last_3_months", "yes", "no");
+        assertRequiredRadio(englishFields, "hiv_result_recent", "negative", "positive");
+        assertRequiredRadio(englishFields, "hiv_result", "negative", "positive");
+        assertRequiredRadio(swahiliFields, "hiv_tested_within_last_3_months", "yes", "no");
+        assertRequiredRadio(swahiliFields, "hiv_result_recent", "negative", "positive");
+        assertRequiredRadio(swahiliFields, "hiv_result", "negative", "positive");
+
+        assertRequiredType(englishFields, "ctc_number_a", "edit_text");
+        assertRequiredType(englishFields, "ctc_number_b", "edit_text");
+        assertRequiredType(englishFields, "facility_name", "edit_text");
+        assertRequiredType(englishFields, "test_date", "date_picker");
+        assertRequiredType(englishFields, "prep_facility_a", "edit_text");
+        assertRequiredType(englishFields, "prep_facility_b", "edit_text");
+        assertRequiredType(swahiliFields, "ctc_number_a", "edit_text");
+        assertRequiredType(swahiliFields, "ctc_number_b", "edit_text");
+    }
+
+    @Test
+    public void promptsAndBranchRelevanceMatchRequirements() throws Exception {
+        JSONArray englishFields = fields(form("json.form"));
+        JSONArray swahiliFields = fields(form("json.form-sw"));
+
+        assertWarningPrompt(englishFields, "referred_for_hiv_test_prompt",
+                "Refer the client for HIV Testing.");
+        assertWarningPrompt(englishFields, "linked_to_prep_recent_prompt",
+                "Refer the client to PrEP services.");
+        assertWarningPrompt(englishFields, "linked_to_prep_prompt",
+                "Refer the client to PrEP services.");
+        assertWarningPrompt(swahiliFields, "referred_for_hiv_test_prompt",
+                "Mpe rufaa mteja kwenda kupima VVU.");
+        assertWarningPrompt(swahiliFields, "linked_to_prep_recent_prompt",
+                "Mpe rufaa mteja kwenda kwenye huduma za PrEP.");
+        assertWarningPrompt(swahiliFields, "linked_to_prep_prompt",
+                "Mpe rufaa mteja kwenda kwenye huduma za PrEP.");
+
+        assertRelevance(englishFields, "hiv_result_recent", "step1:hiv_tested_within_last_3_months", "yes");
+        assertRelevance(englishFields, "referred_for_hiv_test", "step1:hiv_tested_within_last_3_months", "no");
+        assertRelevance(englishFields, "ctc_number_a", "step1:hiv_result_recent", "positive");
+        assertRelevance(englishFields, "ctc_number_b", "step1:hiv_result", "positive");
+        assertRelevance(englishFields, "prep_facility_a", "step1:on_prep", "yes");
+        assertRelevance(englishFields, "prep_facility_b", "step1:prep_follow_up", "yes");
+    }
+
+    @Test
+    public void newFieldsAreMappedAndMigratedAtDatabaseVersion49() throws Exception {
+        JSONObject clientFields = new JSONObject(readText("src/nacp/assets/ec_client_fields.json"));
+        JSONArray columns = findTable(clientFields.getJSONArray("bindobjects"), TABLE_NAME)
+                .getJSONArray("columns");
+        String repository = readText("src/nacp/java/org/smartregister/chw/repository/ChwRepositoryFlv.java");
+
+        for (String field : NEW_PERSISTED_FIELDS) {
+            Assert.assertEquals("Mapped column must occur once: " + field, 1, columnCount(columns, field));
+            Assert.assertTrue("Missing migration for " + field,
+                    repository.contains("addColumnIfMissing(db, tableName, \"" + field + "\")"));
+        }
+
+        Assert.assertTrue(repository.contains("case 49:"));
+        Assert.assertTrue(repository.contains("upgradeToVersion49(db)"));
+        Assert.assertTrue(readText("build.gradle").contains(
+                "buildConfigField \"int\", \"DATABASE_VERSION\", '49'"));
+    }
+
+    private static JSONObject form(String directory) throws Exception {
+        return new JSONObject(readText("src/nacp/assets/" + directory
+                + "/ayp_out_school_medical_services.json"));
+    }
+
+    private static JSONArray fields(JSONObject form) throws Exception {
+        return form.getJSONObject("step1").getJSONArray("fields");
+    }
+
+    private static Set<String> fieldKeys(JSONArray fields) throws Exception {
+        Set<String> keys = new HashSet<>();
+        for (int i = 0; i < fields.length(); i++) {
+            Assert.assertTrue("Duplicate form field: " + fields.getJSONObject(i).optString("key"),
+                    keys.add(fields.getJSONObject(i).optString("key")));
+        }
+        return keys;
+    }
+
+    private static int indexOf(JSONArray fields, String key) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            if (key.equals(fields.getJSONObject(i).optString("key"))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static JSONObject field(JSONArray fields, String key) throws Exception {
+        int index = indexOf(fields, key);
+        if (index < 0) {
+            throw new AssertionError("Missing field: " + key);
+        }
+        return fields.getJSONObject(index);
+    }
+
+    private static void assertRequiredRadio(JSONArray fields, String key, String... optionKeys)
+            throws Exception {
+        JSONObject field = field(fields, key);
+        Assert.assertEquals("native_radio", field.getString("type"));
+        Assert.assertTrue(Boolean.parseBoolean(field.getJSONObject("v_required").get("value").toString()));
+        Set<String> actualOptions = new HashSet<>();
+        JSONArray options = field.getJSONArray("options");
+        for (int i = 0; i < options.length(); i++) {
+            actualOptions.add(options.getJSONObject(i).getString("key"));
+        }
+        Assert.assertEquals(new HashSet<>(Arrays.asList(optionKeys)), actualOptions);
+    }
+
+    private static void assertRequiredType(JSONArray fields, String key, String type) throws Exception {
+        JSONObject field = field(fields, key);
+        Assert.assertEquals(type, field.getString("type"));
+        Assert.assertTrue(Boolean.parseBoolean(field.getJSONObject("v_required").get("value").toString()));
+    }
+
+    private static void assertWarningPrompt(JSONArray fields, String key, String text) throws Exception {
+        JSONObject prompt = field(fields, key);
+        Assert.assertEquals("toaster_notes", prompt.getString("type"));
+        Assert.assertEquals("warning", prompt.getString("toaster_type"));
+        Assert.assertEquals(text, prompt.getString("text"));
+    }
+
+    private static void assertRelevance(JSONArray fields, String key, String source, String value)
+            throws Exception {
+        JSONObject relevance = field(fields, key).getJSONObject("relevance").getJSONObject(source);
+        Assert.assertEquals("equalTo(., \"" + value + "\")", relevance.getString("ex"));
+    }
+
+    private static JSONObject findTable(JSONArray tables, String name) throws Exception {
+        for (int i = 0; i < tables.length(); i++) {
+            JSONObject table = tables.getJSONObject(i);
+            if (name.equals(table.optString("name"))) {
+                return table;
+            }
+        }
+        throw new AssertionError("Missing table: " + name);
+    }
+
+    private static int columnCount(JSONArray columns, String name) throws Exception {
+        int count = 0;
+        for (int i = 0; i < columns.length(); i++) {
+            if (name.equals(columns.getJSONObject(i).optString("column_name"))) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        return Files.exists(direct) ? direct : Paths.get("opensrp-chw").resolve(relativePath);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the legacy AYP Out-of-School HIV questions with the requested recent-test and referral/test branches in English and Swahili.
- Add required CTC, PrEP, facility, test-date, result, and referral fields with branch-specific warning prompts.
- Clear values from inactive branches before saving and retain compatibility fields used by existing reporting.
- Suppress the HIV/PrEP section on future visits after any recorded positive result while keeping the HPV question available.
- Persist and migrate the new follow-up fields at database version 49.

## Root cause

The medical-services form only supported the previous flat HIV flow. It had no action helper to clean mutually exclusive branches or consult historical positive results, and the requested workflow fields were not mapped to the client follow-up table.

## Verification

- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.actionhelper.AypOutSchoolMedicalServicesActionHelperTest --tests org.smartregister.chw.resources.AypOutSchoolMedicalServicesConfigTest`
- Both localized JSON forms and `ec_client_fields.json` parse successfully.
- Installed the NACP debug APK on `emulator-5554`; confirmed the Swahili AYP enrollment form and eligibility path load from the rebuilt app.
- Verified the live SQLCipher database migrated to user version 49 and contains all 18 new follow-up columns.
- Full medical-form UI traversal could not be completed because the AVD repeatedly entered a baseline login/register ANR after a cold restart. Historical-positive suppression, negative-result behavior, branch cleanup, localization parity, persistence mappings, and migration are covered by focused tests.

Closes #982
