### PR TITLE
Move KVP next visit date to a required action

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/KvpPrEPNextVisitDateActionHelper.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/actionhelper/KvpPrEPNextVisitDateActionHelper.java
@@ -1,0 +1,72 @@
+package org.smartregister.chw.actionhelper;
+
+import android.content.Context;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.core.utils.CoreJsonFormUtils;
+import org.smartregister.chw.kvp.domain.VisitDetail;
+import org.smartregister.chw.kvp.model.BaseKvpVisitAction;
+
+import java.util.List;
+import java.util.Map;
+
+import timber.log.Timber;
+
+public class KvpPrEPNextVisitDateActionHelper implements BaseKvpVisitAction.KvpVisitActionHelper {
+    private String jsonPayload;
+    private String nextVisitDate;
+
+    @Override
+    public void onJsonFormLoaded(String jsonPayload, Context context,
+                                 Map<String, List<VisitDetail>> details) {
+        this.jsonPayload = jsonPayload;
+    }
+
+    @Override
+    public String getPreProcessed() {
+        return jsonPayload;
+    }
+
+    @Override
+    public void onPayloadReceived(String jsonPayload) {
+        try {
+            nextVisitDate = CoreJsonFormUtils.getValue(new JSONObject(jsonPayload), "next_visit_date");
+        } catch (JSONException e) {
+            Timber.e(e);
+        }
+    }
+
+    @Override
+    public BaseKvpVisitAction.ScheduleStatus getPreProcessedStatus() {
+        return null;
+    }
+
+    @Override
+    public String getPreProcessedSubTitle() {
+        return null;
+    }
+
+    @Override
+    public String postProcess(String jsonPayload) {
+        return jsonPayload;
+    }
+
+    @Override
+    public String evaluateSubTitle() {
+        return null;
+    }
+
+    @Override
+    public BaseKvpVisitAction.Status evaluateStatusOnPayload() {
+        return StringUtils.isBlank(nextVisitDate)
+                ? BaseKvpVisitAction.Status.PENDING
+                : BaseKvpVisitAction.Status.COMPLETED;
+    }
+
+    @Override
+    public void onPayloadReceived(BaseKvpVisitAction kvpVisitAction) {
+        // No additional action state is required.
+    }
+}

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/KvpPrEPVisitInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/KvpPrEPVisitInteractor.java
@@ -7,6 +7,7 @@ import static org.smartregister.client.utils.constants.JsonFormConstants.KEY;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.smartregister.chw.R;
+import org.smartregister.chw.actionhelper.KvpPrEPNextVisitDateActionHelper;
 import org.smartregister.chw.actionhelper.KvpPrEPPreventiveServicesActionHelper;
 import org.smartregister.chw.actionhelper.KvpPrEPReferralServicesActionHelper;
 import org.smartregister.chw.actionhelper.KvpPrEPSbccServicesActionHelper;
@@ -28,6 +29,7 @@ import java.util.Map;
 import timber.log.Timber;
 
 public class KvpPrEPVisitInteractor extends BaseKvpVisitInteractor {
+    static final String NEXT_VISIT_DATE_FORM = "kvp_prep_next_visit_date";
     private BaseKvpVisitContract.InteractorCallBack callBack;
     private final Map<String, String> visitState = new HashMap<>();
 
@@ -41,6 +43,7 @@ public class KvpPrEPVisitInteractor extends BaseKvpVisitInteractor {
                 evaluatePreventiveServices(details);
                 evaluateStructuralServices(details);
                 evaluateReferralServices(details, null);
+                evaluateNextVisitDate(details);
             } catch (BaseKvpVisitAction.ValidationException e) {
                 Timber.e(e);
             }
@@ -59,10 +62,12 @@ public class KvpPrEPVisitInteractor extends BaseKvpVisitInteractor {
                 actionList.remove(context.getString(R.string.kvp_prep_referral_services));
                 actionList.remove(context.getString(R.string.kvp_prep_preventive_services));
                 actionList.remove(context.getString(R.string.kvp_prep_structural_services));
+                actionList.remove(context.getString(R.string.kvp_prep_next_visit_date));
                 try {
                     evaluatePreventiveServices(details);
                     evaluateStructuralServices(details);
                     evaluateReferralServices(details, visitType);
+                    evaluateNextVisitDate(details);
                 } catch (BaseKvpVisitAction.ValidationException e) {
                     throw new RuntimeException(e);
                 }
@@ -158,6 +163,18 @@ public class KvpPrEPVisitInteractor extends BaseKvpVisitInteractor {
                 .build();
 
         actionList.put(context.getString(R.string.kvp_prep_referral_services), action);
+    }
+
+    private void evaluateNextVisitDate(Map<String, List<VisitDetail>> details) throws BaseKvpVisitAction.ValidationException {
+        KvpPrEPNextVisitDateActionHelper actionHelper = new KvpPrEPNextVisitDateActionHelper();
+        BaseKvpVisitAction action = getBuilder(context.getString(R.string.kvp_prep_next_visit_date))
+                .withOptional(false)
+                .withDetails(details)
+                .withHelper(actionHelper)
+                .withFormName(NEXT_VISIT_DATE_FORM)
+                .build();
+
+        actionList.put(context.getString(R.string.kvp_prep_next_visit_date), action);
     }
 
 }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/interactor/KvpPrEPVisitInteractor.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/interactor/KvpPrEPVisitInteractor.java
@@ -59,15 +59,20 @@ public class KvpPrEPVisitInteractor extends BaseKvpVisitInteractor {
         KvpPrEPVisitTypeActionHelper actionHelper = new KvpPrEPVisitTypeActionHelper(memberObject.getBaseEntityId(), visitState) {
             @Override
             public void processVisitType(String visitType) {
+                String nextVisitDateTitle = context.getString(R.string.kvp_prep_next_visit_date);
+                BaseKvpVisitAction nextVisitDateAction = actionList.remove(nextVisitDateTitle);
                 actionList.remove(context.getString(R.string.kvp_prep_referral_services));
                 actionList.remove(context.getString(R.string.kvp_prep_preventive_services));
                 actionList.remove(context.getString(R.string.kvp_prep_structural_services));
-                actionList.remove(context.getString(R.string.kvp_prep_next_visit_date));
                 try {
                     evaluatePreventiveServices(details);
                     evaluateStructuralServices(details);
                     evaluateReferralServices(details, visitType);
-                    evaluateNextVisitDate(details);
+                    if (nextVisitDateAction == null) {
+                        evaluateNextVisitDate(details);
+                    } else {
+                        actionList.put(nextVisitDateTitle, nextVisitDateAction);
+                    }
                 } catch (BaseKvpVisitAction.ValidationException e) {
                     throw new RuntimeException(e);
                 }

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -558,6 +558,7 @@
     <string name="kvp_prep_preventive_services">Huduma Kinga</string>
     <string name="kvp_prep_structural_services">Huduma za Kimuundo</string>
     <string name="kvp_prep_referral_services">Huduma za Rufaa</string>
+    <string name="kvp_prep_next_visit_date">Tarehe ya Tembeleo Linalofuata</string>
     <string name="new_visit">Mteja Mpya</string>
     <string name="followup">Anaendelea na Huduma</string>
     <string name="positive">Chanya</string>

--- a/opensrp-chw/src/main/res/values/strings.xml
+++ b/opensrp-chw/src/main/res/values/strings.xml
@@ -586,6 +586,7 @@
     <string name="agyw_reports">AGYW Reports</string>
     <string name="agyw_reports_subtitle">View AGYW Report</string>
     <string name="view_visit_history">View visit history</string>
+    <string name="kvp_prep_next_visit_date">Next Visit Date</string>
 
     <string name="child_danger_signs_baby">Danger signs</string>
     <string name="child_danger_signs_baby_task">Danger signs</string>

--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_next_visit_date.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_next_visit_date.json
@@ -1,0 +1,65 @@
+{
+  "count": "1",
+  "encounter_type": "KVP Next Visit Date",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "global": {},
+  "step1": {
+    "title": "Tarehe ya Tembeleo Linalofuata",
+    "fields": [
+      {
+        "key": "next_visit_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "next_visit_date",
+        "type": "date_picker",
+        "label": "Chagua tarehe ya tembeleo linalofuata",
+        "hint": "Chagua tarehe ya tembeleo linalofuata",
+        "expanded": false,
+        "min_date": "today",
+        "v_required": {
+          "value": true,
+          "err": "Tafadhali chagua tarehe ya tembeleo linalofuata"
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_referral_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_referral_services.json
@@ -251,21 +251,6 @@
             ]
           }
         }
-      },
-      {
-        "key": "next_visit_date",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "next_visit_date",
-        "type": "date_picker",
-        "label": "Chagua tarehe ya tembeleo linalofuata",
-        "hint": "Chagua tarehe ya tembeleo linalofuata",
-        "expanded": false,
-        "min_date": "today",
-        "v_required": {
-          "value": true,
-          "err": "Tafadhali chagua tarehe ya ziara inayofuata"
-        }
       }
     ]
   }

--- a/opensrp-chw/src/nacp/assets/json.form/kvp_prep_next_visit_date.json
+++ b/opensrp-chw/src/nacp/assets/json.form/kvp_prep_next_visit_date.json
@@ -1,0 +1,65 @@
+{
+  "count": "1",
+  "encounter_type": "KVP Next Visit Date",
+  "entity_id": "",
+  "metadata": {
+    "start": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "start",
+      "openmrs_entity_id": "163137AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "end": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "end",
+      "openmrs_entity_id": "163138AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "deviceid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "deviceid",
+      "openmrs_entity_id": "163149AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "subscriberid": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "subscriberid",
+      "openmrs_entity_id": "163150AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "simserial": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "simserial",
+      "openmrs_entity_id": "163151AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "phonenumber": {
+      "openmrs_entity_parent": "",
+      "openmrs_entity": "concept",
+      "openmrs_data_type": "phonenumber",
+      "openmrs_entity_id": "163152AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+    },
+    "encounter_location": ""
+  },
+  "global": {},
+  "step1": {
+    "title": "Next Visit Date",
+    "fields": [
+      {
+        "key": "next_visit_date",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "concept",
+        "openmrs_entity_id": "next_visit_date",
+        "type": "date_picker",
+        "label": "Select next visit date",
+        "hint": "Select next visit date",
+        "expanded": false,
+        "min_date": "today",
+        "v_required": {
+          "value": true,
+          "err": "Please select the next visit date"
+        }
+      }
+    ]
+  }
+}

--- a/opensrp-chw/src/nacp/assets/json.form/kvp_prep_referral_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form/kvp_prep_referral_services.json
@@ -258,21 +258,6 @@
             ]
           }
         }
-      },
-      {
-        "key": "next_visit_date",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "concept",
-        "openmrs_entity_id": "next_visit_date",
-        "type": "date_picker",
-        "label": "Select next visit date",
-        "hint": "Select next visit date",
-        "expanded": false,
-        "min_date": "today",
-        "v_required": {
-          "value": true,
-          "err": "Please select the next visit date"
-        }
       }
     ]
   }

--- a/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/KvpPrEPNextVisitDateActionHelperTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/actionhelper/KvpPrEPNextVisitDateActionHelperTest.java
@@ -1,0 +1,32 @@
+package org.smartregister.chw.actionhelper;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.smartregister.chw.kvp.model.BaseKvpVisitAction;
+
+import static org.junit.Assert.assertEquals;
+
+public class KvpPrEPNextVisitDateActionHelperTest {
+
+    @Test
+    public void actionRemainsPendingUntilDateIsProvided() throws Exception {
+        KvpPrEPNextVisitDateActionHelper helper = new KvpPrEPNextVisitDateActionHelper();
+
+        helper.onPayloadReceived(payload(""));
+        assertEquals(BaseKvpVisitAction.Status.PENDING, helper.evaluateStatusOnPayload());
+
+        helper.onPayloadReceived(payload("2026-08-20"));
+        assertEquals(BaseKvpVisitAction.Status.COMPLETED, helper.evaluateStatusOnPayload());
+    }
+
+    private String payload(String value) throws Exception {
+        JSONObject field = new JSONObject()
+                .put("key", "next_visit_date")
+                .put("value", value);
+        return new JSONObject()
+                .put("count", "1")
+                .put("step1", new JSONObject().put("fields", new JSONArray().put(field)))
+                .toString();
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepNextVisitDateConfigTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepNextVisitDateConfigTest.java
@@ -1,0 +1,67 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KvpPrepNextVisitDateConfigTest {
+
+    private static final String[] FORM_DIRECTORIES = {"json.form", "json.form-sw"};
+
+    @Test
+    public void nextVisitDateIsARequiredDedicatedForm() throws Exception {
+        for (String directory : FORM_DIRECTORIES) {
+            JSONObject nextVisitForm = form(directory, "kvp_prep_next_visit_date.json");
+            JSONArray fields = nextVisitForm.getJSONObject("step1").getJSONArray("fields");
+
+            assertEquals(1, fields.length());
+            JSONObject date = fields.getJSONObject(0);
+            assertEquals("next_visit_date", date.getString("key"));
+            assertEquals("date_picker", date.getString("type"));
+            assertEquals("today", date.getString("min_date"));
+            assertTrue(date.getJSONObject("v_required").getBoolean("value"));
+
+            JSONObject referralForm = form(directory, "kvp_prep_referral_services.json");
+            assertFalse(hasField(referralForm.getJSONObject("step1").getJSONArray("fields"),
+                    "next_visit_date"));
+        }
+    }
+
+    private boolean hasField(JSONArray fields, String key) throws Exception {
+        for (int i = 0; i < fields.length(); i++) {
+            if (key.equals(fields.getJSONObject(i).optString("key"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private JSONObject form(String directory, String fileName) throws Exception {
+        String path = "src/nacp/assets/" + directory + "/" + fileName;
+        return new JSONObject(new String(Files.readAllBytes(resolvePath(path)),
+                StandardCharsets.UTF_8));
+    }
+
+    private Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- move the next-visit date out of Referral Services into a dedicated action after referrals
- make the new action mandatory and keep submission disabled until a date is selected
- preserve edit-mode prepopulation and action ordering after visit-type changes
- provide matching English and Swahili forms

## Testing
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.KvpPrepNextVisitDateConfigTest --tests org.smartregister.chw.actionhelper.KvpPrEPNextVisitDateActionHelperTest`

Closes #1016
