### PR TITLE
Localize KVP profile group labels in Swahili

### DIFF
--- a/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPProfileActivity.java
+++ b/opensrp-chw/src/main/java/org/smartregister/chw/activity/KvpPrEPProfileActivity.java
@@ -225,6 +225,10 @@ public class KvpPrEPProfileActivity extends CoreKvpProfileActivity implements On
 
         // Check if there is a dominant KVP group and update UI accordingly
         if (StringUtils.isNotBlank(dominantKVPGroup)) {
+            int horizontalPadding = getResources().getDimensionPixelSize(R.dimen.text_margin);
+            textViewDominantKvpGroup.setPaddingRelative(horizontalPadding,
+                    textViewDominantKvpGroup.getPaddingTop(), horizontalPadding,
+                    textViewDominantKvpGroup.getPaddingBottom());
             textViewDominantKvpGroup.setVisibility(View.VISIBLE);
             textViewDominantKvpGroup.setText(getString(org.smartregister.chw.kvp.R.string.dominant_kvp_group,
                     readStringResourcesWithPrefix(Arrays.asList(dominantKVPGroup), "kvp_")));

--- a/opensrp-chw/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw/src/main/res/values-sw/strings.xml
@@ -626,7 +626,18 @@
     <string name="kvp_friendly_services">Huduma rafiki kwa makundi maalum</string>
     <string name="sti_referral">Magonjwa ya ngono</string>
     <string name="view_visit_history">Angalia Tembeleo Lililopita</string>
+    <string name="dominant_kvp_group">Kundi kuu la KVP: %1$s</string>
+    <string name="kvp_fsw">Mwanamke aliye katika hatari zaidi</string>
+    <string name="kvp_msm">Mwanaume aliye katika hatari zaidi</string>
+    <string name="kvp_pwid">Mjidunga dawa za kulevya</string>
+    <string name="kvp_prisoners">Mfungwa</string>
+    <string name="kvp_inmate">Mahabusu</string>
+    <string name="kvp_agyw">Msichana rika balehe na mwanamke kijana</string>
     <string name="kvp_discordant_couples">Mwenza mwenye majibu kinzani</string>
+    <string name="kvp_fisherman">Wavuvi</string>
+    <string name="kvp_truck_drivers">Dereva wa lori</string>
+    <string name="kvp_miners">Mchimbaji Madini</string>
+    <string name="kvp_other">Makundi Mengine hatarishi</string>
 
     <string name="child_danger_signs_baby">Dalili za hatari</string>
     <string name="child_danger_signs_baby_task">Dalili za hatari </string>

--- a/opensrp-chw/src/nacp/res/values/strings.xml
+++ b/opensrp-chw/src/nacp/res/values/strings.xml
@@ -917,7 +917,14 @@
     <string name="kvp_discordant_couples">Discordant Couples</string>
     <string name="kvp_fsw">WHR</string>
     <string name="kvp_msm">MHR</string>
+    <string name="kvp_pwid">PWID</string>
+    <string name="kvp_prisoners">Prisoners</string>
+    <string name="kvp_inmate">Inmate</string>
     <string name="kvp_agyw">vAGYW</string>
+    <string name="kvp_fisherman">Fisherman</string>
+    <string name="kvp_truck_drivers">Truck drivers</string>
+    <string name="kvp_miners">Miners</string>
+    <string name="kvp_other">Other Groups</string>
 
     <string name="last_appointment_date">Last Appointment date</string>
 

--- a/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpProfileSwahiliStringsTest.java
+++ b/opensrp-chw/src/test/java/org/smartregister/chw/resources/KvpProfileSwahiliStringsTest.java
@@ -1,0 +1,102 @@
+package org.smartregister.chw.resources;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KvpProfileSwahiliStringsTest {
+
+    private static final String REGISTRATION_FORM_PATH =
+            "src/nacp/assets/json.form-sw/kvp_prep_registration.json";
+    private static final String DEFAULT_STRINGS_PATH = "src/nacp/res/values/strings.xml";
+    private static final String STRINGS_PATH = "src/main/res/values-sw/strings.xml";
+    private static final Map<String, String> EXPECTED_GROUPS = expectedGroups();
+
+    @Test
+    public void profileHeadingAndAllRegistrationGroupsHaveSwahiliTranslations() throws Exception {
+        String strings = readText(STRINGS_PATH);
+
+        assertTrue(strings.contains(
+                "<string name=\"dominant_kvp_group\">Kundi kuu la KVP: %1$s</string>"));
+        for (Map.Entry<String, String> group : EXPECTED_GROUPS.entrySet()) {
+            assertTrue("Missing Swahili profile translation for " + group.getKey(),
+                    strings.contains("<string name=\"kvp_" + group.getKey() + "\">"
+                            + group.getValue() + "</string>"));
+        }
+    }
+
+    @Test
+    public void allLocalizedGroupsHaveDefaultResourceEntries() throws Exception {
+        String strings = readText(DEFAULT_STRINGS_PATH);
+
+        for (String group : EXPECTED_GROUPS.keySet()) {
+            assertTrue("Missing default profile resource for " + group,
+                    strings.contains("<string name=\"kvp_" + group + "\">"));
+        }
+    }
+
+    @Test
+    public void profileTranslationsMatchSwahiliRegistrationOptions() throws Exception {
+        JSONObject step = new JSONObject(readText(REGISTRATION_FORM_PATH)).getJSONObject("step1");
+        JSONArray fields = step.getJSONArray("fields");
+        Map<String, String> registrationGroups = new LinkedHashMap<>();
+
+        for (int i = 0; i < fields.length(); i++) {
+            JSONObject field = fields.getJSONObject(i);
+            if (!field.getString("key").startsWith("client_group_")) {
+                continue;
+            }
+            JSONArray options = field.getJSONArray("options");
+            for (int j = 0; j < options.length(); j++) {
+                JSONObject option = options.getJSONObject(j);
+                registrationGroups.put(option.getString("key"), option.getString("text"));
+            }
+        }
+
+        assertEquals(EXPECTED_GROUPS, registrationGroups);
+    }
+
+    private static Map<String, String> expectedGroups() {
+        Map<String, String> groups = new LinkedHashMap<>();
+        groups.put("fsw", "Mwanamke aliye katika hatari zaidi");
+        groups.put("pwid", "Mjidunga dawa za kulevya");
+        groups.put("prisoners", "Mfungwa");
+        groups.put("inmate", "Mahabusu");
+        groups.put("agyw", "Msichana rika balehe na mwanamke kijana");
+        groups.put("discordant_couples", "Mwenza mwenye majibu kinzani");
+        groups.put("fisherman", "Wavuvi");
+        groups.put("truck_drivers", "Dereva wa lori");
+        groups.put("miners", "Mchimbaji Madini");
+        groups.put("other", "Makundi Mengine hatarishi");
+        groups.put("msm", "Mwanaume aliye katika hatari zaidi");
+        return groups;
+    }
+
+    private String readText(String relativePath) throws Exception {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- Translate the `Dominant KVP Group` profile heading into Swahili.
- Add Swahili profile values for every KVP group supported by the registration form, using the form's existing terminology.
- Add matching default resource entries so Android retains every localized group in the APK.
- Add 16dp start and end spacing to the dominant-group text so longer translations do not touch the screen edges.
- Add regression coverage that keeps profile translations aligned with the Swahili registration options.

## Verification
- `:opensrp-chw:testNacpDebugUnitTest --tests org.smartregister.chw.resources.KvpProfileSwahiliStringsTest`
- `:opensrp-chw:assembleNacpDebug`
- Confirmed all eleven KVP group resources and the heading have packaged Swahili values.
- Installed the rebuilt APK and verified the existing MSM client profile displays `Kundi kuu la KVP: Mwanaume aliye katika hatari zaidi`.
- Retested the profile after adding horizontal spacing; the two-line Swahili text has balanced left and right margins with no overlap.