### PR TITLE
Disable duplicate same-day KVP visits

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPProfileActivity.java
@@ -39,6 +39,7 @@ import org.smartregister.chw.kvp.util.Constants;
 import org.smartregister.chw.model.ReferralTypeModel;
 import org.smartregister.chw.util.AllClientsUtils;
 import org.smartregister.chw.util.JsonFormUtils;
+import org.smartregister.chw.util.KvpServiceDateUtils;
 import org.smartregister.chw.util.KvpVisitUtils;
 import org.smartregister.commonregistry.CommonPersonObject;
 import org.smartregister.commonregistry.CommonPersonObjectClient;
@@ -161,6 +162,19 @@ public class KvpPrEPProfileActivity extends CoreKvpProfileActivity implements On
                 imageViewCross.setImageResource(org.smartregister.chw.core.R.drawable.activityrow_notvisited);
             }
         }
+        updateVisitButtonAvailability();
+    }
+
+    private void updateVisitButtonAvailability() {
+        Visit latestVisit = getVisit(org.smartregister.chw.util.Constants.Events.KVP_PREP_FOLLOWUP_VISIT);
+        boolean visitRecordedToday = KvpServiceDateUtils.hasVisitToday(
+                ChwKvpDao.getLatestProcessedFollowupDate(memberObject.getBaseEntityId()),
+                latestVisit == null ? null : latestVisit.getDate(),
+                new Date());
+
+        textViewRecordKvp.setEnabled(!visitRecordedToday);
+        textViewRecordKvp.setClickable(!visitRecordedToday);
+        textViewRecordKvp.setAlpha(visitRecordedToday ? 0.5f : 1.0f);
     }
 
     private Date truncateTimeFromDate(Date date) {
@@ -456,6 +470,9 @@ public class KvpPrEPProfileActivity extends CoreKvpProfileActivity implements On
 
     @Override
     public void onClick(View view) {
+        if (view.getId() == R.id.textview_record_kvp && !textViewRecordKvp.isEnabled()) {
+            return;
+        }
         super.onClick(view);
         handleNotificationRowClick(this, view, notificationListAdapter, memberObject.getBaseEntityId());
     }

--- a/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwKvpDao.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/dao/ChwKvpDao.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.smartregister.chw.kvp.dao.KvpDao;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 
 public class ChwKvpDao extends KvpDao {
@@ -130,6 +131,12 @@ public class ChwKvpDao extends KvpDao {
         Calendar threeMonthsAgo = Calendar.getInstance();
         threeMonthsAgo.add(Calendar.MONTH, -3);
         return latestFollowupDate <= threeMonthsAgo.getTimeInMillis();
+    }
+
+    public static Date getLatestProcessedFollowupDate(String baseEntityId) {
+        Long latestFollowupDate = getLatestLastInteractedWith(
+                "ec_kvp_prep_followup", "entity_id", baseEntityId);
+        return latestFollowupDate == null ? null : new Date(latestFollowupDate);
     }
 
     private static String sanitizeDetail(String detail) {

--- a/opensrp-chw/src/main/java/org/smartregister/chw/util/KvpServiceDateUtils.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/util/KvpServiceDateUtils.java
@@ -1,0 +1,31 @@
+package org.smartregister.chw.util;
+
+import java.util.Calendar;
+import java.util.Date;
+
+public final class KvpServiceDateUtils {
+
+    private KvpServiceDateUtils() {
+    }
+
+    public static boolean hasVisitToday(Date processedVisitDate, Date localVisitDate,
+                                        Date currentDate) {
+        return isSameDay(processedVisitDate, currentDate)
+                || isSameDay(localVisitDate, currentDate);
+    }
+
+    private static boolean isSameDay(Date firstDate, Date secondDate) {
+        if (firstDate == null || secondDate == null) {
+            return false;
+        }
+
+        Calendar firstCalendar = Calendar.getInstance();
+        firstCalendar.setTime(firstDate);
+        Calendar secondCalendar = Calendar.getInstance();
+        secondCalendar.setTime(secondDate);
+
+        return firstCalendar.get(Calendar.ERA) == secondCalendar.get(Calendar.ERA)
+                && firstCalendar.get(Calendar.YEAR) == secondCalendar.get(Calendar.YEAR)
+                && firstCalendar.get(Calendar.DAY_OF_YEAR) == secondCalendar.get(Calendar.DAY_OF_YEAR);
+    }
+}

--- a/opensrp-chw/src/test/java/org/smartregister/chw/util/KvpServiceDateUtilsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/util/KvpServiceDateUtilsTest.java
@@ -1,0 +1,55 @@
+package org.smartregister.chw.util;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class KvpServiceDateUtilsTest {
+
+    @Test
+    public void processedVisitDisablesButtonWithoutLocalVisit() {
+        Date now = dateAt(2026, Calendar.AUGUST, 13, 15).getTime();
+
+        assertTrue(KvpServiceDateUtils.hasVisitToday(now, null, now));
+    }
+
+    @Test
+    public void localVisitDisablesButtonBeforeProcessedVisitIsAvailable() {
+        Date visit = dateAt(2026, Calendar.AUGUST, 13, 8).getTime();
+        Date now = dateAt(2026, Calendar.AUGUST, 13, 18).getTime();
+
+        assertTrue(KvpServiceDateUtils.hasVisitToday(null, visit, now));
+    }
+
+    @Test
+    public void visitBecomesAvailableOnNextCalendarDay() {
+        Date visit = dateAt(2026, Calendar.AUGUST, 13, 23).getTime();
+        Date now = dateAt(2026, Calendar.AUGUST, 14, 0).getTime();
+
+        assertFalse(KvpServiceDateUtils.hasVisitToday(visit, visit, now));
+    }
+
+    @Test
+    public void previousProcessedVisitDoesNotHideButtonWhenLocalVisitIsMissing() {
+        Date processed = dateAt(2026, Calendar.AUGUST, 12, 10).getTime();
+        Date now = dateAt(2026, Calendar.AUGUST, 13, 10).getTime();
+
+        assertFalse(KvpServiceDateUtils.hasVisitToday(processed, null, now));
+    }
+
+    @Test
+    public void missingVisitHistoryKeepsButtonAvailable() {
+        assertFalse(KvpServiceDateUtils.hasVisitToday(null, null, new Date()));
+    }
+
+    private Calendar dateAt(int year, int month, int day, int hour) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(year, month, day, hour, 0, 0);
+        return calendar;
+    }
+}


### PR DESCRIPTION
## Summary
- disable and dim the KVP visit button after a completed visit on the current calendar day
- use both the processed follow-up timestamp and the local visit timestamp to cover sync/processing timing
- restore availability automatically on the next calendar day
- guard the click handler as well as the visual state

## Testing
- `./gradlew :opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.util.KvpServiceDateUtilsTest`

Closes #1017
