### PR TITLE
Correct KVP Swahili yes option labels

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
@@ -54,7 +54,7 @@
         "text_color": "#000000",
         "type": "native_radio",
         "options": [
-          {"key": "yes", "text": "Ndio", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
           {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
         "v_required": {"value": "true", "err": "Tafadhali chagua jibu"}
@@ -116,7 +116,7 @@
         "text_color": "#000000",
         "type": "native_radio",
         "options": [
-          {"key": "yes", "text": "Ndio", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
           {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
         "v_required": {"value": "true", "err": "Tafadhali chagua jibu"},
@@ -174,7 +174,7 @@
         "text_color": "#000000",
         "type": "native_radio",
         "options": [
-          {"key": "yes", "text": "Ndio", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
           {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
         "v_required": {"value": "true", "err": "Tafadhali chagua jibu"},
@@ -203,7 +203,7 @@
         "text_color": "#000000",
         "type": "native_radio",
         "options": [
-          {"key": "yes", "text": "Ndio", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
+          {"key": "yes", "text": "Ndiyo", "openmrs_entity": "concept", "openmrs_entity_id": "yes"},
           {"key": "no", "text": "Hapana", "openmrs_entity": "concept", "openmrs_entity_id": "no"}
         ],
         "v_required": {"value": "true", "err": "Tafadhali chagua jibu"},
@@ -1518,7 +1518,7 @@
         "options": [
           {
             "key": "yes",
-            "text": "Ndio",
+            "text": "Ndiyo",
             "openmrs_entity_parent": "",
             "openmrs_entity": "concept",
             "openmrs_entity_id": "yes"

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepSwahiliOptionsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepSwahiliOptionsTest.java
@@ -1,0 +1,75 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class KvpPrepSwahiliOptionsTest {
+
+    private static final String FORM_PATH =
+            "src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json";
+    private static final String[] FIELDS = {
+            "hiv_tested_within_last_3_months",
+            "on_prep",
+            "referred_for_hiv_test",
+            "tested_for_hiv",
+            "kits_distributed"
+    };
+
+    @Test
+    public void selectedYesOptionsUseCorrectSwahiliSpelling() throws Exception {
+        JSONArray fields = form().getJSONObject("step1").getJSONArray("fields");
+
+        for (String fieldKey : FIELDS) {
+            JSONObject field = getField(fields, fieldKey);
+            assertEquals(fieldKey, "Ndiyo", getOption(field.getJSONArray("options"), "yes")
+                    .getString("text"));
+        }
+    }
+
+    private JSONObject form() throws Exception {
+        return new JSONObject(new String(Files.readAllBytes(resolvePath(FORM_PATH)),
+                StandardCharsets.UTF_8));
+    }
+
+    private JSONObject getField(JSONArray fields, String key) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (key.equals(field.optString("key"))) {
+                return field;
+            }
+        }
+        throw new AssertionError("Missing field: " + key);
+    }
+
+    private JSONObject getOption(JSONArray options, String key) throws Exception {
+        for (int i = 0; i < options.length(); i++) {
+            JSONObject option = options.getJSONObject(i);
+            if (key.equals(option.optString("key"))) {
+                return option;
+            }
+        }
+        throw new AssertionError("Missing option: " + key);
+    }
+
+    private Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- change `Ndio` to `Ndiyo` for the five KVP questions listed in the issue
- keep the stored option key as `yes`, so rules and persisted data are unchanged
- add an asset regression test for the selected Swahili labels

## Testing
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.KvpPrepSwahiliOptionsTest`

Closes #1021
