### PR TITLE
Fix KVP HIVST question and history labels

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPMedicalHistoryActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPMedicalHistoryActivity.java
@@ -46,6 +46,15 @@ public class KvpPrEPMedicalHistoryActivity extends CoreAncMedicalHistoryActivity
             "prep_follow_up", "prep_facility_b", "linked_to_prep"
     };
     static final String[] SCHEDULE_HISTORY_FIELDS = {"next_visit_date"};
+    static final String[] PROTECTIVE_SERVICES_HISTORY_FIELDS = {
+            "condoms_given", "type_of_issued_condoms", "number_of_male_condoms_issued",
+            "number_of_female_condoms_issued", "number_of_iec_distributed",
+            "number_of_needles_and_syringes_distributed",
+            "number_of_sterile_water_for_injection_distributed",
+            "number_of_alcohol_swabs_distributed",
+            "number_of_disposable_safety_boxes_distributed", "number_of_plasters_distributed",
+            "kits_distributed", "number_of_coupons_distributed_for_social_network"
+    };
     private static MemberObject kvpMemberObject;
     private final Flavor flavor = new KvpPrEPMedicalHistoryActivityFlv();
     private ProgressBar progressBar;
@@ -126,8 +135,7 @@ public class KvpPrEPMedicalHistoryActivity extends CoreAncMedicalHistoryActivity
 
                     extractVisitDetails(visits, HIV_PREP_HISTORY_FIELDS, visitDetails, x, context);
 
-                    String[] protectiveServicesParams = {"condoms_given", "type_of_issued_condoms", "number_of_male_condoms_issued", "number_of_female_condoms_issued", "number_of_iec_distributed", "number_of_needles_and_syringes_distributed", "number_of_sterile_water_for_injection_distributed", "number_of_alcohol_swabs_distributed", "number_of_disposable_safety_boxes_distributed", "number_of_plasters_distributed", "kits_distributed", "number_of_coupons_distributed_for_social_network"};
-                    extractVisitDetails(visits, protectiveServicesParams, visitDetails, x, context);
+                    extractVisitDetails(visits, PROTECTIVE_SERVICES_HISTORY_FIELDS, visitDetails, x, context);
 
                     String[] referralServicesParams = {"referral_to_structural_services", "other_referral_to_structural_services", "referrals_completed_to_structural_services", "other_referrals_completed_to_structural_services"};
                     extractVisitDetails(visits, referralServicesParams, visitDetails, x, context);

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -574,7 +574,7 @@
     <string name="kvp_number_of_alcohol_swabs_distributed">Idadi ya pamba zilizotolewa(Alcohol swab):</string>
     <string name="kvp_number_of_disposable_safety_boxes_distributed">Idadi ya mabox yakutupia vitu vyenye ncha kali yaliotolewa:</string>
     <string name="kvp_number_of_plasters_distributed">Idadi ya plasta iliyotolewa:</string>
-    <string name="kvp_kits_distributed">Idadi ya vitepe vya JIPIME vilivyotolewa:</string>
+    <string name="kvp_kits_distributed">Vitepe vya JIPIME vilitolewa:</string>
     <string name="kvp_number_of_coupons_distributed_for_social_network">Idadi ya Kuponi za huduma ya mtandao zilizotolewa:</string>
     <string name="male_condoms">Kondomu ya kiume</string>
     <string name="female_condoms">Kondomu ya Kike</string>

--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
@@ -1512,7 +1512,7 @@
         "openmrs_entity_parent": "",
         "openmrs_entity": "concept",
         "openmrs_entity_id": "kits_distributed",
-        "label": "Vitepe vya JIPIME vilivyotolewa?",
+        "label": "Je, vitepe vya JIPIME vilitolewa?",
         "text_color": "#000000",
         "type": "native_radio",
         "options": [

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -536,7 +536,7 @@
     <string name="kvp_number_of_alcohol_swabs_distributed">Number of Sterile Water for injection Distributed:</string>
     <string name="kvp_number_of_disposable_safety_boxes_distributed">Number of Disposable Safety Boxes Distributed:</string>
     <string name="kvp_number_of_plasters_distributed">Number of Plasters Distributed:</string>
-    <string name="kvp_kits_distributed">Number of HIVST Kits Distributed:</string>
+    <string name="kvp_kits_distributed">HIVST kits distributed:</string>
     <string name="kvp_number_of_coupons_distributed_for_social_network">Number of Coupons Distributed for social network:</string>
     <string name="male_condoms">Male Condoms</string>
     <string name="female_condoms">Female Condoms</string>

--- a/opensrp-chw/src/test/java/org/smartregister/chw/activity/KvpPrEPMedicalHistoryFieldsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/activity/KvpPrEPMedicalHistoryFieldsTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,6 +42,20 @@ public class KvpPrEPMedicalHistoryFieldsTest {
         }
         assertHasLabel(english, "next_visit_date");
         assertHasLabel(swahili, "next_visit_date");
+    }
+
+    @Test
+    public void hivstDistributionAppearsOnceWithBooleanHistoryLabels() throws Exception {
+        assertEquals(1, Collections.frequency(
+                Arrays.asList(KvpPrEPMedicalHistoryActivity.PROTECTIVE_SERVICES_HISTORY_FIELDS),
+                "kits_distributed"));
+
+        String english = readText("src/nacp/res/values/strings.xml");
+        String swahili = readText("src/main/res/values-sw/strings.xml");
+        assertTrue(english.contains(
+                "<string name=\"kvp_kits_distributed\">HIVST kits distributed:</string>"));
+        assertTrue(swahili.contains(
+                "<string name=\"kvp_kits_distributed\">Vitepe vya JIPIME vilitolewa:</string>"));
     }
 
     private void assertHasLabel(String stringsXml, String field) {

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepSwahiliOptionsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpPrepSwahiliOptionsTest.java
@@ -34,6 +34,14 @@ public class KvpPrepSwahiliOptionsTest {
         }
     }
 
+    @Test
+    public void kitsDistributedUsesCanonicalSwahiliQuestion() throws Exception {
+        JSONArray fields = form().getJSONObject("step1").getJSONArray("fields");
+
+        assertEquals("Je, vitepe vya JIPIME vilitolewa?",
+                getField(fields, "kits_distributed").getString("label"));
+    }
+
     private JSONObject form() throws Exception {
         return new JSONObject(new String(Files.readAllBytes(resolvePath(FORM_PATH)),
                 StandardCharsets.UTF_8));


### PR DESCRIPTION
## Summary
- Use the established Swahili yes/no wording for the KVP HIVST-kit distribution question.
- Correct the visit-history captions so the boolean answer is not described as a numeric count.
- Keep the history field list explicit and add regression coverage proving `kits_distributed` is registered exactly once.

## Verification
- `:opensrp-chw:testNacpDebugUnitTest` with the focused KVP form and history tests
- `:opensrp-chw:assembleNacpDebug`
- Installed the NACP debug APK and verified the corrected question in the Swahili KVP Preventive Services flow on the emulator.
- Inspected the existing KVP visit history; it contains no stored HIVST-kit response, while the history registration test confirms the label can render only once when present.

Fixes #1020