### PR TITLE
Update test date constraints in KVP PrEP preventive services forms

### DIFF
--- a/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form-sw/kvp_prep_preventive_services.json
@@ -249,7 +249,8 @@
         "label": "Tarehe ya kipimo",
         "hint": "Tarehe ya kipimo",
         "expanded": false,
-        "max_date": "today-90d",
+        "min_date": "today-3m",
+        "max_date": "today",
         "v_required": {"value": "true", "err": "Tafadhali ingiza tarehe ya kipimo"},
         "relevance": {
           "step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}

--- a/opensrp-chw/src/nacp/assets/json.form/kvp_prep_preventive_services.json
+++ b/opensrp-chw/src/nacp/assets/json.form/kvp_prep_preventive_services.json
@@ -246,7 +246,8 @@
         "label": "Date the test was conducted",
         "hint": "Date the test was conducted",
         "expanded": false,
-        "max_date": "today-90d",
+        "min_date": "today-3m",
+        "max_date": "today",
         "v_required": {"value": "true", "err": "Please enter the test date"},
         "relevance": {
           "step1:testing_location": {"type": "string", "ex": "notEqualTo(., \"\")"}


### PR DESCRIPTION
closes #1018 
* Adjusted `min_date` and `max_date` for the test date field in both English and Swahili JSON forms to allow dates within the last 3 months up to today.